### PR TITLE
feat: Web Admin Interface with HTMX Dashboard

### DIFF
--- a/cmd/mf/admin.go
+++ b/cmd/mf/admin.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/admin"
+	"github.com/younjinjeong/microfoundry/pkg/config"
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+)
+
+func adminCmd() *cobra.Command {
+	var port int
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Start the MicroFoundry admin web interface",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+
+			k8sClient, err := k8s.NewClient(
+				cfg.Kubernetes.Context,
+				cfg.Kubernetes.Namespace,
+				"cf-local.dev",
+			)
+			if err != nil {
+				return fmt.Errorf("connecting to kubernetes: %w", err)
+			}
+
+			srv := admin.NewServer(k8sClient, cfg, version)
+			addr := fmt.Sprintf("%s:%d", host, port)
+			fmt.Printf("MicroFoundry Admin starting at http://localhost:%d\n", port)
+			return srv.ListenAndServe(addr)
+		},
+	}
+
+	cmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
+	cmd.Flags().StringVar(&host, "host", "0.0.0.0", "Host to bind to")
+
+	return cmd
+}

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -24,6 +24,7 @@ func main() {
 		logsCmd(),
 		deleteCmd(),
 		scaleCmd(),
+		adminCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -5,3 +5,7 @@ github:
 kubernetes:
   context: "docker-desktop"
   namespace: "microfoundry"
+
+admin:
+  port: 8080
+  host: "0.0.0.0"

--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func (s *Server) APIListAppsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	names, err := s.k8sClient.ListApps(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ingressMap, _ := s.k8sClient.ListIngresses(ctx)
+
+	type AppResponse struct {
+		Name         string   `json:"name"`
+		State        string   `json:"state"`
+		RunningCount int      `json:"running_count"`
+		TotalCount   int      `json:"total_count"`
+		Routes       []string `json:"routes"`
+	}
+
+	var apps []AppResponse
+	for _, name := range names {
+		app := AppResponse{Name: name, State: "unknown"}
+		if status, err := s.k8sClient.GetAppStatus(ctx, name); err == nil {
+			app.RunningCount = status.RunningCount
+			app.TotalCount = status.TotalCount
+			if status.RunningCount > 0 {
+				app.State = "started"
+			} else {
+				app.State = "stopped"
+			}
+		}
+		if hosts, ok := ingressMap[name]; ok {
+			app.Routes = hosts
+		}
+		apps = append(apps, app)
+	}
+
+	writeJSON(w, http.StatusOK, apps)
+}
+
+func (s *Server) APIGetAppHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	status, err := s.k8sClient.GetAppStatus(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ingressMap, _ := s.k8sClient.ListIngresses(ctx)
+
+	state := "stopped"
+	if status.RunningCount > 0 {
+		state = "started"
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"name":          name,
+		"state":         state,
+		"running_count": status.RunningCount,
+		"total_count":   status.TotalCount,
+		"instances":     status.Instances,
+		"routes":        ingressMap[name],
+	})
+}
+
+func (s *Server) APIGetConfigHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"domain":    s.k8sClient.Domain,
+		"namespace": s.k8sClient.Namespace,
+		"context":   s.config.Kubernetes.Context,
+		"github": map[string]string{
+			"owner": s.config.GitHub.Owner,
+			"repo":  s.config.GitHub.Repo,
+		},
+	})
+}
+
+func (s *Server) APIScaleAppHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	var body struct {
+		Instances int `json:"instances"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if err := s.k8sClient.ScaleApp(ctx, name, body.Instances); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"name":      name,
+		"instances": body.Instances,
+		"scaled":    true,
+	})
+}
+
+func (s *Server) APIDeleteAppHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	if err := s.k8sClient.DeleteApp(ctx, name); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -1,0 +1,212 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+)
+
+// PageData is the base data passed to every full-page template.
+type PageData struct {
+	Title   string
+	Version string
+	Active  string
+	Content any
+}
+
+// AppRow is used for the app list table.
+type AppRow struct {
+	Name         string
+	State        string
+	RunningCount int
+	TotalCount   int
+	Routes       []string
+}
+
+func (s *Server) DashboardHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	apps, _ := s.k8sClient.ListApps(ctx)
+
+	data := PageData{
+		Title:   "Dashboard",
+		Version: s.version,
+		Active:  "dashboard",
+		Content: map[string]any{
+			"AppCount":  len(apps),
+			"Domain":    s.k8sClient.Domain,
+			"Namespace": s.k8sClient.Namespace,
+			"Context":   s.config.Kubernetes.Context,
+			"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
+		},
+	}
+	s.templates.Render(w, "dashboard.html", data)
+}
+
+func (s *Server) AppsListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	names, err := s.k8sClient.ListApps(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ingressMap, _ := s.k8sClient.ListIngresses(ctx)
+
+	var apps []AppRow
+	for _, name := range names {
+		row := AppRow{Name: name, State: "unknown"}
+		if status, err := s.k8sClient.GetAppStatus(ctx, name); err == nil {
+			row.RunningCount = status.RunningCount
+			row.TotalCount = status.TotalCount
+			if status.RunningCount > 0 {
+				row.State = "started"
+			} else {
+				row.State = "stopped"
+			}
+		}
+		if hosts, ok := ingressMap[name]; ok {
+			row.Routes = hosts
+		}
+		apps = append(apps, row)
+	}
+
+	data := PageData{
+		Title:   "Applications",
+		Version: s.version,
+		Active:  "apps",
+		Content: apps,
+	}
+	s.templates.Render(w, "apps.html", data)
+}
+
+func (s *Server) AppDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	name := r.PathValue("name")
+
+	status, err := s.k8sClient.GetAppStatus(ctx, name)
+	if err != nil {
+		http.Error(w, "App not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	ingressMap, _ := s.k8sClient.ListIngresses(ctx)
+	routes := ingressMap[name]
+
+	state := "stopped"
+	if status.RunningCount > 0 {
+		state = "started"
+	}
+
+	data := PageData{
+		Title:   name,
+		Version: s.version,
+		Active:  "apps",
+		Content: map[string]any{
+			"Name":         name,
+			"State":        state,
+			"RunningCount": status.RunningCount,
+			"TotalCount":   status.TotalCount,
+			"Instances":    status.Instances,
+			"Routes":       routes,
+		},
+	}
+	s.templates.Render(w, "app_detail.html", data)
+}
+
+func (s *Server) AppInstancesHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	name := r.PathValue("name")
+
+	status, err := s.k8sClient.GetAppStatus(ctx, name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.templates.RenderPartial(w, "app_instances.html", map[string]any{
+		"Instances":    status.Instances,
+		"RunningCount": status.RunningCount,
+		"TotalCount":   status.TotalCount,
+	})
+}
+
+func (s *Server) ScaleAppHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	name := r.PathValue("name")
+
+	instancesStr := r.FormValue("instances")
+	instances, err := strconv.Atoi(instancesStr)
+	if err != nil || instances < 0 {
+		http.Error(w, "Invalid instance count", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.k8sClient.ScaleApp(ctx, name, instances); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Return updated app row
+	ingressMap, _ := s.k8sClient.ListIngresses(ctx)
+	row := AppRow{Name: name, State: "started", RunningCount: instances, TotalCount: instances}
+	if hosts, ok := ingressMap[name]; ok {
+		row.Routes = hosts
+	}
+	s.templates.RenderPartial(w, "app_row.html", row)
+}
+
+func (s *Server) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	name := r.PathValue("name")
+
+	if err := s.k8sClient.DeleteApp(ctx, name); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
+	data := PageData{
+		Title:   "Configuration",
+		Version: s.version,
+		Active:  "config",
+		Content: map[string]any{
+			"Domain":    s.k8sClient.Domain,
+			"Namespace": s.k8sClient.Namespace,
+			"Context":   s.config.Kubernetes.Context,
+			"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
+			"Owner":     s.config.GitHub.Owner,
+			"Repo":      s.config.GitHub.Repo,
+		},
+	}
+	s.templates.Render(w, "config.html", data)
+}
+
+func (s *Server) ServicesHandler(w http.ResponseWriter, r *http.Request) {
+	data := PageData{
+		Title:   "Backing Services",
+		Version: s.version,
+		Active:  "services",
+	}
+	s.templates.Render(w, "services.html", data)
+}
+
+func (s *Server) SecretsHandler(w http.ResponseWriter, r *http.Request) {
+	data := PageData{
+		Title:   "Secrets",
+		Version: s.version,
+		Active:  "secrets",
+	}
+	s.templates.Render(w, "secrets.html", data)
+}
+
+func (s *Server) UsersHandler(w http.ResponseWriter, r *http.Request) {
+	data := PageData{
+		Title:   "Users & Organizations",
+		Version: s.version,
+		Active:  "users",
+	}
+	s.templates.Render(w, "users.html", data)
+}

--- a/pkg/admin/logs.go
+++ b/pkg/admin/logs.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"bufio"
+	"fmt"
+	"html"
+	"net/http"
+)
+
+func (s *Server) LogStreamHandler(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	stream, err := s.k8sClient.GetAppLogs(ctx, name, true)
+	if err != nil {
+		fmt.Fprintf(w, "event: error\ndata: %s\n\n", html.EscapeString(err.Error()))
+		flusher.Flush()
+		return
+	}
+	defer stream.Close()
+
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			line := html.EscapeString(scanner.Text())
+			fmt.Fprintf(w, "data: <div class=\"py-0.5\">%s</div>\n\n", line)
+			flusher.Flush()
+		}
+	}
+}

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -1,0 +1,59 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/config"
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+)
+
+type Server struct {
+	k8sClient *k8s.Client
+	config    *config.Config
+	version   string
+	templates *TemplateRenderer
+	mux       *http.ServeMux
+}
+
+func NewServer(k8sClient *k8s.Client, cfg *config.Config, version string) *Server {
+	s := &Server{
+		k8sClient: k8sClient,
+		config:    cfg,
+		version:   version,
+		templates: NewTemplateRenderer(),
+		mux:       http.NewServeMux(),
+	}
+	s.registerRoutes()
+	return s
+}
+
+func (s *Server) registerRoutes() {
+	// Static CSS files
+	s.mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(staticFS())))
+
+	// Page routes
+	s.mux.HandleFunc("GET /{$}", s.DashboardHandler)
+	s.mux.HandleFunc("GET /apps", s.AppsListHandler)
+	s.mux.HandleFunc("GET /apps/{name}", s.AppDetailHandler)
+	s.mux.HandleFunc("GET /apps/{name}/instances", s.AppInstancesHandler)
+	s.mux.HandleFunc("GET /apps/{name}/logs/stream", s.LogStreamHandler)
+	s.mux.HandleFunc("GET /config", s.ConfigHandler)
+	s.mux.HandleFunc("GET /services", s.ServicesHandler)
+	s.mux.HandleFunc("GET /secrets", s.SecretsHandler)
+	s.mux.HandleFunc("GET /users", s.UsersHandler)
+
+	// HTMX action routes
+	s.mux.HandleFunc("POST /apps/{name}/scale", s.ScaleAppHandler)
+	s.mux.HandleFunc("DELETE /apps/{name}", s.DeleteAppHandler)
+
+	// JSON API routes
+	s.mux.HandleFunc("GET /api/apps", s.APIListAppsHandler)
+	s.mux.HandleFunc("GET /api/apps/{name}", s.APIGetAppHandler)
+	s.mux.HandleFunc("GET /api/config", s.APIGetConfigHandler)
+	s.mux.HandleFunc("POST /api/apps/{name}/scale", s.APIScaleAppHandler)
+	s.mux.HandleFunc("DELETE /api/apps/{name}", s.APIDeleteAppHandler)
+}
+
+func (s *Server) ListenAndServe(addr string) error {
+	return http.ListenAndServe(addr, s.mux)
+}

--- a/pkg/admin/static/css/custom.css
+++ b/pkg/admin/static/css/custom.css
@@ -1,0 +1,1 @@
+/* MicroFoundry Admin - minimal custom styles beyond Tailwind */

--- a/pkg/admin/static/templates/app_detail.html
+++ b/pkg/admin/static/templates/app_detail.html
@@ -1,0 +1,119 @@
+{{define "app_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="space-y-6">
+    <!-- App Header -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-4">
+                <h3 class="text-2xl font-bold text-gray-900">{{index $c "Name"}}</h3>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{stateBg (index $c "State")}}">
+                    {{index $c "State"}}
+                </span>
+            </div>
+            <div class="flex items-center space-x-3">
+                <a href="/apps" class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700 transition-colors">
+                    Back to Apps
+                </a>
+            </div>
+        </div>
+        <div class="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+                <p class="text-sm text-gray-500">Instances</p>
+                <p class="text-lg font-semibold">{{index $c "RunningCount"}}/{{index $c "TotalCount"}}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Routes</p>
+                <div>
+                    {{range index $c "Routes"}}
+                    <a href="http://{{.}}" target="_blank" class="text-blue-600 hover:underline text-sm">{{.}}</a>
+                    {{else}}
+                    <span class="text-gray-400 text-sm">No routes</span>
+                    {{end}}
+                </div>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Scale</p>
+                <form hx-post="/apps/{{index $c "Name"}}/scale"
+                      hx-target="#instances-panel"
+                      hx-swap="innerHTML"
+                      class="flex items-center space-x-2 mt-1">
+                    <input type="number" name="instances" value="{{index $c "TotalCount"}}" min="0" max="20"
+                           class="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-center">
+                    <button type="submit"
+                            class="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-colors">
+                        Scale
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Instances Table -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">Instances</h3>
+        </div>
+        <div id="instances-panel"
+             hx-get="/apps/{{index $c "Name"}}/instances"
+             hx-trigger="every 5s"
+             hx-swap="innerHTML">
+            {{template "app_instances.html" $c}}
+        </div>
+    </div>
+
+    <!-- Logs Panel -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+            <h3 class="text-lg font-medium text-gray-900">Logs</h3>
+            <button id="log-toggle"
+                    onclick="toggleLogs('{{index $c "Name"}}')"
+                    class="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 transition-colors">
+                Start Streaming
+            </button>
+        </div>
+        <div id="log-container" class="hidden">
+            <div hx-ext="sse" id="log-sse-container">
+                <pre id="log-output"
+                     class="bg-gray-900 text-green-400 p-4 overflow-y-auto font-mono text-xs leading-relaxed"
+                     style="max-height: 400px;">
+                </pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function toggleLogs(appName) {
+    const container = document.getElementById('log-container');
+    const toggle = document.getElementById('log-toggle');
+    const sseContainer = document.getElementById('log-sse-container');
+    const logOutput = document.getElementById('log-output');
+
+    if (container.classList.contains('hidden')) {
+        container.classList.remove('hidden');
+        toggle.textContent = 'Stop Streaming';
+        toggle.classList.remove('bg-green-600', 'hover:bg-green-700');
+        toggle.classList.add('bg-red-600', 'hover:bg-red-700');
+
+        sseContainer.setAttribute('sse-connect', '/apps/' + appName + '/logs/stream');
+        logOutput.setAttribute('sse-swap', 'message');
+        logOutput.setAttribute('hx-swap', 'beforeend scroll:bottom');
+        htmx.process(sseContainer);
+    } else {
+        container.classList.add('hidden');
+        toggle.textContent = 'Start Streaming';
+        toggle.classList.remove('bg-red-600', 'hover:bg-red-700');
+        toggle.classList.add('bg-green-600', 'hover:bg-green-700');
+
+        sseContainer.removeAttribute('sse-connect');
+        logOutput.removeAttribute('sse-swap');
+        logOutput.innerHTML = '';
+        htmx.process(sseContainer);
+    }
+}
+</script>
+{{end}}

--- a/pkg/admin/static/templates/app_instances.html
+++ b/pkg/admin/static/templates/app_instances.html
@@ -1,0 +1,28 @@
+{{define "app_instances.html"}}
+<table class="min-w-full divide-y divide-gray-200">
+    <thead class="bg-gray-50">
+        <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">State</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Since</th>
+        </tr>
+    </thead>
+    <tbody class="bg-white divide-y divide-gray-200">
+        {{range .Instances}}
+        <tr>
+            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-700">#{{.Index}}</td>
+            <td class="px-6 py-3 whitespace-nowrap">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{stateBg .State}}">
+                    {{.State}}
+                </span>
+            </td>
+            <td class="px-6 py-3 whitespace-nowrap text-sm text-gray-500">{{timeAgo .Since}}</td>
+        </tr>
+        {{else}}
+        <tr>
+            <td colspan="3" class="px-6 py-8 text-center text-gray-500 text-sm">No instances running</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}

--- a/pkg/admin/static/templates/app_row.html
+++ b/pkg/admin/static/templates/app_row.html
@@ -1,0 +1,52 @@
+{{define "app_row.html"}}
+<tr id="app-row-{{.Name}}">
+    <td class="px-6 py-4 whitespace-nowrap">
+        <a href="/apps/{{.Name}}" class="text-blue-600 hover:text-blue-800 font-medium">{{.Name}}</a>
+    </td>
+    <td class="px-6 py-4 whitespace-nowrap">
+        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{stateBg .State}}">
+            {{.State}}
+        </span>
+    </td>
+    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+        {{.RunningCount}}/{{.TotalCount}}
+    </td>
+    <td class="px-6 py-4 whitespace-nowrap text-sm">
+        {{range .Routes}}
+        <a href="http://{{.}}" target="_blank" class="text-blue-500 hover:underline mr-2">{{.}}</a>
+        {{end}}
+    </td>
+    <td class="px-6 py-4 whitespace-nowrap text-right text-sm space-x-2">
+        <button onclick="document.getElementById('scale-dialog-{{.Name}}').classList.toggle('hidden')"
+                class="px-2.5 py-1 bg-blue-50 text-blue-700 rounded hover:bg-blue-100 text-xs font-medium transition-colors">
+            Scale
+        </button>
+        <button hx-delete="/apps/{{.Name}}"
+                hx-target="#app-row-{{.Name}}"
+                hx-swap="outerHTML"
+                hx-confirm="Are you sure you want to delete {{.Name}}?"
+                class="px-2.5 py-1 bg-red-50 text-red-700 rounded hover:bg-red-100 text-xs font-medium transition-colors">
+            Delete
+        </button>
+        <!-- Inline scale form (hidden by default) -->
+        <div id="scale-dialog-{{.Name}}" class="hidden mt-2">
+            <form hx-post="/apps/{{.Name}}/scale"
+                  hx-target="#app-row-{{.Name}}"
+                  hx-swap="outerHTML"
+                  class="flex items-center space-x-2">
+                <input type="number" name="instances" value="{{.TotalCount}}" min="0" max="20"
+                       class="w-16 px-2 py-1 border border-gray-300 rounded text-xs text-center">
+                <button type="submit"
+                        class="px-2 py-1 bg-green-50 text-green-700 rounded hover:bg-green-100 text-xs font-medium">
+                    Apply
+                </button>
+                <button type="button"
+                        onclick="this.closest('.hidden, div').classList.add('hidden')"
+                        class="px-2 py-1 bg-gray-50 text-gray-600 rounded hover:bg-gray-100 text-xs font-medium">
+                    Cancel
+                </button>
+            </form>
+        </div>
+    </td>
+</tr>
+{{end}}

--- a/pkg/admin/static/templates/apps.html
+++ b/pkg/admin/static/templates/apps.html
@@ -1,0 +1,51 @@
+{{define "apps.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="bg-white rounded-lg shadow">
+    <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <h3 class="text-lg font-medium text-gray-900">Deployed Applications</h3>
+        <button hx-get="/apps"
+                hx-target="#app-table-body"
+                hx-select="#app-table-body"
+                hx-swap="outerHTML"
+                class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700 transition-colors">
+            Refresh
+        </button>
+    </div>
+    <div id="app-table"
+         hx-get="/apps"
+         hx-trigger="every 10s"
+         hx-select="#app-table-body"
+         hx-target="#app-table-body"
+         hx-swap="outerHTML">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">State</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Instances</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Routes</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody id="app-table-body" class="bg-white divide-y divide-gray-200">
+                {{range .Content}}
+                    {{template "app_row.html" .}}
+                {{else}}
+                <tr>
+                    <td colspan="5" class="px-6 py-12 text-center text-gray-500">
+                        <svg class="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                        </svg>
+                        <p class="text-lg font-medium">No applications deployed</p>
+                        <p class="text-sm mt-1">Use <code class="bg-gray-100 px-1.5 py-0.5 rounded text-gray-800">mf push</code> to deploy your first app.</p>
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/config.html
+++ b/pkg/admin/static/templates/config.html
@@ -1,0 +1,63 @@
+{{define "config.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="space-y-6">
+    <!-- Kubernetes Configuration -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">Kubernetes</h3>
+        </div>
+        <dl class="divide-y divide-gray-200">
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Context</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{index $c "Context"}}</dd>
+            </div>
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Namespace</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{index $c "Namespace"}}</dd>
+            </div>
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Domain</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{index $c "Domain"}}</dd>
+            </div>
+        </dl>
+    </div>
+
+    <!-- GitHub Configuration -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">GitHub</h3>
+        </div>
+        <dl class="divide-y divide-gray-200">
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Owner</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{index $c "Owner"}}</dd>
+            </div>
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Repository</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{index $c "Repo"}}</dd>
+            </div>
+        </dl>
+    </div>
+
+    <!-- Platform Info -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">Platform</h3>
+        </div>
+        <dl class="divide-y divide-gray-200">
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">Version</dt>
+                <dd class="text-sm text-gray-900 font-mono">{{$.Version}}</dd>
+            </div>
+            <div class="px-6 py-4 flex">
+                <dt class="w-48 text-sm font-medium text-gray-500">App Routing</dt>
+                <dd class="text-sm text-gray-900">&lt;app-name&gt;.{{index $c "Domain"}}</dd>
+            </div>
+        </dl>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/dashboard.html
+++ b/pkg/admin/static/templates/dashboard.html
@@ -1,0 +1,95 @@
+{{define "dashboard.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+    <!-- Applications Card -->
+    <a href="/apps" class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow">
+        <div class="flex items-center">
+            <div class="p-3 rounded-full bg-blue-100 text-blue-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-500">Applications</p>
+                <p class="text-2xl font-bold text-gray-900">{{index $c "AppCount"}}</p>
+            </div>
+        </div>
+    </a>
+
+    <!-- Domain Card -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center">
+            <div class="p-3 rounded-full bg-green-100 text-green-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"/>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-500">Domain</p>
+                <p class="text-lg font-bold text-gray-900">{{index $c "Domain"}}</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Namespace Card -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center">
+            <div class="p-3 rounded-full bg-purple-100 text-purple-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-500">Namespace</p>
+                <p class="text-lg font-bold text-gray-900">{{index $c "Namespace"}}</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- K8s Context Card -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center">
+            <div class="p-3 rounded-full bg-orange-100 text-orange-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
+                </svg>
+            </div>
+            <div class="ml-4">
+                <p class="text-sm font-medium text-gray-500">K8s Context</p>
+                <p class="text-lg font-bold text-gray-900">{{index $c "Context"}}</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Quick Links -->
+<div class="bg-white rounded-lg shadow">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <h3 class="text-lg font-medium text-gray-900">Quick Links</h3>
+    </div>
+    <div class="p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+        <a href="/apps" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+            <span class="text-blue-600 font-medium">View Applications</span>
+            <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+        </a>
+        <a href="/config" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+            <span class="text-blue-600 font-medium">Platform Configuration</span>
+            <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+        </a>
+        <a href="/services" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+            <span class="text-blue-600 font-medium">Backing Services</span>
+            <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+        </a>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/layout.html
+++ b/pkg/admin/static/templates/layout.html
@@ -1,0 +1,27 @@
+{{define "layout"}}
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-gray-50">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Title}} - MicroFoundry Admin</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+    <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
+    <style>
+        [hx-swap-oob] { display: none; }
+    </style>
+</head>
+<body class="h-full">
+    <div class="flex h-full">
+        {{template "nav" .}}
+        <main class="flex-1 overflow-y-auto">
+            {{template "header" .}}
+            <div class="p-6">
+                {{block "content" .}}{{end}}
+            </div>
+        </main>
+    </div>
+</body>
+</html>
+{{end}}

--- a/pkg/admin/static/templates/partials/header.html
+++ b/pkg/admin/static/templates/partials/header.html
@@ -1,0 +1,5 @@
+{{define "header"}}
+<header class="bg-white border-b border-gray-200 px-6 py-4">
+    <h2 class="text-xl font-semibold text-gray-800">{{.Title}}</h2>
+</header>
+{{end}}

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -1,0 +1,53 @@
+{{define "nav"}}
+<aside class="w-56 bg-gray-900 text-gray-300 flex flex-col min-h-screen">
+    <div class="p-4 border-b border-gray-700">
+        <h1 class="text-lg font-bold text-white">MicroFoundry</h1>
+        <span class="text-xs text-gray-500">{{.Version}}</span>
+    </div>
+    <nav class="flex-1 p-3 space-y-1">
+        <a href="/"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "dashboard"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+            </svg>
+            Dashboard
+        </a>
+        <a href="/apps"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "apps"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+            </svg>
+            Applications
+        </a>
+        <a href="/services"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "services"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
+            </svg>
+            Services
+        </a>
+        <a href="/secrets"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "secrets"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+            </svg>
+            Secrets
+        </a>
+        <a href="/users"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            Users & Orgs
+        </a>
+        <a href="/config"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "config"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+            </svg>
+            Configuration
+        </a>
+    </nav>
+</aside>
+{{end}}

--- a/pkg/admin/static/templates/scale_form.html
+++ b/pkg/admin/static/templates/scale_form.html
@@ -1,0 +1,18 @@
+{{define "scale_form.html"}}
+<form hx-post="/apps/{{.Name}}/scale"
+      hx-target="#app-row-{{.Name}}"
+      hx-swap="outerHTML"
+      class="flex items-center space-x-2">
+    <input type="number" name="instances" value="{{.TotalCount}}" min="0" max="20"
+           class="w-16 px-2 py-1 border border-gray-300 rounded text-xs text-center">
+    <button type="submit"
+            class="px-2 py-1 bg-green-50 text-green-700 rounded hover:bg-green-100 text-xs font-medium">
+        Apply
+    </button>
+    <button type="button"
+            onclick="this.closest('form').parentElement.innerHTML=''"
+            class="px-2 py-1 bg-gray-50 text-gray-600 rounded hover:bg-gray-100 text-xs font-medium">
+        Cancel
+    </button>
+</form>
+{{end}}

--- a/pkg/admin/static/templates/secrets.html
+++ b/pkg/admin/static/templates/secrets.html
@@ -1,0 +1,23 @@
+{{define "secrets.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="bg-white rounded-lg shadow p-12 text-center">
+    <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+    </svg>
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
+        Coming Soon
+    </span>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">Secrets Management</h3>
+    <p class="text-gray-500 mt-2 max-w-md mx-auto">
+        Configure and manage application secrets and environment variables.
+        MicroFoundry integrates with CSP-native secret managers
+        (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault).
+    </p>
+    <div class="mt-6 text-sm text-gray-400">
+        <p>Equivalent to: cf set-env, cf bind-service (user-provided)</p>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/services.html
+++ b/pkg/admin/static/templates/services.html
@@ -1,0 +1,22 @@
+{{define "services.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="bg-white rounded-lg shadow p-12 text-center">
+    <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+    </svg>
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
+        Coming Soon
+    </span>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">Backing Services</h3>
+    <p class="text-gray-500 mt-2 max-w-md mx-auto">
+        Manage backing services like databases, message queues, and caches.
+        MicroFoundry uses OSBAPI-compatible service brokers to provision and bind services to your applications.
+    </p>
+    <div class="mt-6 text-sm text-gray-400">
+        <p>Planned services: AWS RDS, Cloud SQL, Azure Database, Redis, RabbitMQ</p>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/users.html
+++ b/pkg/admin/static/templates/users.html
@@ -1,0 +1,23 @@
+{{define "users.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="bg-white rounded-lg shadow p-12 text-center">
+    <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
+        Coming Soon
+    </span>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">Users & Organizations</h3>
+    <p class="text-gray-500 mt-2 max-w-md mx-auto">
+        Manage organizations, spaces, and user roles.
+        MicroFoundry maps CF's org/space model to Kubernetes namespaces
+        with RBAC-based access control.
+    </p>
+    <div class="mt-6 text-sm text-gray-400">
+        <p>Equivalent to: cf orgs, cf org-users, cf set-org-role, cf create-space</p>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -1,0 +1,100 @@
+package admin
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"net/http"
+	"strings"
+	"time"
+)
+
+//go:embed static/templates/*.html static/templates/partials/*.html
+var templateFiles embed.FS
+
+//go:embed static/css/*
+var cssFiles embed.FS
+
+func staticFS() http.FileSystem {
+	sub, _ := fs.Sub(cssFiles, "static")
+	return http.FS(sub)
+}
+
+type TemplateRenderer struct {
+	templates *template.Template
+}
+
+func NewTemplateRenderer() *TemplateRenderer {
+	funcMap := template.FuncMap{
+		"stateColor": func(state string) string {
+			switch strings.ToLower(state) {
+			case "started", "running":
+				return "green"
+			case "stopped", "down":
+				return "red"
+			case "starting", "staging", "deploying", "uploading":
+				return "yellow"
+			case "crashed", "failed":
+				return "red"
+			default:
+				return "gray"
+			}
+		},
+		"stateBg": func(state string) string {
+			switch strings.ToLower(state) {
+			case "started", "running":
+				return "bg-green-100 text-green-800"
+			case "stopped", "down":
+				return "bg-red-100 text-red-800"
+			case "starting", "staging", "deploying", "uploading":
+				return "bg-yellow-100 text-yellow-800"
+			case "crashed", "failed":
+				return "bg-red-100 text-red-800"
+			default:
+				return "bg-gray-100 text-gray-800"
+			}
+		},
+		"timeAgo": func(t time.Time) string {
+			if t.IsZero() {
+				return "-"
+			}
+			d := time.Since(t)
+			switch {
+			case d < time.Minute:
+				return fmt.Sprintf("%ds ago", int(d.Seconds()))
+			case d < time.Hour:
+				return fmt.Sprintf("%dm ago", int(d.Minutes()))
+			case d < 24*time.Hour:
+				return fmt.Sprintf("%dh ago", int(d.Hours()))
+			default:
+				return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+			}
+		},
+		"join": strings.Join,
+	}
+
+	tmpl := template.Must(
+		template.New("").Funcs(funcMap).ParseFS(
+			templateFiles,
+			"static/templates/*.html",
+			"static/templates/partials/*.html",
+		),
+	)
+
+	return &TemplateRenderer{templates: tmpl}
+}
+
+func (tr *TemplateRenderer) Render(w http.ResponseWriter, name string, data any) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tr.templates.ExecuteTemplate(w, name, data); err != nil {
+		http.Error(w, fmt.Sprintf("template error: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func (tr *TemplateRenderer) RenderPartial(w http.ResponseWriter, name string, data any) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := tr.templates.ExecuteTemplate(w, name, data); err != nil {
+		http.Error(w, fmt.Sprintf("template error: %v", err), http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the MicroFoundry Web Admin Interface — a server-side rendered dashboard embedded in the `mf` binary.

- **`mf admin`** command starts an HTTP server (default `:8080`)
- **Dashboard**: Summary cards showing app count, domain, namespace, K8s context
- **Applications page**: Live K8s data with HTMX auto-refresh, inline scale/delete
- **App detail**: Instance table with 5s polling, SSE live log streaming
- **Config page**: Platform configuration display (K8s, GitHub, domain)
- **Placeholder pages**: Services, Secrets, Users/Orgs — "Coming Soon"
- **JSON API**: `/api/apps`, `/api/apps/{name}`, `/api/config`
- **Zero new dependencies**: stdlib `net/http` + `html/template` + `embed`

### Files Added (22 files, 1,171 lines)

**Go code:**
- `cmd/mf/admin.go` — Cobra command
- `pkg/admin/server.go` — HTTP server + route registration
- `pkg/admin/handlers.go` — SSR page handlers
- `pkg/admin/api.go` — JSON API handlers
- `pkg/admin/logs.go` — SSE log streaming
- `pkg/admin/templates.go` — Embedded template renderer

**Templates (Go embed):**
- `layout.html`, `dashboard.html`, `apps.html`, `app_detail.html`
- `app_row.html`, `app_instances.html`, `scale_form.html`
- `config.html`, `services.html`, `secrets.html`, `users.html`
- `partials/nav.html`, `partials/header.html`

Resolves #3

## Test plan

- [ ] `go build ./cmd/mf` succeeds
- [ ] `mf admin` starts server at http://localhost:8080
- [ ] Dashboard shows real K8s data (app count, domain, namespace)
- [ ] `/apps` lists deployed applications with live status
- [ ] Scale/delete work via HTMX without page reload
- [ ] `/apps/{name}` shows instance details + live log stream
- [ ] `/api/apps` returns JSON
- [ ] Placeholder pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)