### PR TITLE
feat: Multi-cluster Kubernetes management

### DIFF
--- a/cmd/mf/admin.go
+++ b/cmd/mf/admin.go
@@ -36,7 +36,7 @@ func adminCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVarP(&port, "port", "p", 8080, "Port to listen on")
-	cmd.Flags().StringVar(&host, "host", "0.0.0.0", "Host to bind to")
+	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "Host to bind to")
 
 	return cmd
 }

--- a/cmd/mf/admin.go
+++ b/cmd/mf/admin.go
@@ -22,18 +22,15 @@ func adminCmd() *cobra.Command {
 				return fmt.Errorf("loading config: %w", err)
 			}
 
-			k8sClient, err := k8s.NewClient(
-				cfg.Kubernetes.Context,
-				cfg.Kubernetes.Namespace,
-				"cf-local.dev",
+			clientManager := k8s.NewClientManager(
+				cfg.Kubernetes.Clusters,
+				cfg.Kubernetes.Active,
 			)
-			if err != nil {
-				return fmt.Errorf("connecting to kubernetes: %w", err)
-			}
 
-			srv := admin.NewServer(k8sClient, cfg, version)
+			srv := admin.NewServer(clientManager, cfg, version)
 			addr := fmt.Sprintf("%s:%d", host, port)
 			fmt.Printf("MicroFoundry Admin starting at http://localhost:%d\n", port)
+			fmt.Printf("Active cluster: %s\n", cfg.Kubernetes.Active)
 			return srv.ListenAndServe(addr)
 		},
 	}

--- a/cmd/mf/apps.go
+++ b/cmd/mf/apps.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/younjinjeong/microfoundry/pkg/k8s"
 )
 
 func appsCmd() *cobra.Command {
@@ -15,7 +14,7 @@ func appsCmd() *cobra.Command {
 		Short: "List all deployed applications",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", "cf-local.dev")
+			k8sClient, err := newK8sClient()
 			if err != nil {
 				return err
 			}
@@ -69,7 +68,7 @@ func appCmd() *cobra.Command {
 			ctx := context.Background()
 			name := args[0]
 
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", "cf-local.dev")
+			k8sClient, err := newK8sClient()
 			if err != nil {
 				return err
 			}

--- a/cmd/mf/bind_service.go
+++ b/cmd/mf/bind_service.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func bindServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bind-service <app-name> <service-instance>",
+		Short: "Bind a service instance to an application",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			appName := args[0]
+			svcName := args[1]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			binder := service.NewBinder(k8sClient)
+
+			// Verify service exists and is available
+			inst, err := mgr.Get(ctx, svcName)
+			if err != nil {
+				return err
+			}
+			if inst.Status != models.ServiceStatusAvailable {
+				return fmt.Errorf("service %q is not available (status: %s)", svcName, inst.Status)
+			}
+
+			fmt.Printf("Binding service '%s' to app '%s'...\n", svcName, appName)
+
+			// Add binding metadata
+			if err := mgr.AddBinding(ctx, svcName, appName); err != nil {
+				return fmt.Errorf("adding binding: %w", err)
+			}
+
+			// Inject credentials into deployment
+			secretName := service.SecretName(svcName)
+			if err := binder.Bind(ctx, appName, secretName); err != nil {
+				// Rollback binding metadata
+				_ = mgr.RemoveBinding(ctx, svcName, appName)
+				return fmt.Errorf("binding to deployment: %w", err)
+			}
+
+			fmt.Printf("Service '%s' bound to app '%s'.\n", svcName, appName)
+			fmt.Printf("The app will restart to pick up the new environment variables.\n")
+			return nil
+		},
+	}
+}

--- a/cmd/mf/create_service.go
+++ b/cmd/mf/create_service.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func createServiceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-service <service-type> <plan> <instance-name>",
+		Short: "Provision a new backing service instance",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			serviceType := args[0]
+			plan := args[1]
+			name := args[2]
+
+			// Validate instance name
+			if !models.ValidServiceName.MatchString(name) {
+				return fmt.Errorf("invalid service name %q: must be lowercase alphanumeric with hyphens, 2-42 characters", name)
+			}
+
+			// Validate service type and plan exist
+			_, ok := service.FindServiceType(serviceType)
+			if !ok {
+				return fmt.Errorf("unknown service type %q — run 'mf marketplace' to see available services", serviceType)
+			}
+			planInfo, ok := service.FindPlan(serviceType, plan)
+			if !ok {
+				return fmt.Errorf("unknown plan %q for service %q", plan, serviceType)
+			}
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+
+			// Check if already exists
+			if existing, _ := mgr.Get(ctx, name); existing != nil {
+				return fmt.Errorf("service instance %q already exists (status: %s)", name, existing.Status)
+			}
+
+			inst := &models.ServiceInstance{
+				Name:        name,
+				ServiceType: serviceType,
+				Plan:        plan,
+				ClusterID:   "active",
+			}
+
+			fmt.Printf("Creating service instance '%s'...\n", name)
+			fmt.Printf("  Service: %s\n", serviceType)
+			fmt.Printf("  Plan:    %s (%s)\n", plan, planInfo.InstanceClass)
+			fmt.Printf("  Cost:    %s\n", planInfo.CostEstimate)
+
+			if err := mgr.Create(ctx, inst); err != nil {
+				return fmt.Errorf("creating service: %w", err)
+			}
+
+			// For now, immediately set to available with mock outputs
+			// In production, this would trigger async Terraform apply
+			password := generateCLIPassword(24)
+			outputs := models.ServiceOutputs{
+				Host:     fmt.Sprintf("%s.cluster.local", name),
+				Port:     3306,
+				Username: "admin",
+				Password: password,
+				Database: name,
+				URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
+			}
+
+			if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
+				fmt.Printf("  Warning: could not save outputs: %v\n", err)
+			}
+
+			if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
+				fmt.Printf("  Warning: could not update status: %v\n", err)
+			}
+
+			fmt.Printf("\nService instance '%s' created successfully.\n", name)
+			fmt.Printf("Use 'mf bind-service <app-name> %s' to bind it to an application.\n", name)
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func generateCLIPassword(length int) string {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-change-me"
+	}
+	return hex.EncodeToString(b)[:length]
+}

--- a/cmd/mf/delete.go
+++ b/cmd/mf/delete.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/younjinjeong/microfoundry/pkg/hosts"
-	"github.com/younjinjeong/microfoundry/pkg/k8s"
 )
 
 func deleteCmd() *cobra.Command {
@@ -17,9 +16,7 @@ func deleteCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			name := args[0]
-			domain := "cf-local.dev"
-
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", domain)
+			k8sClient, err := newK8sClient()
 			if err != nil {
 				return err
 			}

--- a/cmd/mf/delete_service.go
+++ b/cmd/mf/delete_service.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func deleteServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete-service <instance-name>",
+		Short: "Delete a provisioned service instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+
+			// Verify exists
+			inst, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			// Check for active bindings
+			if len(inst.Bindings) > 0 {
+				return fmt.Errorf("service %q has %d active binding(s) — unbind all apps first", name, len(inst.Bindings))
+			}
+
+			fmt.Printf("Deleting service instance '%s'...\n", name)
+
+			if err := mgr.Delete(ctx, name); err != nil {
+				return fmt.Errorf("deleting service: %w", err)
+			}
+
+			fmt.Printf("Service instance '%s' deleted.\n", name)
+			return nil
+		},
+	}
+}

--- a/cmd/mf/logs.go
+++ b/cmd/mf/logs.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/younjinjeong/microfoundry/pkg/k8s"
 )
 
 func logsCmd() *cobra.Command {
@@ -21,7 +20,7 @@ func logsCmd() *cobra.Command {
 			ctx := context.Background()
 			name := args[0]
 
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", "cf-local.dev")
+			k8sClient, err := newK8sClient()
 			if err != nil {
 				return err
 			}

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/config"
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
 )
 
 var version = "dev"
@@ -31,6 +33,19 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+}
+
+// newK8sClient loads config and returns a k8s.Client for the active cluster.
+func newK8sClient() (*k8s.Client, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+	_, cluster, ok := cfg.Kubernetes.GetActiveCluster()
+	if !ok {
+		return nil, fmt.Errorf("no active cluster configured")
+	}
+	return k8s.NewClient(cluster.Context, cluster.Namespace, cluster.Domain)
 }
 
 func versionCmd() *cobra.Command {

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -27,6 +27,17 @@ func main() {
 		deleteCmd(),
 		scaleCmd(),
 		adminCmd(),
+		marketplaceCmd(),
+		createServiceCmd(),
+		servicesCmd(),
+		serviceCmd(),
+		bindServiceCmd(),
+		unbindServiceCmd(),
+		deleteServiceCmd(),
+		secretsListCmd(),
+		secretDetailCmd(),
+		createSecretCmd(),
+		deleteSecretCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/mf/marketplace.go
+++ b/cmd/mf/marketplace.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func marketplaceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "marketplace",
+		Short:   "List available backing services and plans",
+		Aliases: []string{"m"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			catalog := service.Catalog()
+
+			if len(catalog) == 0 {
+				fmt.Println("No services available.")
+				return nil
+			}
+
+			for _, svc := range catalog {
+				fmt.Printf("\n%s  (%s)\n", svc.Name, svc.ID)
+				fmt.Printf("  %s\n", svc.Description)
+				fmt.Printf("  Provider: %s  |  Category: %s\n", svc.Provider, svc.Category)
+				fmt.Println()
+				fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n", "PLAN", "INSTANCE", "STORAGE", "REPLICAS", "AZ", "COST")
+				for _, p := range svc.Plans {
+					replicas := "none"
+					if p.Replicas > 0 {
+						replicas = fmt.Sprintf("%d", p.Replicas)
+					}
+					az := "single"
+					if p.MultiAZ {
+						az = "multi"
+					}
+					fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n",
+						p.ID, p.InstanceClass, fmt.Sprintf("%dGB", p.StorageGB),
+						replicas, az, p.CostEstimate)
+				}
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+}

--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/younjinjeong/microfoundry/pkg/build"
+	"github.com/younjinjeong/microfoundry/pkg/config"
 	"github.com/younjinjeong/microfoundry/pkg/hosts"
 	"github.com/younjinjeong/microfoundry/pkg/k8s"
 	"github.com/younjinjeong/microfoundry/pkg/manifest"
@@ -31,6 +32,17 @@ func pushCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
+			// Load config for active cluster
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			_, cluster, ok := cfg.Kubernetes.GetActiveCluster()
+			if !ok {
+				return fmt.Errorf("no active cluster configured")
+			}
+			domain := cluster.Domain
+
 			// Determine source directory
 			srcDir := path
 			if srcDir == "" {
@@ -41,7 +53,6 @@ func pushCmd() *cobra.Command {
 			// Load manifest or build from flags
 			var app models.App
 			var routes []models.Route
-			domain := "cf-local.dev"
 
 			manifestPath := filepath.Join(srcDir, "manifest.yml")
 			if _, err := os.Stat(manifestPath); err == nil {
@@ -99,8 +110,8 @@ func pushCmd() *cobra.Command {
 			fmt.Printf("  Build: OK (%s)\n", result.ImageRef)
 
 			// Phase 2: Deploy to K8s
-			fmt.Printf("Deploying %s...\n", app.Name)
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", domain)
+			fmt.Printf("Deploying %s to cluster %s...\n", app.Name, cfg.Kubernetes.Active)
+			k8sClient, err := k8s.NewClient(cluster.Context, cluster.Namespace, domain)
 			if err != nil {
 				return fmt.Errorf("connecting to kubernetes: %w", err)
 			}

--- a/cmd/mf/scale.go
+++ b/cmd/mf/scale.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/younjinjeong/microfoundry/pkg/k8s"
 )
 
 func scaleCmd() *cobra.Command {
@@ -23,7 +22,7 @@ func scaleCmd() *cobra.Command {
 				return fmt.Errorf("--instances (-i) must be a positive number")
 			}
 
-			k8sClient, err := k8s.NewClient("docker-desktop", "microfoundry", "cf-local.dev")
+			k8sClient, err := newK8sClient()
 			if err != nil {
 				return err
 			}

--- a/cmd/mf/secrets.go
+++ b/cmd/mf/secrets.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+)
+
+func secretsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "secrets",
+		Short: "List all managed secrets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+			items, err := mgr.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No managed secrets found.")
+				fmt.Println("Use 'mf create-secret <name> key=value...' to create a secret.")
+				return nil
+			}
+
+			fmt.Printf("%-25s %-15s %-20s %-6s %-10s\n", "NAME", "TYPE", "SERVICE", "KEYS", "CREATED")
+			for _, item := range items {
+				svc := "—"
+				if item.ServiceInstance != "" {
+					svc = item.ServiceInstance
+				}
+				fmt.Printf("%-25s %-15s %-20s %-6d %-10s\n",
+					item.K8sName, item.Type, svc, item.KeyCount, item.CreatedAt.Format("2006-01-02"))
+			}
+			return nil
+		},
+	}
+}
+
+func secretDetailCmd() *cobra.Command {
+	var reveal bool
+
+	cmd := &cobra.Command{
+		Use:   "secret <name>",
+		Short: "Show secret details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+			detail, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("name:         %s\n", detail.Name)
+			fmt.Printf("k8s-name:     %s\n", detail.K8sName)
+			fmt.Printf("type:         %s\n", detail.Type)
+			if detail.ServiceInstance != "" {
+				fmt.Printf("service:      %s\n", detail.ServiceInstance)
+			}
+			if detail.Description != "" {
+				fmt.Printf("description:  %s\n", detail.Description)
+			}
+			fmt.Printf("keys:         %s\n", strings.Join(detail.Keys, ", "))
+			fmt.Printf("created:      %s\n", detail.CreatedAt.Format("2006-01-02T15:04:05Z"))
+
+			if len(detail.Keys) > 0 {
+				fmt.Println()
+				fmt.Println("Key-Value Pairs:")
+				for _, key := range detail.Keys {
+					if reveal {
+						val, err := mgr.GetValue(ctx, name, key)
+						if err != nil {
+							fmt.Printf("  %-15s %s\n", key+":", "(error: "+err.Error()+")")
+						} else {
+							fmt.Printf("  %-15s %s\n", key+":", val)
+						}
+					} else {
+						fmt.Printf("  %-15s %s\n", key+":", "********")
+					}
+				}
+			}
+
+			if len(detail.BoundApps) > 0 {
+				fmt.Println()
+				fmt.Println("Bound Applications:")
+				for _, app := range detail.BoundApps {
+					fmt.Printf("  %s\n", app)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&reveal, "reveal", false, "Show actual secret values")
+	return cmd
+}
+
+func createSecretCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create-secret <name> [key=value...]",
+		Short: "Create a user-defined secret",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			if !models.ValidSecretName.MatchString(name) {
+				return fmt.Errorf("invalid secret name %q: must be lowercase alphanumeric with hyphens, 2-42 characters", name)
+			}
+
+			// Parse key=value pairs
+			data := make(map[string]string)
+			for _, kv := range args[1:] {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid key=value pair: %q (expected KEY=VALUE format)", kv)
+				}
+				if parts[0] == "" {
+					return fmt.Errorf("empty key in pair: %q", kv)
+				}
+				data[parts[0]] = parts[1]
+			}
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+
+			fmt.Printf("Creating secret '%s' with %d key(s)...\n", name, len(data))
+			if err := mgr.CreateUserSecret(ctx, name, "", data); err != nil {
+				return fmt.Errorf("creating secret: %w", err)
+			}
+
+			fmt.Printf("Secret '%s' created successfully.\n", name)
+			fmt.Printf("K8s Secret name: %s%s\n", models.UserSecretPrefix, name)
+			return nil
+		},
+	}
+}
+
+func deleteSecretCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete-secret <name>",
+		Short: "Delete a user-defined secret",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+
+			// Check if it's a service secret
+			detail, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			if detail.Type == models.SecretTypeService {
+				return fmt.Errorf("cannot delete service secret %q — use 'mf delete-service %s' instead", name, detail.ServiceInstance)
+			}
+
+			if len(detail.BoundApps) > 0 {
+				return fmt.Errorf("secret %q has %d active binding(s) — unbind all apps first", name, len(detail.BoundApps))
+			}
+
+			fmt.Printf("Deleting secret '%s'...\n", name)
+			if err := mgr.Delete(ctx, name); err != nil {
+				return fmt.Errorf("deleting secret: %w", err)
+			}
+
+			fmt.Printf("Secret '%s' deleted.\n", name)
+			return nil
+		},
+	}
+}

--- a/cmd/mf/services.go
+++ b/cmd/mf/services.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func servicesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "services",
+		Short: "List provisioned service instances",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			items, err := mgr.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No service instances found.")
+				fmt.Println("Use 'mf marketplace' to see available services.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %-12s %-12s %-5s\n", "NAME", "SERVICE", "PLAN", "STATUS", "APPS")
+			for _, item := range items {
+				fmt.Printf("%-20s %-30s %-12s %-12s %-5d\n",
+					item.Name, item.ServiceType, item.Plan, item.Status, item.BoundApps)
+			}
+			return nil
+		},
+	}
+}
+
+func serviceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "service [name]",
+		Short: "Show service instance details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			inst, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("name:         %s\n", inst.Name)
+			fmt.Printf("service:      %s\n", inst.ServiceType)
+			fmt.Printf("plan:         %s\n", inst.Plan)
+			fmt.Printf("status:       %s\n", inst.Status)
+			if inst.StatusMsg != "" {
+				fmt.Printf("message:      %s\n", inst.StatusMsg)
+			}
+			fmt.Printf("cluster:      %s\n", inst.ClusterID)
+
+			if inst.Outputs.Host != "" {
+				fmt.Println()
+				fmt.Println("Connection Info:")
+				fmt.Printf("  host:       %s\n", inst.Outputs.Host)
+				fmt.Printf("  port:       %d\n", inst.Outputs.Port)
+				fmt.Printf("  database:   %s\n", inst.Outputs.Database)
+				fmt.Printf("  username:   %s\n", inst.Outputs.Username)
+			}
+
+			if len(inst.Bindings) > 0 {
+				fmt.Println()
+				fmt.Println("Bound Applications:")
+				var apps []string
+				for _, b := range inst.Bindings {
+					apps = append(apps, b.AppName)
+				}
+				fmt.Printf("  %s\n", strings.Join(apps, ", "))
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/mf/unbind_service.go
+++ b/cmd/mf/unbind_service.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func unbindServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unbind-service <app-name> <service-instance>",
+		Short: "Unbind a service instance from an application",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			appName := args[0]
+			svcName := args[1]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			binder := service.NewBinder(k8sClient)
+
+			fmt.Printf("Unbinding service '%s' from app '%s'...\n", svcName, appName)
+
+			// Remove credentials from deployment
+			secretName := service.SecretName(svcName)
+			if err := binder.Unbind(ctx, appName, secretName); err != nil {
+				return fmt.Errorf("unbinding from deployment: %w", err)
+			}
+
+			// Remove binding metadata
+			if err := mgr.RemoveBinding(ctx, svcName, appName); err != nil {
+				return fmt.Errorf("removing binding: %w", err)
+			}
+
+			fmt.Printf("Service '%s' unbound from app '%s'.\n", svcName, appName)
+			return nil
+		},
+	}
+}

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -3,8 +3,28 @@ github:
   repo: "microfoundry"
 
 kubernetes:
-  context: "docker-desktop"
-  namespace: "microfoundry"
+  active: "docker-desktop"
+  clusters:
+    docker-desktop:
+      name: "docker-desktop"
+      context: "docker-desktop"
+      namespace: "microfoundry"
+      domain: "cf-local.dev"
+      provider: "docker-desktop"
+      enabled: true
+    # Example: Add an EKS cluster
+    # my-eks-cluster:
+    #   name: "Production EKS"
+    #   context: "arn:aws:eks:us-east-1:123456789:cluster/my-cluster"
+    #   namespace: "microfoundry"
+    #   domain: "apps.example.com"
+    #   provider: "eks"
+    #   region: "us-east-1"
+    #   enabled: true
+
+  # Legacy single-cluster format (auto-migrated):
+  # context: "docker-desktop"
+  # namespace: "microfoundry"
 
 admin:
   port: 8080

--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -13,7 +13,14 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func (s *Server) APIListAppsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	items, err := s.k8sClient.ListAppItems(ctx)
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	items, err := client.ListAppItems(ctx)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -25,7 +32,13 @@ func (s *Server) APIGetAppHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	detail, err := s.k8sClient.GetAppDetail(ctx, name)
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	detail, err := client.GetAppDetail(ctx, name)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 		return
@@ -35,10 +48,19 @@ func (s *Server) APIGetAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) APIGetConfigHandler(w http.ResponseWriter, r *http.Request) {
+	client, _ := s.getClient(r)
+
+	domain := ""
+	namespace := ""
+	if client != nil {
+		domain = client.Domain
+		namespace = client.Namespace
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"domain":    s.k8sClient.Domain,
-		"namespace": s.k8sClient.Namespace,
-		"context":   s.config.Kubernetes.Context,
+		"domain":         domain,
+		"namespace":      namespace,
+		"active_cluster": s.clientManager.GetActive(),
 		"github": map[string]string{
 			"owner": s.config.GitHub.Owner,
 			"repo":  s.config.GitHub.Repo,
@@ -62,7 +84,13 @@ func (s *Server) APIScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.k8sClient.ScaleApp(ctx, name, body.Instances); err != nil {
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := client.ScaleApp(ctx, name, body.Instances); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -78,7 +106,13 @@ func (s *Server) APIDeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	if err := s.k8sClient.DeleteApp(ctx, name); err != nil {
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if err := client.DeleteApp(ctx, name); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/pkg/admin/cluster_handlers.go
+++ b/pkg/admin/cluster_handlers.go
@@ -2,23 +2,23 @@ package admin
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/younjinjeong/microfoundry/pkg/config"
 )
+
+// validClusterID restricts cluster names to safe alphanumeric characters.
+var validClusterID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,62}$`)
 
 // ClustersListHandler renders the clusters page with all registered clusters.
 func (s *Server) ClustersListHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	clusters := s.clientManager.ListClusters(ctx)
 
-	data := PageData{
-		Title:   "Clusters",
-		Version: s.version,
-		Active:  "clusters",
-		Content: map[string]any{
-			"Clusters":      clusters,
-			"ActiveCluster": s.clientManager.GetActive(),
-		},
+	data := s.pageData("Clusters", "clusters")
+	data.Content = map[string]any{
+		"Clusters":      clusters,
+		"ActiveCluster": s.clientManager.GetActive(),
 	}
 	s.templates.Render(w, "clusters.html", data)
 }
@@ -34,12 +34,8 @@ func (s *Server) ClusterDetailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := PageData{
-		Title:   detail.Name,
-		Version: s.version,
-		Active:  "clusters",
-		Content: detail,
-	}
+	data := s.pageData(detail.Name, "clusters")
+	data.Content = detail
 	s.templates.Render(w, "cluster_detail.html", data)
 }
 
@@ -52,16 +48,15 @@ func (s *Server) SetActiveClusterHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Set cookie so the active cluster persists across browser sessions
 	http.SetCookie(w, &http.Cookie{
 		Name:     "mf-cluster",
 		Value:    id,
 		Path:     "/",
+		MaxAge:   30 * 24 * 60 * 60, // 30 days
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})
 
-	// If HTMX request, redirect via HX-Redirect header
 	if r.Header.Get("HX-Request") == "true" {
 		w.Header().Set("HX-Redirect", "/clusters")
 		w.WriteHeader(http.StatusOK)
@@ -81,6 +76,10 @@ func (s *Server) AddClusterHandler(w http.ResponseWriter, r *http.Request) {
 	id := r.FormValue("name")
 	if id == "" {
 		http.Error(w, "Cluster name is required", http.StatusBadRequest)
+		return
+	}
+	if !validClusterID.MatchString(id) {
+		http.Error(w, "Invalid cluster name: must be alphanumeric with .-_: allowed, max 63 chars", http.StatusBadRequest)
 		return
 	}
 
@@ -104,7 +103,6 @@ func (s *Server) AddClusterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If HTMX request, redirect via HX-Redirect header
 	if r.Header.Get("HX-Request") == "true" {
 		w.Header().Set("HX-Redirect", "/clusters")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/admin/cluster_handlers.go
+++ b/pkg/admin/cluster_handlers.go
@@ -1,0 +1,159 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/config"
+)
+
+// ClustersListHandler renders the clusters page with all registered clusters.
+func (s *Server) ClustersListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clusters := s.clientManager.ListClusters(ctx)
+
+	data := PageData{
+		Title:   "Clusters",
+		Version: s.version,
+		Active:  "clusters",
+		Content: map[string]any{
+			"Clusters":      clusters,
+			"ActiveCluster": s.clientManager.GetActive(),
+		},
+	}
+	s.templates.Render(w, "clusters.html", data)
+}
+
+// ClusterDetailHandler renders the detail page for a single cluster.
+func (s *Server) ClusterDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+
+	detail, err := s.clientManager.GetClusterDetail(ctx, id)
+	if err != nil {
+		http.Error(w, "Cluster not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	data := PageData{
+		Title:   detail.Name,
+		Version: s.version,
+		Active:  "clusters",
+		Content: detail,
+	}
+	s.templates.Render(w, "cluster_detail.html", data)
+}
+
+// SetActiveClusterHandler sets the active cluster and redirects back to the clusters page.
+func (s *Server) SetActiveClusterHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.clientManager.SetActive(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Set cookie so the active cluster persists across browser sessions
+	http.SetCookie(w, &http.Cookie{
+		Name:     "mf-cluster",
+		Value:    id,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	// If HTMX request, redirect via HX-Redirect header
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/clusters")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	http.Redirect(w, r, "/clusters", http.StatusSeeOther)
+}
+
+// AddClusterHandler adds a new cluster from form data.
+func (s *Server) AddClusterHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	id := r.FormValue("name")
+	if id == "" {
+		http.Error(w, "Cluster name is required", http.StatusBadRequest)
+		return
+	}
+
+	provider := r.FormValue("provider")
+	if provider == "" {
+		provider = config.DetectProvider(r.FormValue("context"))
+	}
+
+	cfg := config.ClusterConfig{
+		Name:      id,
+		Provider:  provider,
+		Context:   r.FormValue("context"),
+		Namespace: r.FormValue("namespace"),
+		Domain:    r.FormValue("domain"),
+		Region:    r.FormValue("region"),
+		Enabled:   true,
+	}
+
+	if err := s.clientManager.AddCluster(id, cfg); err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+
+	// If HTMX request, redirect via HX-Redirect header
+	if r.Header.Get("HX-Request") == "true" {
+		w.Header().Set("HX-Redirect", "/clusters")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	http.Redirect(w, r, "/clusters", http.StatusSeeOther)
+}
+
+// RemoveClusterHandler removes a cluster by ID.
+func (s *Server) RemoveClusterHandler(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.clientManager.RemoveCluster(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// APIClustersListHandler returns all clusters as JSON.
+func (s *Server) APIClustersListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clusters := s.clientManager.ListClusters(ctx)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"clusters": clusters,
+		"active":   s.clientManager.GetActive(),
+	})
+}
+
+// APIClusterHealthHandler returns the health status of a single cluster as JSON.
+func (s *Server) APIClusterHealthHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+
+	status, err := s.clientManager.CheckHealth(ctx, id)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"cluster": id,
+			"status":  status,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"cluster": id,
+		"status":  status,
+	})
+}

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -247,16 +247,6 @@ func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	s.templates.Render(w, "config.html", data)
 }
 
-func (s *Server) ServicesHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Backing Services", "services")
-	s.templates.Render(w, "services.html", data)
-}
-
-func (s *Server) SecretsHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Secrets", "secrets")
-	s.templates.Render(w, "secrets.html", data)
-}
-
 func (s *Server) UsersHandler(w http.ResponseWriter, r *http.Request) {
 	data := s.pageData("Users & Organizations", "users")
 	s.templates.Render(w, "users.html", data)

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -178,8 +178,8 @@ func (s *Server) ScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 
 	instancesStr := r.FormValue("instances")
 	instances, err := strconv.Atoi(instancesStr)
-	if err != nil || instances < 0 {
-		http.Error(w, "Invalid instance count", http.StatusBadRequest)
+	if err != nil || instances < 0 || instances > 20 {
+		http.Error(w, "instances must be between 0 and 20", http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -7,34 +7,54 @@ import (
 
 // PageData is the base data passed to every full-page template.
 type PageData struct {
-	Title   string
-	Version string
-	Active  string
-	Content any
+	Title         string
+	Version       string
+	Active        string
+	ActiveCluster string
+	Content       any
+}
+
+func (s *Server) pageData(title, active string) PageData {
+	return PageData{
+		Title:         title,
+		Version:       s.version,
+		Active:        active,
+		ActiveCluster: s.clientManager.GetActive(),
+	}
 }
 
 func (s *Server) DashboardHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	apps, _ := s.k8sClient.ListApps(ctx)
 
-	data := PageData{
-		Title:   "Dashboard",
-		Version: s.version,
-		Active:  "dashboard",
-		Content: map[string]any{
-			"AppCount":  len(apps),
-			"Domain":    s.k8sClient.Domain,
-			"Namespace": s.k8sClient.Namespace,
-			"Context":   s.config.Kubernetes.Context,
-			"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
-		},
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	apps, _ := client.ListApps(ctx)
+
+	data := s.pageData("Dashboard", "dashboard")
+	data.Content = map[string]any{
+		"AppCount":  len(apps),
+		"Domain":    client.Domain,
+		"Namespace": client.Namespace,
+		"Context":   s.config.Kubernetes.Active,
+		"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
 	}
 	s.templates.Render(w, "dashboard.html", data)
 }
 
 func (s *Server) AppsListHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	items, err := s.k8sClient.ListAppItems(ctx)
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	items, err := client.ListAppItems(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -49,27 +69,19 @@ func (s *Server) AppsListHandler(w http.ResponseWriter, r *http.Request) {
 				filtered = append(filtered, item)
 			}
 		}
-		data := PageData{
-			Title:   "Applications",
-			Version: s.version,
-			Active:  "apps",
-			Content: map[string]any{
-				"Apps":   filtered,
-				"Filter": filter,
-			},
+		data := s.pageData("Applications", "apps")
+		data.Content = map[string]any{
+			"Apps":   filtered,
+			"Filter": filter,
 		}
 		s.templates.Render(w, "apps.html", data)
 		return
 	}
 
-	data := PageData{
-		Title:   "Applications",
-		Version: s.version,
-		Active:  "apps",
-		Content: map[string]any{
-			"Apps":   items,
-			"Filter": "all",
-		},
+	data := s.pageData("Applications", "apps")
+	data.Content = map[string]any{
+		"Apps":   items,
+		"Filter": "all",
 	}
 	s.templates.Render(w, "apps.html", data)
 }
@@ -78,7 +90,13 @@ func (s *Server) AppDetailHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	detail, err := s.k8sClient.GetAppDetail(ctx, name)
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	detail, err := client.GetAppDetail(ctx, name)
 	if err != nil {
 		http.Error(w, "App not found: "+err.Error(), http.StatusNotFound)
 		return
@@ -90,14 +108,10 @@ func (s *Server) AppDetailHandler(w http.ResponseWriter, r *http.Request) {
 		tab = "overview"
 	}
 
-	data := PageData{
-		Title:   name,
-		Version: s.version,
-		Active:  "apps",
-		Content: map[string]any{
-			"Detail": detail,
-			"Tab":    tab,
-		},
+	data := s.pageData(name, "apps")
+	data.Content = map[string]any{
+		"Detail": detail,
+		"Tab":    tab,
 	}
 	s.templates.Render(w, "app_detail.html", data)
 }
@@ -119,7 +133,13 @@ func (s *Server) AppTabHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	detail, err := s.k8sClient.GetAppDetail(ctx, name)
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	detail, err := client.GetAppDetail(ctx, name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -133,7 +153,13 @@ func (s *Server) AppInstancesHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	status, err := s.k8sClient.GetAppStatus(ctx, name)
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	status, err := client.GetAppStatus(ctx, name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -157,13 +183,19 @@ func (s *Server) ScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.k8sClient.ScaleApp(ctx, name, instances); err != nil {
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := client.ScaleApp(ctx, name, instances); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Return updated app row via ListAppItems
-	items, _ := s.k8sClient.ListAppItems(ctx)
+	items, _ := client.ListAppItems(ctx)
 	for _, item := range items {
 		if item.Name == name {
 			s.templates.RenderPartial(w, "app_row.html", item)
@@ -179,7 +211,13 @@ func (s *Server) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	if err := s.k8sClient.DeleteApp(ctx, name); err != nil {
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := client.DeleteApp(ctx, name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -188,45 +226,38 @@ func (s *Server) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
-	data := PageData{
-		Title:   "Configuration",
-		Version: s.version,
-		Active:  "config",
-		Content: map[string]any{
-			"Domain":    s.k8sClient.Domain,
-			"Namespace": s.k8sClient.Namespace,
-			"Context":   s.config.Kubernetes.Context,
-			"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
-			"Owner":     s.config.GitHub.Owner,
-			"Repo":      s.config.GitHub.Repo,
-		},
+	client, _ := s.getClient(r)
+
+	domain := ""
+	namespace := ""
+	if client != nil {
+		domain = client.Domain
+		namespace = client.Namespace
+	}
+
+	data := s.pageData("Configuration", "config")
+	data.Content = map[string]any{
+		"Domain":    domain,
+		"Namespace": namespace,
+		"Context":   s.config.Kubernetes.Active,
+		"GitHub":    s.config.GitHub.Owner + "/" + s.config.GitHub.Repo,
+		"Owner":     s.config.GitHub.Owner,
+		"Repo":      s.config.GitHub.Repo,
 	}
 	s.templates.Render(w, "config.html", data)
 }
 
 func (s *Server) ServicesHandler(w http.ResponseWriter, r *http.Request) {
-	data := PageData{
-		Title:   "Backing Services",
-		Version: s.version,
-		Active:  "services",
-	}
+	data := s.pageData("Backing Services", "services")
 	s.templates.Render(w, "services.html", data)
 }
 
 func (s *Server) SecretsHandler(w http.ResponseWriter, r *http.Request) {
-	data := PageData{
-		Title:   "Secrets",
-		Version: s.version,
-		Active:  "secrets",
-	}
+	data := s.pageData("Secrets", "secrets")
 	s.templates.Render(w, "secrets.html", data)
 }
 
 func (s *Server) UsersHandler(w http.ResponseWriter, r *http.Request) {
-	data := PageData{
-		Title:   "Users & Organizations",
-		Version: s.version,
-		Active:  "users",
-	}
+	data := s.pageData("Users & Organizations", "users")
 	s.templates.Render(w, "users.html", data)
 }

--- a/pkg/admin/logs.go
+++ b/pkg/admin/logs.go
@@ -21,8 +21,15 @@ func (s *Server) LogStreamHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	client, err := s.getClient(r)
+	if err != nil {
+		fmt.Fprintf(w, "event: error\ndata: %s\n\n", html.EscapeString(err.Error()))
+		flusher.Flush()
+		return
+	}
+
 	ctx := r.Context()
-	stream, err := s.k8sClient.GetAppLogs(ctx, name, true)
+	stream, err := client.GetAppLogs(ctx, name, true)
 	if err != nil {
 		fmt.Fprintf(w, "event: error\ndata: %s\n\n", html.EscapeString(err.Error()))
 		flusher.Flush()

--- a/pkg/admin/secret_handlers.go
+++ b/pkg/admin/secret_handlers.go
@@ -1,0 +1,291 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+)
+
+// SecretsListHandler shows all managed secrets.
+func (s *Server) SecretsListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		log.Printf("error listing secrets: %v", err)
+		items = []models.SecretListItem{}
+	}
+
+	// Apply type filter
+	filter := r.URL.Query().Get("type")
+	if filter == "" {
+		filter = "all"
+	}
+	if filter != "all" {
+		var filtered []models.SecretListItem
+		for _, item := range items {
+			if item.Type == filter {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+
+	data := s.pageData("Secrets Manager", "secrets")
+	data.Content = map[string]any{
+		"Secrets": items,
+		"Filter":  filter,
+	}
+	s.templates.Render(w, "secrets.html", data)
+}
+
+// SecretDetailHandler shows details of a single secret.
+func (s *Server) SecretDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Secret not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	data := s.pageData(name, "secrets")
+	data.Content = map[string]any{
+		"Detail": detail,
+	}
+	s.templates.Render(w, "secret_detail.html", data)
+}
+
+// SecretRevealHandler returns the actual value of a single key (HTMX partial).
+func (s *Server) SecretRevealHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	key := r.PathValue("key")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	value, err := mgr.GetValue(ctx, name, key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<span class="font-mono text-sm text-gray-900 break-all">%s</span>`, value)
+}
+
+// CreateSecretFormHandler renders the secret creation form.
+func (s *Server) CreateSecretFormHandler(w http.ResponseWriter, r *http.Request) {
+	data := s.pageData("Create Secret", "secrets")
+	s.templates.Render(w, "secret_create.html", data)
+}
+
+// CreateSecretHandler creates a user-defined secret.
+func (s *Server) CreateSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	name := r.FormValue("name")
+	description := r.FormValue("description")
+
+	if name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	if !models.ValidSecretName.MatchString(name) {
+		http.Error(w, "invalid secret name: must be lowercase alphanumeric with hyphens, 2-42 characters", http.StatusBadRequest)
+		return
+	}
+
+	// Parse key-value pairs from form
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "parsing form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	keyNames := r.Form["key_name"]
+	keyValues := r.Form["key_value"]
+
+	if len(keyNames) == 0 {
+		http.Error(w, "at least one key-value pair is required", http.StatusBadRequest)
+		return
+	}
+
+	data := make(map[string]string)
+	for i, k := range keyNames {
+		if k == "" {
+			continue
+		}
+		v := ""
+		if i < len(keyValues) {
+			v = keyValues[i]
+		}
+		data[k] = v
+	}
+
+	if len(data) == 0 {
+		http.Error(w, "at least one non-empty key is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	if err := mgr.CreateUserSecret(ctx, name, description, data); err != nil {
+		http.Error(w, "creating secret: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/secrets/"+name, http.StatusSeeOther)
+}
+
+// DeleteSecretHandler deletes a user-defined secret.
+func (s *Server) DeleteSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+
+	// Check if it's a service secret — those must be deleted via delete-service
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Secret not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if detail.Type == models.SecretTypeService {
+		http.Error(w, fmt.Sprintf("cannot delete service secret %q — use 'mf delete-service %s' instead", name, detail.ServiceInstance), http.StatusBadRequest)
+		return
+	}
+
+	// Check for bound apps
+	if len(detail.BoundApps) > 0 {
+		http.Error(w, fmt.Sprintf("secret %q has %d active binding(s) — unbind all apps first", name, len(detail.BoundApps)), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.Delete(ctx, name); err != nil {
+		http.Error(w, "deleting secret: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// API handlers
+
+// APISecretsListHandler returns secrets as JSON.
+func (s *Server) APISecretsListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+// APISecretDetailHandler returns a single secret as JSON (values redacted).
+func (s *Server) APISecretDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, detail)
+}
+
+// APICreateSecretHandler creates a user-defined secret from JSON.
+func (s *Server) APICreateSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req struct {
+		Name        string            `json:"name"`
+		Description string            `json:"description"`
+		Data        map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	if !models.ValidSecretName.MatchString(req.Name) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid secret name"})
+		return
+	}
+	if len(req.Data) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one key-value pair is required"})
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	if err := mgr.CreateUserSecret(ctx, req.Name, req.Description, req.Data); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"name": req.Name, "status": "created"})
+}

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -8,23 +8,32 @@ import (
 )
 
 type Server struct {
-	k8sClient *k8s.Client
-	config    *config.Config
-	version   string
-	templates *TemplateRenderer
-	mux       *http.ServeMux
+	clientManager *k8s.ClientManager
+	config        *config.Config
+	version       string
+	templates     *TemplateRenderer
+	mux           *http.ServeMux
 }
 
-func NewServer(k8sClient *k8s.Client, cfg *config.Config, version string) *Server {
+func NewServer(clientManager *k8s.ClientManager, cfg *config.Config, version string) *Server {
 	s := &Server{
-		k8sClient: k8sClient,
-		config:    cfg,
-		version:   version,
-		templates: NewTemplateRenderer(),
-		mux:       http.NewServeMux(),
+		clientManager: clientManager,
+		config:        cfg,
+		version:       version,
+		templates:     NewTemplateRenderer(),
+		mux:           http.NewServeMux(),
 	}
 	s.registerRoutes()
 	return s
+}
+
+// getClient resolves the active K8s client for the current request.
+// Priority: cookie "mf-cluster" → config active cluster.
+func (s *Server) getClient(r *http.Request) (*k8s.Client, error) {
+	if cookie, err := r.Cookie("mf-cluster"); err == nil && cookie.Value != "" {
+		return s.clientManager.GetClient(cookie.Value)
+	}
+	return s.clientManager.GetActiveClient()
 }
 
 func (s *Server) registerRoutes() {
@@ -43,6 +52,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /secrets", s.SecretsHandler)
 	s.mux.HandleFunc("GET /users", s.UsersHandler)
 
+	// Cluster routes
+	s.mux.HandleFunc("GET /clusters", s.ClustersListHandler)
+	s.mux.HandleFunc("GET /clusters/{id}", s.ClusterDetailHandler)
+	s.mux.HandleFunc("POST /clusters", s.AddClusterHandler)
+	s.mux.HandleFunc("POST /clusters/{id}/activate", s.SetActiveClusterHandler)
+	s.mux.HandleFunc("DELETE /clusters/{id}", s.RemoveClusterHandler)
+
 	// HTMX action routes
 	s.mux.HandleFunc("POST /apps/{name}/scale", s.ScaleAppHandler)
 	s.mux.HandleFunc("DELETE /apps/{name}", s.DeleteAppHandler)
@@ -53,6 +69,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/config", s.APIGetConfigHandler)
 	s.mux.HandleFunc("POST /api/apps/{name}/scale", s.APIScaleAppHandler)
 	s.mux.HandleFunc("DELETE /api/apps/{name}", s.APIDeleteAppHandler)
+	s.mux.HandleFunc("GET /api/clusters", s.APIClustersListHandler)
+	s.mux.HandleFunc("GET /api/clusters/{id}/health", s.APIClusterHealthHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -48,8 +48,20 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /apps/{name}/instances", s.AppInstancesHandler)
 	s.mux.HandleFunc("GET /apps/{name}/logs/stream", s.LogStreamHandler)
 	s.mux.HandleFunc("GET /config", s.ConfigHandler)
-	s.mux.HandleFunc("GET /services", s.ServicesHandler)
-	s.mux.HandleFunc("GET /secrets", s.SecretsHandler)
+	s.mux.HandleFunc("GET /services", s.ServicesListHandler)
+	s.mux.HandleFunc("GET /services/{name}", s.ServiceDetailHandler)
+	s.mux.HandleFunc("GET /marketplace", s.MarketplaceHandler)
+	s.mux.HandleFunc("POST /services/create", s.CreateServiceHandler)
+	s.mux.HandleFunc("POST /services/{name}/bind", s.BindServiceHandler)
+	s.mux.HandleFunc("POST /services/{name}/unbind", s.UnbindServiceHandler)
+	s.mux.HandleFunc("DELETE /services/{name}", s.DeleteServiceHandler)
+	// Secret routes
+	s.mux.HandleFunc("GET /secrets", s.SecretsListHandler)
+	s.mux.HandleFunc("GET /secrets/new", s.CreateSecretFormHandler)
+	s.mux.HandleFunc("GET /secrets/{name}", s.SecretDetailHandler)
+	s.mux.HandleFunc("GET /secrets/{name}/reveal/{key}", s.SecretRevealHandler)
+	s.mux.HandleFunc("POST /secrets", s.CreateSecretHandler)
+	s.mux.HandleFunc("DELETE /secrets/{name}", s.DeleteSecretHandler)
 	s.mux.HandleFunc("GET /users", s.UsersHandler)
 
 	// Cluster routes
@@ -71,6 +83,12 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("DELETE /api/apps/{name}", s.APIDeleteAppHandler)
 	s.mux.HandleFunc("GET /api/clusters", s.APIClustersListHandler)
 	s.mux.HandleFunc("GET /api/clusters/{id}/health", s.APIClusterHealthHandler)
+	s.mux.HandleFunc("GET /api/services", s.APIServicesListHandler)
+	s.mux.HandleFunc("GET /api/services/{name}", s.APIServiceDetailHandler)
+	s.mux.HandleFunc("GET /api/marketplace", s.APIMarketplaceHandler)
+	s.mux.HandleFunc("GET /api/secrets", s.APISecretsListHandler)
+	s.mux.HandleFunc("GET /api/secrets/{name}", s.APISecretDetailHandler)
+	s.mux.HandleFunc("POST /api/secrets", s.APICreateSecretHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/service_handlers.go
+++ b/pkg/admin/service_handlers.go
@@ -1,0 +1,323 @@
+package admin
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+// generatePassword returns a cryptographically random hex password.
+func generatePassword(length int) string {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-change-me" // should never happen
+	}
+	return hex.EncodeToString(b)[:length]
+}
+
+// ServicesListHandler shows all provisioned service instances.
+func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		log.Printf("error listing services: %v", err)
+		items = []models.ServiceListItem{}
+	}
+
+	data := s.pageData("Backing Services", "services")
+	data.Content = map[string]any{
+		"Services": items,
+	}
+	s.templates.Render(w, "services.html", data)
+}
+
+// ServiceDetailHandler shows details of a single service instance.
+func (s *Server) ServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Find plan details from catalog
+	plan, _ := service.FindPlan(inst.ServiceType, inst.Plan)
+
+	data := s.pageData(name, "services")
+	data.Content = map[string]any{
+		"Instance": inst,
+		"Plan":     plan,
+	}
+	s.templates.Render(w, "service_detail.html", data)
+}
+
+// MarketplaceHandler shows the service catalog.
+func (s *Server) MarketplaceHandler(w http.ResponseWriter, r *http.Request) {
+	catalog := service.Catalog()
+
+	data := s.pageData("Service Marketplace", "marketplace")
+	data.Content = map[string]any{
+		"Catalog": catalog,
+	}
+	s.templates.Render(w, "marketplace.html", data)
+}
+
+// CreateServiceHandler provisions a new service instance from the marketplace.
+func (s *Server) CreateServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	serviceType := r.FormValue("service_type")
+	plan := r.FormValue("plan")
+	name := r.FormValue("name")
+
+	if serviceType == "" || plan == "" || name == "" {
+		http.Error(w, "service_type, plan, and name are required", http.StatusBadRequest)
+		return
+	}
+
+	if !models.ValidServiceName.MatchString(name) {
+		http.Error(w, "invalid service name: must be lowercase alphanumeric with hyphens, 2-42 characters", http.StatusBadRequest)
+		return
+	}
+
+	_, ok := service.FindServiceType(serviceType)
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown service type: %s", serviceType), http.StatusBadRequest)
+		return
+	}
+	if _, ok := service.FindPlan(serviceType, plan); !ok {
+		http.Error(w, fmt.Sprintf("unknown plan %q for service %q", plan, serviceType), http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+
+	// Check if already exists
+	if existing, _ := mgr.Get(ctx, name); existing != nil {
+		http.Error(w, fmt.Sprintf("service instance %q already exists", name), http.StatusConflict)
+		return
+	}
+
+	inst := &models.ServiceInstance{
+		Name:        name,
+		ServiceType: serviceType,
+		Plan:        plan,
+		ClusterID:   s.clientManager.GetActive(),
+	}
+
+	if err := mgr.Create(ctx, inst); err != nil {
+		http.Error(w, "creating service: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Mock outputs with per-instance random password (will be replaced by Terraform)
+	password := generatePassword(24)
+	outputs := models.ServiceOutputs{
+		Host:     fmt.Sprintf("%s.cluster.local", name),
+		Port:     3306,
+		Username: "admin",
+		Password: password,
+		Database: name,
+		URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
+	}
+	if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
+		log.Printf("error saving service outputs for %q: %v", name, err)
+	}
+	if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
+		log.Printf("error updating service status for %q: %v", name, err)
+	}
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// BindServiceHandler binds a service instance to an app.
+func (s *Server) BindServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	appName := r.FormValue("app_name")
+
+	if appName == "" {
+		http.Error(w, "app_name is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	binder := service.NewBinder(client)
+
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+	if inst.Status != models.ServiceStatusAvailable {
+		http.Error(w, fmt.Sprintf("service %q is not available (status: %s)", name, inst.Status), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.AddBinding(ctx, name, appName); err != nil {
+		http.Error(w, "adding binding: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	secretName := service.SecretName(name)
+	if err := binder.Bind(ctx, appName, secretName); err != nil {
+		_ = mgr.RemoveBinding(ctx, name, appName)
+		http.Error(w, "binding to deployment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// UnbindServiceHandler unbinds a service instance from an app.
+func (s *Server) UnbindServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	appName := r.FormValue("app_name")
+
+	if appName == "" {
+		http.Error(w, "app_name is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	binder := service.NewBinder(client)
+
+	secretName := service.SecretName(name)
+	if err := binder.Unbind(ctx, appName, secretName); err != nil {
+		http.Error(w, "unbinding from deployment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := mgr.RemoveBinding(ctx, name, appName); err != nil {
+		http.Error(w, "removing binding: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeleteServiceHandler deletes a service instance.
+func (s *Server) DeleteServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if len(inst.Bindings) > 0 {
+		http.Error(w, fmt.Sprintf("service %q has %d active binding(s) — unbind all apps first", name, len(inst.Bindings)), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.Delete(ctx, name); err != nil {
+		http.Error(w, "deleting service: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// API handlers
+
+// APIServicesListHandler returns service instances as JSON.
+func (s *Server) APIServicesListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := service.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+// APIServiceDetailHandler returns a single service instance as JSON (credentials redacted).
+func (s *Server) APIServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := service.NewManager(client)
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Redact sensitive fields in API response
+	redacted := inst.Redacted()
+	writeJSON(w, http.StatusOK, redacted)
+}
+
+// APIMarketplaceHandler returns the service catalog as JSON.
+func (s *Server) APIMarketplaceHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, service.Catalog())
+}

--- a/pkg/admin/static/templates/cluster_detail.html
+++ b/pkg/admin/static/templates/cluster_detail.html
@@ -1,0 +1,199 @@
+{{define "cluster_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$d := .Content}}
+<div class="space-y-6">
+    <!-- Cluster Header -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-4">
+                <a href="/clusters" class="text-gray-400 hover:text-gray-600">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+                    </svg>
+                </a>
+                <h3 class="text-2xl font-bold text-gray-900">{{$d.Name}}</h3>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{stateBg $d.Status}}">
+                    {{$d.Status}}
+                </span>
+                {{if $d.IsActive}}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                    active cluster
+                </span>
+                {{end}}
+            </div>
+            {{if $d.Version}}
+            <span class="text-sm text-gray-500">Kubernetes {{$d.Version}}</span>
+            {{end}}
+        </div>
+    </div>
+
+    <!-- Info Cards Row -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Cluster Info Card -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Cluster Info</h4>
+            </div>
+            <div class="p-6">
+                <dl class="grid grid-cols-2 gap-x-6 gap-y-4">
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Provider</dt>
+                        <dd class="mt-1 text-sm text-gray-900">
+                            {{if eq $d.Provider "docker-desktop"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">docker-desktop</span>
+                            {{else if eq $d.Provider "eks"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">EKS</span>
+                            {{else if eq $d.Provider "gke"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">GKE</span>
+                            {{else if eq $d.Provider "aks"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800">AKS</span>
+                            {{else if eq $d.Provider "native"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">native</span>
+                            {{else}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{$d.Provider}}</span>
+                            {{end}}
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Context</dt>
+                        <dd class="mt-1 text-sm text-gray-900 font-mono">{{$d.Context}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Namespace</dt>
+                        <dd class="mt-1 text-sm text-gray-900 font-mono">{{$d.Namespace}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Domain</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$d.Domain}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Version</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{if $d.Version}}{{$d.Version}}{{else}}<span class="text-gray-400">-</span>{{end}}</dd>
+                    </div>
+                    {{if $d.Region}}
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Region</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$d.Region}}</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+
+        <!-- Resources Card -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Resources</h4>
+            </div>
+            <div class="p-6 space-y-5">
+                <!-- CPU -->
+                <div>
+                    <div class="flex items-center justify-between mb-1">
+                        <span class="text-sm font-medium text-gray-700">CPU</span>
+                        <span class="text-sm text-gray-500">
+                            {{if $d.ResourceUsage.CPUUsed}}{{$d.ResourceUsage.CPUUsed}}{{else}}--{{end}}
+                            / {{if $d.ResourceUsage.CPUCapacity}}{{$d.ResourceUsage.CPUCapacity}}{{else}}--{{end}}
+                        </span>
+                    </div>
+                    <div class="w-full bg-gray-200 rounded-full h-2">
+                        <div class="bg-blue-500 h-2 rounded-full" style="width: 0%"></div>
+                    </div>
+                </div>
+                <!-- Memory -->
+                <div>
+                    <div class="flex items-center justify-between mb-1">
+                        <span class="text-sm font-medium text-gray-700">Memory</span>
+                        <span class="text-sm text-gray-500">
+                            {{if $d.ResourceUsage.MemoryUsed}}{{$d.ResourceUsage.MemoryUsed}}{{else}}--{{end}}
+                            / {{if $d.ResourceUsage.MemoryCapacity}}{{$d.ResourceUsage.MemoryCapacity}}{{else}}--{{end}}
+                        </span>
+                    </div>
+                    <div class="w-full bg-gray-200 rounded-full h-2">
+                        <div class="bg-green-500 h-2 rounded-full" style="width: 0%"></div>
+                    </div>
+                </div>
+                <!-- Pods -->
+                <div>
+                    <div class="flex items-center justify-between mb-1">
+                        <span class="text-sm font-medium text-gray-700">Pods</span>
+                        <span class="text-sm text-gray-500">
+                            {{$d.ResourceUsage.PodUsed}} / {{$d.ResourceUsage.PodCapacity}}
+                        </span>
+                    </div>
+                    <div class="w-full bg-gray-200 rounded-full h-2">
+                        <div class="bg-purple-500 h-2 rounded-full" style="width: 0%"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Nodes Table -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Nodes ({{$d.NodeCount}})</h4>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Roles</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Version</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">OS</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">CPU</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Memory</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    {{range $d.Nodes}}
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{.Name}}</td>
+                        <td class="px-4 py-4 whitespace-nowrap">
+                            {{if eq .Status "Ready"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Ready</span>
+                            {{else}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">{{.Status}}</span>
+                            {{end}}
+                        </td>
+                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">{{.Roles}}</td>
+                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 font-mono">{{.Version}}</td>
+                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">{{.OS}}</td>
+                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">{{.CPU}}</td>
+                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">{{.Memory}}</td>
+                    </tr>
+                    {{else}}
+                    <tr>
+                        <td colspan="7" class="px-6 py-8 text-center text-gray-500 text-sm">
+                            No node information available.
+                        </td>
+                    </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Apps Summary -->
+    <div class="bg-white rounded-lg shadow p-6">
+        <div class="flex items-center space-x-4">
+            <div class="p-3 rounded-full bg-blue-100 text-blue-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                </svg>
+            </div>
+            <div>
+                <p class="text-sm font-medium text-gray-500">Deployed Applications</p>
+                <p class="text-2xl font-bold text-gray-900">{{$d.AppCount}}</p>
+            </div>
+            <a href="/apps" class="ml-auto text-sm text-blue-600 hover:text-blue-800 font-medium">
+                View Apps &rarr;
+            </a>
+        </div>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/clusters.html
+++ b/pkg/admin/static/templates/clusters.html
@@ -1,0 +1,174 @@
+{{define "clusters.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="bg-white rounded-lg shadow">
+    <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <h3 class="text-lg font-medium text-gray-900">Kubernetes Clusters</h3>
+        <div class="flex items-center space-x-3">
+            <button onclick="document.getElementById('add-cluster-form').classList.toggle('hidden')"
+                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                </svg>
+                Add Cluster
+            </button>
+        </div>
+    </div>
+
+    <!-- Add Cluster Inline Form -->
+    <div id="add-cluster-form" class="hidden border-b border-gray-200 bg-gray-50 p-6">
+        <form hx-post="/clusters" hx-swap="none" class="space-y-4">
+            <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Register New Cluster</h4>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div>
+                    <label for="cluster-name" class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                    <input type="text" id="cluster-name" name="name" required
+                           placeholder="my-cluster"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="cluster-provider" class="block text-sm font-medium text-gray-700 mb-1">Provider</label>
+                    <select id="cluster-provider" name="provider"
+                            class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                        <option value="docker-desktop">Docker Desktop</option>
+                        <option value="eks">AWS EKS</option>
+                        <option value="gke">Google GKE</option>
+                        <option value="aks">Azure AKS</option>
+                        <option value="native">Native / Other</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="cluster-context" class="block text-sm font-medium text-gray-700 mb-1">Kubeconfig Context</label>
+                    <input type="text" id="cluster-context" name="context" required
+                           placeholder="docker-desktop"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="cluster-namespace" class="block text-sm font-medium text-gray-700 mb-1">Namespace</label>
+                    <input type="text" id="cluster-namespace" name="namespace"
+                           placeholder="microfoundry"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="cluster-domain" class="block text-sm font-medium text-gray-700 mb-1">Domain</label>
+                    <input type="text" id="cluster-domain" name="domain"
+                           placeholder="cf-local.dev"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="cluster-region" class="block text-sm font-medium text-gray-700 mb-1">Region</label>
+                    <input type="text" id="cluster-region" name="region"
+                           placeholder="us-east-1"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+            </div>
+            <div class="flex items-center space-x-3 pt-2">
+                <button type="submit"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                    Register Cluster
+                </button>
+                <button type="button"
+                        onclick="document.getElementById('add-cluster-form').classList.add('hidden')"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Clusters Table -->
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Provider</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nodes</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Apps</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Namespace</th>
+                    <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                {{range index $c "Clusters"}}
+                <tr class="{{if .IsActive}}bg-blue-50 border-l-4 border-blue-500{{else}}hover:bg-gray-50{{end}}">
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        <div class="flex items-center">
+                            <a href="/clusters/{{.ID}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">
+                                {{.Name}}
+                            </a>
+                            {{if .IsActive}}
+                            <span class="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                active
+                            </span>
+                            {{end}}
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        {{if eq .Provider "docker-desktop"}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">docker-desktop</span>
+                        {{else if eq .Provider "eks"}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">EKS</span>
+                        {{else if eq .Provider "gke"}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">GKE</span>
+                        {{else if eq .Provider "aks"}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-cyan-100 text-cyan-800">AKS</span>
+                        {{else if eq .Provider "native"}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">native</span>
+                        {{else}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{.Provider}}</span>
+                        {{end}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{stateBg .Status}}">
+                            {{.Status}}
+                        </span>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">
+                        {{.NodeCount}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-700">
+                        {{.AppCount}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
+                        {{.Namespace}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                        {{if not .IsActive}}
+                        <button hx-post="/clusters/{{.ID}}/activate"
+                                hx-swap="none"
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors">
+                            Set Active
+                        </button>
+                        <button hx-delete="/clusters/{{.ID}}"
+                                hx-confirm="Are you sure you want to remove cluster '{{.Name}}'?"
+                                hx-target="closest tr"
+                                hx-swap="outerHTML"
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 rounded-md transition-colors">
+                            Remove
+                        </button>
+                        {{else}}
+                        <span class="text-xs text-gray-400">current</span>
+                        {{end}}
+                    </td>
+                </tr>
+                {{else}}
+                <tr>
+                    <td colspan="7" class="px-6 py-12 text-center text-gray-500">
+                        <svg class="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
+                        </svg>
+                        <p class="text-lg font-medium">No clusters registered</p>
+                        <p class="text-sm mt-1">Click <strong>"+ Add Cluster"</strong> to register your first Kubernetes cluster.</p>
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/marketplace.html
+++ b/pkg/admin/static/templates/marketplace.html
@@ -1,0 +1,101 @@
+{{define "marketplace.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="mb-6">
+    <h2 class="text-lg font-semibold text-gray-900">Service Marketplace</h2>
+    <p class="text-sm text-gray-500">Browse available backing services and provision new instances</p>
+</div>
+
+{{with .Content}}
+{{range .Catalog}}
+<div class="bg-white rounded-lg shadow mb-8">
+    <!-- Service Type Header -->
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-3">
+                <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center">
+                    <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
+                    </svg>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                    <p class="text-sm text-gray-500">{{.Description}}</p>
+                </div>
+            </div>
+            <div class="flex items-center space-x-2">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">{{.Provider}}</span>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{.Category}}</span>
+            </div>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+
+    <!-- Plans -->
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-blue-300 hover:shadow-sm transition-all">
+                <div class="flex justify-between items-start mb-3">
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                        <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                    </div>
+                </div>
+
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Instance</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.InstanceClass}}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Storage</dt>
+                        <dd class="text-gray-900">{{.StorageGB}} GB</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Replicas</dt>
+                        <dd class="text-gray-900">{{if .Replicas}}{{.Replicas}}{{else}}None{{end}}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Multi-AZ</dt>
+                        <dd class="text-gray-900">{{if .MultiAZ}}Yes{{else}}No{{end}}</dd>
+                    </div>
+                </dl>
+
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                    {{if .Customizable}}
+                    <span class="text-xs text-blue-600">Customizable</span>
+                    {{end}}
+                </div>
+
+                <!-- Create Service Form (inline) -->
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-db)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/partials/header.html
+++ b/pkg/admin/static/templates/partials/header.html
@@ -1,5 +1,13 @@
 {{define "header"}}
-<header class="bg-white border-b border-gray-200 px-6 py-4">
+<header class="bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
     <h2 class="text-xl font-semibold text-gray-800">{{.Title}}</h2>
+    {{if .ActiveCluster}}
+    <div class="flex items-center space-x-2 text-sm text-gray-500">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
+        </svg>
+        <a href="/clusters" class="font-medium text-gray-700 hover:text-blue-600">{{.ActiveCluster}}</a>
+    </div>
+    {{end}}
 </header>
 {{end}}

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -33,6 +33,13 @@
             </svg>
             Services
         </a>
+        <a href="/marketplace"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "marketplace"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"/>
+            </svg>
+            Marketplace
+        </a>
         <a href="/secrets"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "secrets"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -12,6 +12,13 @@
             </svg>
             Dashboard
         </a>
+        <a href="/clusters"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "clusters"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
+            </svg>
+            Kubernetes Clusters
+        </a>
         <a href="/apps"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "apps"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pkg/admin/static/templates/secret_create.html
+++ b/pkg/admin/static/templates/secret_create.html
@@ -1,0 +1,92 @@
+{{define "secret_create.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/secrets" class="hover:text-blue-600">Secrets</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">Create</span>
+    </nav>
+</div>
+
+<!-- Form Card -->
+<div class="max-w-2xl">
+    <div class="bg-white rounded-lg shadow p-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-6">Create Secret</h3>
+
+        <form method="POST" action="/secrets" class="space-y-6">
+            <!-- Name -->
+            <div>
+                <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                <input type="text" id="name" name="name"
+                       required
+                       pattern="[a-z][a-z0-9-]*[a-z0-9]"
+                       placeholder="my-secret"
+                       class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500">
+                <p class="mt-1 text-xs text-gray-500">Lowercase letters, numbers, and hyphens only. Must start with a letter and end with a letter or number.</p>
+            </div>
+
+            <!-- Description -->
+            <div>
+                <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
+                <textarea id="description" name="description"
+                          rows="2"
+                          placeholder="Optional description..."
+                          class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500"></textarea>
+            </div>
+
+            <!-- Key-Value Pairs -->
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2">Key-Value Pairs</label>
+                <div id="kv-pairs" class="space-y-2">
+                    <div class="kv-row flex items-center space-x-2">
+                        <input type="text" name="key_name" placeholder="KEY_NAME" required
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-mono focus:ring-blue-500 focus:border-blue-500">
+                        <input type="text" name="key_value" placeholder="value" required
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="button" onclick="this.parentElement.remove()"
+                                class="inline-flex items-center p-2 text-red-500 hover:text-red-700">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <button type="button" onclick="addKVRow()"
+                        class="mt-2 inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium">
+                    <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                    </svg>
+                    Add Key
+                </button>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex justify-end space-x-3 pt-4 border-t border-gray-200">
+                <a href="/secrets" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium">
+                    Cancel
+                </a>
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+                    Create Secret
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+function addKVRow() {
+    var container = document.getElementById('kv-pairs');
+    var firstRow = container.querySelector('.kv-row');
+    var newRow = firstRow.cloneNode(true);
+    var inputs = newRow.querySelectorAll('input');
+    for (var i = 0; i < inputs.length; i++) {
+        inputs[i].value = '';
+    }
+    container.appendChild(newRow);
+}
+</script>
+{{end}}

--- a/pkg/admin/static/templates/secret_detail.html
+++ b/pkg/admin/static/templates/secret_detail.html
@@ -1,0 +1,151 @@
+{{define "secret_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{with .Content}}
+{{$detail := .Detail}}
+
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/secrets" class="hover:text-blue-600">Secrets</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">{{$detail.Name}}</span>
+    </nav>
+</div>
+
+<!-- Header -->
+<div class="flex justify-between items-start mb-6">
+    <div>
+        <h2 class="text-2xl font-bold text-gray-900">{{$detail.Name}}</h2>
+        {{if eq $detail.Type "service"}}
+        <p class="text-sm text-gray-500 mt-1">
+            Part of service instance:
+            <a href="/services/{{$detail.ServiceInstance}}" class="text-blue-600 hover:text-blue-800">{{$detail.ServiceInstance}}</a>
+        </p>
+        {{end}}
+    </div>
+    <div class="flex items-center space-x-3">
+        {{if eq $detail.Type "service"}}
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">Service</span>
+        {{else}}
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">User-defined</span>
+        {{end}}
+        {{if eq $detail.Type "user-defined"}}
+        <button hx-delete="/secrets/{{$detail.Name}}"
+                hx-confirm="Delete secret '{{$detail.Name}}'? This cannot be undone."
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+            Delete
+        </button>
+        {{end}}
+    </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- Left Column: Key-Value Pairs -->
+    <div class="lg:col-span-2 space-y-6">
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Key-Value Pairs</h3>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{$detail.KeyCount}} keys</span>
+            </div>
+            <div class="overflow-hidden">
+                {{if $detail.Keys}}
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Key</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Value</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        {{range $detail.Keys}}
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="text-sm font-mono {{if isSensitive .}}text-red-600 font-semibold{{else}}text-gray-900{{end}}">{{.}}</span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span id="val-{{.}}" class="text-sm text-gray-400 italic">********</span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right">
+                                <button hx-get="/secrets/{{$detail.Name}}/reveal/{{.}}"
+                                        hx-target="#val-{{.}}"
+                                        hx-swap="innerHTML"
+                                        class="text-blue-600 hover:text-blue-800 text-sm font-medium">Reveal</button>
+                            </td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+                {{else}}
+                <div class="px-6 py-8 text-center">
+                    <p class="text-sm text-gray-500">No keys defined in this secret.</p>
+                </div>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    <!-- Right Sidebar -->
+    <div class="space-y-6">
+        <!-- Bound Applications -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Bound Applications</h3>
+            </div>
+            <div class="px-6 py-4">
+                {{if $detail.BoundApps}}
+                <ul class="divide-y divide-gray-200">
+                    {{range $detail.BoundApps}}
+                    <li class="py-3">
+                        <a href="/apps/{{.}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.}}</a>
+                    </li>
+                    {{end}}
+                </ul>
+                {{else}}
+                <p class="text-sm text-gray-500">No applications bound.</p>
+                {{end}}
+            </div>
+        </div>
+
+        <!-- Metadata -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Metadata</h3>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="space-y-3">
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">K8s Secret Name</dt>
+                        <dd class="mt-1 text-sm text-gray-900 font-mono">{{$detail.K8sName}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Type</dt>
+                        <dd class="mt-1">
+                            {{if eq $detail.Type "service"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Service</span>
+                            {{else}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">User-defined</span>
+                            {{end}}
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Created</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{timeAgo $detail.CreatedAt}}</dd>
+                    </div>
+                    {{if $detail.Description}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Description</dt>
+                        <dd class="mt-1 text-sm text-gray-700">{{$detail.Description}}</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/secrets.html
+++ b/pkg/admin/static/templates/secrets.html
@@ -3,21 +3,108 @@
 {{end}}
 
 {{define "content"}}
+<div class="flex justify-between items-center mb-6">
+    <div>
+        <h2 class="text-lg font-semibold text-gray-900">Secrets Manager</h2>
+        <p class="text-sm text-gray-500">Manage application secrets and environment variables</p>
+    </div>
+    <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        Create Secret
+    </a>
+</div>
+
+{{with .Content}}
+<!-- Filter Tabs -->
+<div class="border-b border-gray-200 mb-6">
+    <nav class="-mb-px flex space-x-4">
+        <a href="/secrets?type=all"
+           hx-get="/secrets?type=all" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "all"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            All
+        </a>
+        <a href="/secrets?type=service"
+           hx-get="/secrets?type=service" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "service"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            Service
+        </a>
+        <a href="/secrets?type=user-defined"
+           hx-get="/secrets?type=user-defined" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "user-defined"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            User-defined
+        </a>
+    </nav>
+</div>
+
+{{if .Secrets}}
+<div class="bg-white rounded-lg shadow overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Service</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Keys</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bound Apps</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200" id="secret-list"
+               hx-trigger="every 15s" hx-get="/secrets?type={{.Filter}}" hx-swap="innerHTML">
+            {{range .Secrets}}
+            <tr id="secret-row-{{.Name}}" class="hover:bg-gray-50">
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <a href="/secrets/{{.Name}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.Name}}</a>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    {{if eq .Type "service"}}
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Service</span>
+                    {{else}}
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">User-defined</span>
+                    {{end}}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {{if .ServiceInstance}}
+                    <a href="/services/{{.ServiceInstance}}" class="text-blue-600 hover:text-blue-800">{{.ServiceInstance}}</a>
+                    {{else}}
+                    &mdash;
+                    {{end}}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.KeyCount}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.BoundApps}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{timeAgo .CreatedAt}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-right">
+                    {{if eq .Type "user-defined"}}
+                    <button hx-delete="/secrets/{{.Name}}"
+                            hx-target="closest tr"
+                            hx-swap="outerHTML swap:500ms"
+                            hx-confirm="Delete secret '{{.Name}}'? This cannot be undone."
+                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                    {{end}}
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
 <div class="bg-white rounded-lg shadow p-12 text-center">
     <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
     </svg>
-    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
-        Coming Soon
-    </span>
-    <h3 class="text-xl font-bold text-gray-900 mt-2">Secrets Management</h3>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">No Secrets Found</h3>
     <p class="text-gray-500 mt-2 max-w-md mx-auto">
-        Configure and manage application secrets and environment variables.
-        MicroFoundry integrates with CSP-native secret managers
-        (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault).
+        You haven't created any secrets yet. Create a secret to store sensitive configuration for your applications.
     </p>
-    <div class="mt-6 text-sm text-gray-400">
-        <p>Equivalent to: cf set-env, cf bind-service (user-provided)</p>
+    <div class="mt-6">
+        <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+            Create Secret
+        </a>
     </div>
 </div>
+{{end}}
+{{end}}
 {{end}}

--- a/pkg/admin/static/templates/service_detail.html
+++ b/pkg/admin/static/templates/service_detail.html
@@ -1,0 +1,200 @@
+{{define "service_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{with .Content}}
+{{$inst := .Instance}}
+{{$plan := .Plan}}
+
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/services" class="hover:text-blue-600">Services</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">{{$inst.Name}}</span>
+    </nav>
+</div>
+
+<!-- Header -->
+<div class="flex justify-between items-start mb-6">
+    <div>
+        <h2 class="text-2xl font-bold text-gray-900">{{$inst.Name}}</h2>
+        <p class="text-sm text-gray-500 mt-1">{{$inst.ServiceType}} &middot; {{$inst.Plan}} plan</p>
+    </div>
+    <div class="flex items-center space-x-3">
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{stateBg $inst.Status}}">{{$inst.Status}}</span>
+        {{if eq (len $inst.Bindings) 0}}
+        <button hx-delete="/services/{{$inst.Name}}"
+                hx-confirm="Delete service '{{$inst.Name}}'? This cannot be undone."
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+            Delete
+        </button>
+        {{end}}
+    </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- Service Info -->
+    <div class="lg:col-span-2 space-y-6">
+        <!-- Overview Card -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Service Information</h3>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="grid grid-cols-2 gap-4">
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Service Type</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$inst.ServiceType}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Plan</dt>
+                        <dd class="mt-1 text-sm text-gray-900">
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">{{$inst.Plan}}</span>
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Cluster</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$inst.ClusterID}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Created</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{timeAgo $inst.CreatedAt}}</dd>
+                    </div>
+                    {{if $plan.InstanceClass}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Instance Class</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.InstanceClass}}</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.StorageGB}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Storage</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.StorageGB}} GB</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.MultiAZ}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Multi-AZ</dt>
+                        <dd class="mt-1 text-sm text-gray-900">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Enabled</span>
+                        </dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.Replicas}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Read Replicas</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Replicas}}</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.CostEstimate}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Estimated Cost</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.CostEstimate}}</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+
+        <!-- Connection Info -->
+        {{if $inst.Outputs.Host}}
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Connection Details</h3>
+                <a href="/secrets/{{$inst.Name}}" class="text-sm text-blue-600 hover:text-blue-800 font-medium">View in Secrets Manager &rarr;</a>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="space-y-3">
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Host</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Host}}</dd>
+                    </div>
+                    {{if $inst.Outputs.Port}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Port</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Port}}</dd>
+                    </div>
+                    {{end}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Database</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Database}}</dd>
+                    </div>
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Username</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Username}}</dd>
+                    </div>
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Password</dt>
+                        <dd class="text-sm text-gray-400 italic">********</dd>
+                    </div>
+                    {{if $inst.Outputs.URI}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">URI</dt>
+                        <dd class="text-sm text-gray-400 italic">****hidden****</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+        {{end}}
+    </div>
+
+    <!-- Sidebar: Bindings -->
+    <div class="space-y-6">
+        <!-- Bound Applications -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Bound Applications</h3>
+            </div>
+            <div class="px-6 py-4">
+                {{if $inst.Bindings}}
+                <ul class="divide-y divide-gray-200">
+                    {{range $inst.Bindings}}
+                    <li class="py-3 flex justify-between items-center">
+                        <div>
+                            <a href="/apps/{{.AppName}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.AppName}}</a>
+                            <p class="text-xs text-gray-500">bound {{timeAgo .BoundAt}}</p>
+                        </div>
+                        <form>
+                            <input type="hidden" name="app_name" value="{{.AppName}}">
+                            <button hx-post="/services/{{$inst.Name}}/unbind"
+                                    hx-include="closest form"
+                                    hx-confirm="Unbind '{{.AppName}}' from '{{$inst.Name}}'?"
+                                    class="text-xs text-red-600 hover:text-red-800 font-medium">Unbind</button>
+                        </form>
+                    </li>
+                    {{end}}
+                </ul>
+                {{else}}
+                <p class="text-sm text-gray-500">No applications bound.</p>
+                {{end}}
+
+                <!-- Bind form -->
+                <div class="mt-4 pt-4 border-t border-gray-200">
+                    <form hx-post="/services/{{$inst.Name}}/bind" hx-swap="none" class="flex space-x-2">
+                        <input type="text" name="app_name" placeholder="App name"
+                               class="flex-1 px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">Bind</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        {{if $inst.StatusMsg}}
+        <!-- Status Message -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Status Message</h3>
+            </div>
+            <div class="px-6 py-4">
+                <p class="text-sm text-gray-700">{{$inst.StatusMsg}}</p>
+            </div>
+        </div>
+        {{end}}
+    </div>
+</div>
+
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/services.html
+++ b/pkg/admin/static/templates/services.html
@@ -3,20 +3,76 @@
 {{end}}
 
 {{define "content"}}
+<div class="flex justify-between items-center mb-6">
+    <div>
+        <h2 class="text-lg font-semibold text-gray-900">Provisioned Services</h2>
+        <p class="text-sm text-gray-500">Backing services bound to your applications</p>
+    </div>
+    <a href="/marketplace" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        Create Service
+    </a>
+</div>
+
+{{with .Content}}
+{{if .Services}}
+<div class="bg-white rounded-lg shadow overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Service</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Plan</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bound Apps</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200" id="service-table-body" hx-trigger="every 15s" hx-get="/services" hx-select="#service-table-body" hx-swap="outerHTML">
+            {{range .Services}}
+            <tr id="svc-row-{{.Name}}" class="hover:bg-gray-50">
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <a href="/services/{{.Name}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.Name}}</a>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{.ServiceType}}</td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">{{.Plan}}</span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{stateBg .Status}}">{{.Status}}</span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.BoundApps}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{timeAgo .CreatedAt}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-right">
+                    <button hx-delete="/services/{{.Name}}"
+                            hx-target="#svc-row-{{.Name}}"
+                            hx-swap="outerHTML swap:0.3s"
+                            hx-confirm="Delete service '{{.Name}}'? This cannot be undone."
+                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
 <div class="bg-white rounded-lg shadow p-12 text-center">
     <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
     </svg>
-    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
-        Coming Soon
-    </span>
-    <h3 class="text-xl font-bold text-gray-900 mt-2">Backing Services</h3>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">No Services Provisioned</h3>
     <p class="text-gray-500 mt-2 max-w-md mx-auto">
-        Manage backing services like databases, message queues, and caches.
-        MicroFoundry uses OSBAPI-compatible service brokers to provision and bind services to your applications.
+        You haven't created any backing services yet. Browse the marketplace to provision databases, caches, and more.
     </p>
-    <div class="mt-6 text-sm text-gray-400">
-        <p>Planned services: AWS RDS, Cloud SQL, Azure Database, Redis, RabbitMQ</p>
+    <div class="mt-6">
+        <a href="/marketplace" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+            Browse Marketplace
+        </a>
     </div>
 </div>
+{{end}}
+{{end}}
 {{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -31,13 +31,13 @@ func templateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"stateColor": func(state string) string {
 			switch strings.ToLower(state) {
-			case "started", "running":
+			case "started", "running", "connected", "available":
 				return "green"
 			case "stopped", "down":
 				return "red"
-			case "starting", "staging", "deploying", "uploading":
+			case "starting", "staging", "deploying", "uploading", "creating", "deleting":
 				return "yellow"
-			case "crashed", "failed":
+			case "crashed", "failed", "error":
 				return "red"
 			default:
 				return "gray"
@@ -45,11 +45,11 @@ func templateFuncs() template.FuncMap {
 		},
 		"stateBg": func(state string) string {
 			switch strings.ToLower(state) {
-			case "started", "running", "connected":
+			case "started", "running", "connected", "available":
 				return "bg-green-100 text-green-800"
 			case "stopped", "down":
 				return "bg-red-100 text-red-800"
-			case "starting", "staging", "deploying", "uploading":
+			case "starting", "staging", "deploying", "uploading", "creating", "deleting":
 				return "bg-yellow-100 text-yellow-800"
 			case "crashed", "failed", "error":
 				return "bg-red-100 text-red-800"
@@ -149,6 +149,10 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"users.html",
 		"clusters.html",
 		"cluster_detail.html",
+		"service_detail.html",
+		"marketplace.html",
+		"secret_detail.html",
+		"secret_create.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -45,14 +45,16 @@ func templateFuncs() template.FuncMap {
 		},
 		"stateBg": func(state string) string {
 			switch strings.ToLower(state) {
-			case "started", "running":
+			case "started", "running", "connected":
 				return "bg-green-100 text-green-800"
 			case "stopped", "down":
 				return "bg-red-100 text-red-800"
 			case "starting", "staging", "deploying", "uploading":
 				return "bg-yellow-100 text-yellow-800"
-			case "crashed", "failed":
+			case "crashed", "failed", "error":
 				return "bg-red-100 text-red-800"
+			case "disconnected":
+				return "bg-gray-100 text-gray-800"
 			default:
 				return "bg-gray-100 text-gray-800"
 			}
@@ -145,6 +147,8 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"services.html",
 		"secrets.html",
 		"users.html",
+		"clusters.html",
+		"cluster_detail.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -19,9 +20,79 @@ type GitHubConfig struct {
 	Repo  string `mapstructure:"repo"`
 }
 
+// ClusterConfig represents a registered Kubernetes cluster.
+type ClusterConfig struct {
+	Name      string `mapstructure:"name"      json:"name"`
+	Context   string `mapstructure:"context"   json:"context"`
+	Namespace string `mapstructure:"namespace" json:"namespace"`
+	Domain    string `mapstructure:"domain"    json:"domain"`
+	Provider  string `mapstructure:"provider"  json:"provider"`
+	Region    string `mapstructure:"region"    json:"region,omitempty"`
+	Enabled   bool   `mapstructure:"enabled"   json:"enabled"`
+}
+
 type KubernetesConfig struct {
+	// Multi-cluster support
+	Clusters map[string]ClusterConfig `mapstructure:"clusters"`
+	Active   string                   `mapstructure:"active"`
+
+	// Legacy single-cluster fields (for migration)
 	Context   string `mapstructure:"context"`
 	Namespace string `mapstructure:"namespace"`
+}
+
+// Migrate converts legacy single-cluster config to multi-cluster format.
+func (k *KubernetesConfig) Migrate() {
+	if len(k.Clusters) > 0 {
+		return // Already new format
+	}
+
+	ctx := k.Context
+	if ctx == "" {
+		ctx = "docker-desktop"
+	}
+	ns := k.Namespace
+	if ns == "" {
+		ns = "microfoundry"
+	}
+
+	k.Clusters = map[string]ClusterConfig{
+		ctx: {
+			Name:      ctx,
+			Context:   ctx,
+			Namespace: ns,
+			Domain:    "cf-local.dev",
+			Provider:  DetectProvider(ctx),
+			Enabled:   true,
+		},
+	}
+	k.Active = ctx
+}
+
+// GetActiveCluster returns the active cluster config.
+func (k *KubernetesConfig) GetActiveCluster() (string, ClusterConfig, bool) {
+	if k.Active == "" {
+		return "", ClusterConfig{}, false
+	}
+	cfg, ok := k.Clusters[k.Active]
+	return k.Active, cfg, ok
+}
+
+// DetectProvider guesses the provider from a kubeconfig context name.
+func DetectProvider(context string) string {
+	lower := strings.ToLower(context)
+	switch {
+	case strings.Contains(lower, "docker-desktop"):
+		return "docker-desktop"
+	case strings.Contains(lower, "eks") || strings.Contains(lower, "aws"):
+		return "eks"
+	case strings.Contains(lower, "gke") || strings.Contains(lower, "gke_"):
+		return "gke"
+	case strings.Contains(lower, "aks") || strings.Contains(lower, "azure"):
+		return "aks"
+	default:
+		return "native"
+	}
 }
 
 // Load reads configuration from files and env vars and returns a Config.
@@ -40,7 +111,7 @@ func Load() (*Config, error) {
 	v.SetEnvPrefix("MF")
 	v.AutomaticEnv()
 
-	// Defaults
+	// Defaults (legacy format)
 	v.SetDefault("github.owner", "younjinjeong")
 	v.SetDefault("github.repo", "microfoundry")
 	v.SetDefault("kubernetes.context", "docker-desktop")
@@ -57,6 +128,9 @@ func Load() (*Config, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("unmarshalling config: %w", err)
 	}
+
+	// Auto-migrate legacy config to multi-cluster format
+	cfg.Kubernetes.Migrate()
 
 	return &cfg, nil
 }

--- a/pkg/k8s/manager.go
+++ b/pkg/k8s/manager.go
@@ -1,0 +1,277 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/younjinjeong/microfoundry/pkg/config"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ClientManager manages multiple K8s clients, one per registered cluster.
+type ClientManager struct {
+	clients map[string]*Client
+	configs map[string]config.ClusterConfig
+	active  string
+	mu      sync.RWMutex
+}
+
+// NewClientManager creates a manager from the config's cluster map.
+func NewClientManager(clusters map[string]config.ClusterConfig, active string) *ClientManager {
+	return &ClientManager{
+		clients: make(map[string]*Client),
+		configs: clusters,
+		active:  active,
+	}
+}
+
+// GetClient returns a cached or newly-created client for the given cluster ID.
+func (cm *ClientManager) GetClient(clusterID string) (*Client, error) {
+	cm.mu.RLock()
+	if client, ok := cm.clients[clusterID]; ok {
+		cm.mu.RUnlock()
+		return client, nil
+	}
+	cm.mu.RUnlock()
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if client, ok := cm.clients[clusterID]; ok {
+		return client, nil
+	}
+
+	cfg, ok := cm.configs[clusterID]
+	if !ok {
+		return nil, fmt.Errorf("cluster %q not found", clusterID)
+	}
+
+	client, err := NewClient(cfg.Context, cfg.Namespace, cfg.Domain)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to cluster %q: %w", clusterID, err)
+	}
+
+	cm.clients[clusterID] = client
+	return client, nil
+}
+
+// GetActiveClient returns the client for the currently active cluster.
+func (cm *ClientManager) GetActiveClient() (*Client, error) {
+	cm.mu.RLock()
+	active := cm.active
+	cm.mu.RUnlock()
+	return cm.GetClient(active)
+}
+
+// SetActive changes the active cluster.
+func (cm *ClientManager) SetActive(clusterID string) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if _, ok := cm.configs[clusterID]; !ok {
+		return fmt.Errorf("cluster %q not found", clusterID)
+	}
+	cm.active = clusterID
+	return nil
+}
+
+// GetActive returns the currently active cluster ID.
+func (cm *ClientManager) GetActive() string {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.active
+}
+
+// ListClusters returns info for all registered clusters.
+func (cm *ClientManager) ListClusters(ctx context.Context) []models.ClusterInfo {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+
+	var infos []models.ClusterInfo
+	for id, cfg := range cm.configs {
+		info := models.ClusterInfo{
+			ID:        id,
+			Name:      cfg.Name,
+			Provider:  cfg.Provider,
+			Region:    cfg.Region,
+			Context:   cfg.Context,
+			Namespace: cfg.Namespace,
+			Domain:    cfg.Domain,
+			Enabled:   cfg.Enabled,
+			IsActive:  id == cm.active,
+			Status:    "disconnected",
+		}
+
+		// Try to get live status
+		if client, ok := cm.clients[id]; ok {
+			info.Status = "connected"
+			if names, err := client.ListApps(ctx); err == nil {
+				info.AppCount = len(names)
+			}
+			if nodes, err := client.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
+				info.NodeCount = len(nodes.Items)
+			}
+			if ver, err := client.Clientset.Discovery().ServerVersion(); err == nil {
+				info.Version = ver.GitVersion
+			}
+		} else {
+			// Try creating the client to check connectivity
+			if c, err := NewClient(cfg.Context, cfg.Namespace, cfg.Domain); err == nil {
+				cm.clients[id] = c
+				info.Status = "connected"
+				if ver, err := c.Clientset.Discovery().ServerVersion(); err == nil {
+					info.Version = ver.GitVersion
+				}
+				if nodes, err := c.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
+					info.NodeCount = len(nodes.Items)
+				}
+				if names, err := c.ListApps(ctx); err == nil {
+					info.AppCount = len(names)
+				}
+			} else {
+				info.Status = "error"
+				info.StatusMsg = err.Error()
+			}
+		}
+
+		infos = append(infos, info)
+	}
+	return infos
+}
+
+// GetClusterDetail returns detailed info for a single cluster.
+func (cm *ClientManager) GetClusterDetail(ctx context.Context, clusterID string) (*models.ClusterDetail, error) {
+	cm.mu.RLock()
+	cfg, ok := cm.configs[clusterID]
+	isActive := clusterID == cm.active
+	cm.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("cluster %q not found", clusterID)
+	}
+
+	client, err := cm.GetClient(clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := &models.ClusterDetail{
+		ClusterInfo: models.ClusterInfo{
+			ID:        clusterID,
+			Name:      cfg.Name,
+			Provider:  cfg.Provider,
+			Region:    cfg.Region,
+			Context:   cfg.Context,
+			Namespace: cfg.Namespace,
+			Domain:    cfg.Domain,
+			Enabled:   cfg.Enabled,
+			IsActive:  isActive,
+			Status:    "connected",
+		},
+	}
+
+	// K8s server version
+	if ver, err := client.Clientset.Discovery().ServerVersion(); err == nil {
+		detail.Version = ver.GitVersion
+	}
+
+	// Node info
+	nodes, err := client.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err == nil {
+		detail.NodeCount = len(nodes.Items)
+		for _, node := range nodes.Items {
+			roles := "worker"
+			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+				roles = "control-plane"
+			}
+			ni := models.NodeInfo{
+				Name:    node.Name,
+				Version: node.Status.NodeInfo.KubeletVersion,
+				OS:      node.Status.NodeInfo.OperatingSystem + "/" + node.Status.NodeInfo.Architecture,
+			}
+			ni.Roles = roles
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == "Ready" {
+					if cond.Status == "True" {
+						ni.Status = "Ready"
+					} else {
+						ni.Status = "NotReady"
+					}
+				}
+			}
+			alloc := node.Status.Allocatable
+			if cpu, ok := alloc["cpu"]; ok {
+				ni.CPU = cpu.String()
+			}
+			if mem, ok := alloc["memory"]; ok {
+				ni.Memory = mem.String()
+			}
+			detail.Nodes = append(detail.Nodes, ni)
+
+			// Aggregate resources
+			cap := node.Status.Capacity
+			if cpu, ok := cap["cpu"]; ok {
+				detail.ResourceUsage.CPUCapacity = cpu.String()
+			}
+			if mem, ok := cap["memory"]; ok {
+				detail.ResourceUsage.MemoryCapacity = mem.String()
+			}
+			if pods, ok := cap["pods"]; ok {
+				detail.ResourceUsage.PodCapacity += int(pods.Value())
+			}
+		}
+	}
+
+	// App count
+	if names, err := client.ListApps(ctx); err == nil {
+		detail.AppCount = len(names)
+	}
+
+	// Pod count for resource usage
+	if pods, err := client.Clientset.CoreV1().Pods(cfg.Namespace).List(ctx, metav1.ListOptions{}); err == nil {
+		detail.ResourceUsage.PodUsed = len(pods.Items)
+	}
+
+	return detail, nil
+}
+
+// AddCluster registers a new cluster.
+func (cm *ClientManager) AddCluster(id string, cfg config.ClusterConfig) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if _, ok := cm.configs[id]; ok {
+		return fmt.Errorf("cluster %q already exists", id)
+	}
+	cm.configs[id] = cfg
+	return nil
+}
+
+// RemoveCluster unregisters a cluster.
+func (cm *ClientManager) RemoveCluster(id string) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	if _, ok := cm.configs[id]; !ok {
+		return fmt.Errorf("cluster %q not found", id)
+	}
+	if id == cm.active {
+		return fmt.Errorf("cannot remove active cluster %q", id)
+	}
+	delete(cm.configs, id)
+	delete(cm.clients, id)
+	return nil
+}
+
+// CheckHealth verifies connectivity to a cluster.
+func (cm *ClientManager) CheckHealth(ctx context.Context, clusterID string) (string, error) {
+	client, err := cm.GetClient(clusterID)
+	if err != nil {
+		return "error", err
+	}
+	_, err = client.Clientset.Discovery().ServerVersion()
+	if err != nil {
+		return "disconnected", err
+	}
+	return "connected", nil
+}

--- a/pkg/k8s/manager.go
+++ b/pkg/k8s/manager.go
@@ -85,12 +85,18 @@ func (cm *ClientManager) GetActive() string {
 }
 
 // ListClusters returns info for all registered clusters.
+// Copies config under read-lock, then makes network calls without holding the lock.
 func (cm *ClientManager) ListClusters(ctx context.Context) []models.ClusterInfo {
 	cm.mu.RLock()
-	defer cm.mu.RUnlock()
+	configs := make(map[string]config.ClusterConfig, len(cm.configs))
+	active := cm.active
+	for id, cfg := range cm.configs {
+		configs[id] = cfg
+	}
+	cm.mu.RUnlock()
 
 	var infos []models.ClusterInfo
-	for id, cfg := range cm.configs {
+	for id, cfg := range configs {
 		info := models.ClusterInfo{
 			ID:        id,
 			Name:      cfg.Name,
@@ -100,12 +106,12 @@ func (cm *ClientManager) ListClusters(ctx context.Context) []models.ClusterInfo 
 			Namespace: cfg.Namespace,
 			Domain:    cfg.Domain,
 			Enabled:   cfg.Enabled,
-			IsActive:  id == cm.active,
+			IsActive:  id == active,
 			Status:    "disconnected",
 		}
 
-		// Try to get live status
-		if client, ok := cm.clients[id]; ok {
+		// GetClient has its own proper locking for lazy initialization
+		if client, err := cm.GetClient(id); err == nil {
 			info.Status = "connected"
 			if names, err := client.ListApps(ctx); err == nil {
 				info.AppCount = len(names)
@@ -117,23 +123,8 @@ func (cm *ClientManager) ListClusters(ctx context.Context) []models.ClusterInfo 
 				info.Version = ver.GitVersion
 			}
 		} else {
-			// Try creating the client to check connectivity
-			if c, err := NewClient(cfg.Context, cfg.Namespace, cfg.Domain); err == nil {
-				cm.clients[id] = c
-				info.Status = "connected"
-				if ver, err := c.Clientset.Discovery().ServerVersion(); err == nil {
-					info.Version = ver.GitVersion
-				}
-				if nodes, err := c.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
-					info.NodeCount = len(nodes.Items)
-				}
-				if names, err := c.ListApps(ctx); err == nil {
-					info.AppCount = len(names)
-				}
-			} else {
-				info.Status = "error"
-				info.StatusMsg = err.Error()
-			}
+			info.Status = "error"
+			info.StatusMsg = err.Error()
 		}
 
 		infos = append(infos, info)
@@ -181,6 +172,8 @@ func (cm *ClientManager) GetClusterDetail(ctx context.Context, clusterID string)
 	nodes, err := client.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err == nil {
 		detail.NodeCount = len(nodes.Items)
+		var totalCPUMillis int64
+		var totalMemBytes int64
 		for _, node := range nodes.Items {
 			roles := "worker"
 			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
@@ -210,17 +203,24 @@ func (cm *ClientManager) GetClusterDetail(ctx context.Context, clusterID string)
 			}
 			detail.Nodes = append(detail.Nodes, ni)
 
-			// Aggregate resources
+			// Aggregate resources across all nodes
 			cap := node.Status.Capacity
 			if cpu, ok := cap["cpu"]; ok {
-				detail.ResourceUsage.CPUCapacity = cpu.String()
+				totalCPUMillis += cpu.MilliValue()
 			}
 			if mem, ok := cap["memory"]; ok {
-				detail.ResourceUsage.MemoryCapacity = mem.String()
+				totalMemBytes += mem.Value()
 			}
 			if pods, ok := cap["pods"]; ok {
 				detail.ResourceUsage.PodCapacity += int(pods.Value())
 			}
+		}
+		// Format aggregated totals
+		if totalCPUMillis > 0 {
+			detail.ResourceUsage.CPUCapacity = fmt.Sprintf("%dm", totalCPUMillis)
+		}
+		if totalMemBytes > 0 {
+			detail.ResourceUsage.MemoryCapacity = fmt.Sprintf("%dMi", totalMemBytes/(1024*1024))
 		}
 	}
 

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -1,0 +1,55 @@
+package models
+
+const (
+	ProviderDockerDesktop = "docker-desktop"
+	ProviderEKS           = "eks"
+	ProviderGKE           = "gke"
+	ProviderAKS           = "aks"
+	ProviderNative        = "native"
+)
+
+// ClusterInfo is the runtime view of a registered cluster.
+type ClusterInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	Region    string `json:"region,omitempty"`
+	Context   string `json:"context"`
+	Namespace string `json:"namespace"`
+	Domain    string `json:"domain"`
+	Status    string `json:"status"` // connected, disconnected, error
+	Enabled   bool   `json:"enabled"`
+	IsActive  bool   `json:"is_active"`
+	NodeCount int    `json:"node_count"`
+	AppCount  int    `json:"app_count"`
+	Version   string `json:"version,omitempty"`
+	StatusMsg string `json:"status_message,omitempty"`
+}
+
+// ClusterDetail extends ClusterInfo with node and resource data.
+type ClusterDetail struct {
+	ClusterInfo
+	Nodes         []NodeInfo      `json:"nodes"`
+	ResourceUsage ResourceSummary `json:"resource_usage"`
+}
+
+// NodeInfo represents a K8s node.
+type NodeInfo struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Roles   string `json:"roles"`
+	Version string `json:"version"`
+	OS      string `json:"os"`
+	CPU     string `json:"cpu"`
+	Memory  string `json:"memory"`
+}
+
+// ResourceSummary holds cluster-wide resource usage.
+type ResourceSummary struct {
+	CPUCapacity    string `json:"cpu_capacity"`
+	CPUUsed        string `json:"cpu_used"`
+	MemoryCapacity string `json:"memory_capacity"`
+	MemoryUsed     string `json:"memory_used"`
+	PodCapacity    int    `json:"pod_capacity"`
+	PodUsed        int    `json:"pod_used"`
+}

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"regexp"
+	"time"
+)
+
+// UserSecretPrefix is the K8s Secret name prefix for user-defined secrets.
+const UserSecretPrefix = "mf-secret-"
+
+// ValidSecretName matches valid secret names (lowercase alphanumeric + hyphens, 2-42 chars).
+var ValidSecretName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,40}[a-z0-9]$`)
+
+// Secret type constants.
+const (
+	SecretTypeService = "service"
+	SecretTypeUser    = "user-defined"
+)
+
+// SecretInfo represents K8s Secret metadata (no values exposed).
+// Used in app detail views to show bound secrets.
+type SecretInfo struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	KeyCount  int    `json:"key_count"`
+	CreatedAt string `json:"created_at"`
+}
+
+// SecretListItem is the summary for secrets list views.
+type SecretListItem struct {
+	Name            string    `json:"name"`
+	K8sName         string    `json:"k8s_name"`
+	Type            string    `json:"type"`
+	ServiceInstance string    `json:"service_instance,omitempty"`
+	KeyCount        int       `json:"key_count"`
+	BoundApps       int       `json:"bound_apps"`
+	Description     string    `json:"description,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// SecretDetail is the full view for secret detail pages (values NOT included).
+type SecretDetail struct {
+	Name            string    `json:"name"`
+	K8sName         string    `json:"k8s_name"`
+	Type            string    `json:"type"`
+	ServiceInstance string    `json:"service_instance,omitempty"`
+	Keys            []string  `json:"keys"`
+	KeyCount        int       `json:"key_count"`
+	BoundApps       []string  `json:"bound_apps"`
+	Description     string    `json:"description,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -1,16 +1,116 @@
 package models
 
+import (
+	"regexp"
+	"time"
+)
+
+// Service status constants
+const (
+	ServiceStatusCreating  = "creating"
+	ServiceStatusAvailable = "available"
+	ServiceStatusFailed    = "failed"
+	ServiceStatusDeleting  = "deleting"
+	ServiceStatusDeleted   = "deleted"
+)
+
+// ServiceSecretPrefix is the K8s Secret name prefix for service credentials.
+const ServiceSecretPrefix = "mf-svc-"
+
+// ValidServiceName matches valid service instance names (lowercase alphanumeric + hyphens, 2-42 chars).
+var ValidServiceName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,40}[a-z0-9]$`)
+
 // ServiceBindingInfo represents a service bound to an app (display only).
 type ServiceBindingInfo struct {
 	Name   string `json:"name"`
-	Type   string `json:"type"`   // managed, user-provided
-	Status string `json:"status"` // bound, binding, failed
+	Type   string `json:"type"`
+	Status string `json:"status"`
 }
 
-// SecretInfo represents K8s Secret metadata (no values exposed).
-type SecretInfo struct {
-	Name      string `json:"name"`
-	Type      string `json:"type"` // Opaque, kubernetes.io/tls, etc.
-	KeyCount  int    `json:"key_count"`
-	CreatedAt string `json:"created_at"`
+// ServiceType defines a backing service offering in the catalog.
+type ServiceType struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Provider    string        `json:"provider"`
+	Category    string        `json:"category"`
+	Plans       []ServicePlan `json:"plans"`
+	Tags        []string      `json:"tags,omitempty"`
+}
+
+// ServicePlan defines a sizing tier within a service type.
+type ServicePlan struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	InstanceClass string            `json:"instance_class"`
+	StorageGB     int               `json:"storage_gb"`
+	Replicas      int               `json:"replicas"`
+	MultiAZ       bool              `json:"multi_az"`
+	CostEstimate  string            `json:"cost_estimate"`
+	Customizable  bool              `json:"customizable"`
+	Defaults      map[string]string `json:"defaults,omitempty"`
+}
+
+// ServiceInstance represents a provisioned backing service.
+type ServiceInstance struct {
+	Name        string            `json:"name"`
+	ServiceType string            `json:"service_type"`
+	Plan        string            `json:"plan"`
+	Status      string            `json:"status"`
+	StatusMsg   string            `json:"status_message,omitempty"`
+	ClusterID   string            `json:"cluster_id"`
+	Region      string            `json:"region,omitempty"`
+	Parameters  map[string]string `json:"parameters,omitempty"`
+	Outputs     ServiceOutputs    `json:"outputs,omitempty"`
+	Bindings    []ServiceBinding  `json:"bindings,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// Redacted returns a copy with sensitive fields masked.
+func (si *ServiceInstance) Redacted() ServiceInstance {
+	out := *si
+	out.Outputs = si.Outputs.Redacted()
+	return out
+}
+
+// ServiceOutputs holds the provisioned resource connection details.
+type ServiceOutputs struct {
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Database string `json:"database,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+// Redacted returns a copy with password and URI masked.
+func (o ServiceOutputs) Redacted() ServiceOutputs {
+	out := o
+	if out.Password != "" {
+		out.Password = "********"
+	}
+	if out.URI != "" {
+		out.URI = "********"
+	}
+	return out
+}
+
+// ServiceBinding represents a binding between an app and a service instance.
+type ServiceBinding struct {
+	AppName   string    `json:"app_name"`
+	SecretRef string    `json:"secret_ref"`
+	BoundAt   time.Time `json:"bound_at"`
+}
+
+// ServiceListItem is a summary view for list pages.
+type ServiceListItem struct {
+	Name        string    `json:"name"`
+	ServiceType string    `json:"service_type"`
+	Plan        string    `json:"plan"`
+	Status      string    `json:"status"`
+	ClusterID   string    `json:"cluster_id"`
+	BoundApps   int       `json:"bound_apps"`
+	CreatedAt   time.Time `json:"created_at"`
 }

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -1,0 +1,317 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	labelManagedBy       = "microfoundry"
+	labelManagedByKey    = "app.kubernetes.io/managed-by"
+	labelSecretType      = "microfoundry.io/secret-type"
+	labelServiceInstance = "microfoundry.io/service-instance"
+	annotationCreatedBy  = "microfoundry.io/created-by"
+	annotationDesc       = "microfoundry.io/description"
+)
+
+// Manager provides a vault-like interface for managing K8s Secrets.
+type Manager struct {
+	k8sClient *k8s.Client
+}
+
+// NewManager creates a new secrets manager.
+func NewManager(client *k8s.Client) *Manager {
+	return &Manager{k8sClient: client}
+}
+
+// List returns all MicroFoundry-managed secrets.
+func (m *Manager) List(ctx context.Context) ([]models.SecretListItem, error) {
+	secrets, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelManagedByKey + "=" + labelManagedBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+
+	var items []models.SecretListItem
+	for _, s := range secrets.Items {
+		// Only include MicroFoundry-managed secrets (mf-svc-* or mf-secret-*)
+		if !strings.HasPrefix(s.Name, models.ServiceSecretPrefix) &&
+			!strings.HasPrefix(s.Name, models.UserSecretPrefix) {
+			continue
+		}
+
+		item := models.SecretListItem{
+			K8sName:  s.Name,
+			KeyCount: len(s.Data),
+		}
+
+		// Determine logical name and type
+		if strings.HasPrefix(s.Name, models.ServiceSecretPrefix) {
+			item.Name = strings.TrimPrefix(s.Name, models.ServiceSecretPrefix)
+			item.Type = models.SecretTypeService
+			item.ServiceInstance = s.Labels[labelServiceInstance]
+		} else {
+			item.Name = strings.TrimPrefix(s.Name, models.UserSecretPrefix)
+			item.Type = models.SecretTypeUser
+		}
+
+		// Override type from label if present (for forward compatibility)
+		if t, ok := s.Labels[labelSecretType]; ok {
+			item.Type = t
+		}
+
+		// Read annotations
+		item.Description = s.Annotations[annotationDesc]
+
+		// CreatedAt from K8s metadata
+		item.CreatedAt = s.CreationTimestamp.Time
+
+		// Count bound apps
+		boundApps, err := m.GetBoundApps(ctx, s.Name)
+		if err != nil {
+			log.Printf("warning: could not get bound apps for secret %q: %v", s.Name, err)
+		}
+		item.BoundApps = len(boundApps)
+
+		items = append(items, item)
+	}
+
+	// Sort by creation time descending (newest first)
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+
+	return items, nil
+}
+
+// Get returns secret metadata, key names (no values), and bound apps.
+func (m *Manager) Get(ctx context.Context, name string) (*models.SecretDetail, error) {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("secret %q not found", name)
+		}
+		return nil, err
+	}
+
+	detail := &models.SecretDetail{
+		K8sName:   secret.Name,
+		KeyCount:  len(secret.Data),
+		CreatedAt: secret.CreationTimestamp.Time,
+	}
+
+	// Determine logical name and type
+	if strings.HasPrefix(secret.Name, models.ServiceSecretPrefix) {
+		detail.Name = strings.TrimPrefix(secret.Name, models.ServiceSecretPrefix)
+		detail.Type = models.SecretTypeService
+		detail.ServiceInstance = secret.Labels[labelServiceInstance]
+	} else if strings.HasPrefix(secret.Name, models.UserSecretPrefix) {
+		detail.Name = strings.TrimPrefix(secret.Name, models.UserSecretPrefix)
+		detail.Type = models.SecretTypeUser
+	} else {
+		detail.Name = secret.Name
+		detail.Type = models.SecretTypeUser
+	}
+
+	// Override type from label if present
+	if t, ok := secret.Labels[labelSecretType]; ok {
+		detail.Type = t
+	}
+
+	detail.Description = secret.Annotations[annotationDesc]
+
+	// Collect key names (sorted)
+	keys := make([]string, 0, len(secret.Data))
+	for k := range secret.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	detail.Keys = keys
+
+	// Bound apps
+	boundApps, err := m.GetBoundApps(ctx, secret.Name)
+	if err != nil {
+		log.Printf("warning: could not get bound apps for secret %q: %v", secret.Name, err)
+	}
+	detail.BoundApps = boundApps
+
+	return detail, nil
+}
+
+// GetValue returns the decoded value of a single key in a secret.
+func (m *Manager) GetValue(ctx context.Context, name, key string) (string, error) {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting secret %q: %w", name, err)
+	}
+
+	val, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret %q", key, name)
+	}
+
+	return string(val), nil
+}
+
+// CreateServiceSecret creates a K8s Secret for a service instance with proper labels.
+func (m *Manager) CreateServiceSecret(ctx context.Context, serviceName string, data map[string]string) error {
+	k8sName := models.ServiceSecretPrefix + serviceName
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: k8sName,
+			Labels: map[string]string{
+				labelManagedByKey:    labelManagedBy,
+				labelSecretType:     models.SecretTypeService,
+				labelServiceInstance: serviceName,
+			},
+			Annotations: map[string]string{
+				annotationCreatedBy: "create-service",
+			},
+		},
+		StringData: data,
+	}
+
+	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			return err
+		}
+		return err
+	}
+
+	// Update existing secret
+	existing.StringData = data
+	// Ensure labels are set (for backward compatibility migration)
+	if existing.Labels == nil {
+		existing.Labels = make(map[string]string)
+	}
+	existing.Labels[labelManagedByKey] = labelManagedBy
+	existing.Labels[labelSecretType] = models.SecretTypeService
+	existing.Labels[labelServiceInstance] = serviceName
+	if existing.Annotations == nil {
+		existing.Annotations = make(map[string]string)
+	}
+	existing.Annotations[annotationCreatedBy] = "create-service"
+
+	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// CreateUserSecret creates a user-defined K8s Secret.
+func (m *Manager) CreateUserSecret(ctx context.Context, name, description string, data map[string]string) error {
+	k8sName := models.UserSecretPrefix + name
+
+	labels := map[string]string{
+		labelManagedByKey: labelManagedBy,
+		labelSecretType:  models.SecretTypeUser,
+	}
+
+	annotations := map[string]string{
+		annotationCreatedBy: "admin-ui",
+	}
+	if description != "" {
+		annotations[annotationDesc] = description
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        k8sName,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		StringData: data,
+	}
+
+	_, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return fmt.Errorf("secret %q already exists", name)
+		}
+		return err
+	}
+	return nil
+}
+
+// Delete removes a K8s Secret by its logical name.
+func (m *Manager) Delete(ctx context.Context, name string) error {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, k8sName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting secret %q: %w", name, err)
+	}
+	return nil
+}
+
+// GetBoundApps lists Deployments whose envFrom references the given K8s Secret name.
+func (m *Manager) GetBoundApps(ctx context.Context, k8sSecretName string) ([]string, error) {
+	deployments, err := m.k8sClient.Clientset.AppsV1().Deployments(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing deployments: %w", err)
+	}
+
+	var apps []string
+	for _, d := range deployments.Items {
+		for _, c := range d.Spec.Template.Spec.Containers {
+			for _, ef := range c.EnvFrom {
+				if ef.SecretRef != nil && ef.SecretRef.Name == k8sSecretName {
+					apps = append(apps, d.Name)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Strings(apps)
+	return apps, nil
+}
+
+// resolveK8sName maps a logical name to the actual K8s Secret name.
+// It tries the service prefix first, then user prefix, then the raw name.
+func (m *Manager) resolveK8sName(ctx context.Context, name string) (string, error) {
+	// If name already has a known prefix, use it directly
+	if strings.HasPrefix(name, models.ServiceSecretPrefix) || strings.HasPrefix(name, models.UserSecretPrefix) {
+		return name, nil
+	}
+
+	// Try service secret first
+	svcName := models.ServiceSecretPrefix + name
+	_, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err == nil {
+		return svcName, nil
+	}
+
+	// Try user-defined secret
+	userName := models.UserSecretPrefix + name
+	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, userName, metav1.GetOptions{})
+	if err == nil {
+		return userName, nil
+	}
+
+	return "", fmt.Errorf("secret %q not found (tried %s and %s)", name, svcName, userName)
+}

--- a/pkg/service/binder.go
+++ b/pkg/service/binder.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Binder handles injecting service credentials into app deployments.
+type Binder struct {
+	k8sClient *k8s.Client
+}
+
+// NewBinder creates a new binder.
+func NewBinder(client *k8s.Client) *Binder {
+	return &Binder{k8sClient: client}
+}
+
+// Bind injects service credentials from a K8s Secret into an app's Deployment as env vars.
+func (b *Binder) Bind(ctx context.Context, appName, secretName string) error {
+	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("deployment %q not found: %w", appName, err)
+	}
+
+	// Add envFrom reference to the service secret
+	envFrom := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+		},
+	}
+
+	// Check if already bound
+	containers := deploy.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return fmt.Errorf("deployment %q has no containers", appName)
+	}
+
+	for _, ef := range containers[0].EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+			return nil // Already bound
+		}
+	}
+
+	deploy.Spec.Template.Spec.Containers[0].EnvFrom = append(
+		deploy.Spec.Template.Spec.Containers[0].EnvFrom,
+		envFrom,
+	)
+
+	// Add annotation
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = make(map[string]string)
+	}
+	existing := deploy.Spec.Template.Annotations["microfoundry.io/bound-services"]
+	if existing != "" {
+		existing += ","
+	}
+	deploy.Spec.Template.Annotations["microfoundry.io/bound-services"] = existing + secretName
+
+	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	return err
+}
+
+// Unbind removes service credentials from an app's Deployment.
+func (b *Binder) Unbind(ctx context.Context, appName, secretName string) error {
+	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("deployment %q not found: %w", appName, err)
+	}
+
+	containers := deploy.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return nil
+	}
+
+	// Remove envFrom reference
+	var updated []corev1.EnvFromSource
+	for _, ef := range containers[0].EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+			continue
+		}
+		updated = append(updated, ef)
+	}
+	deploy.Spec.Template.Spec.Containers[0].EnvFrom = updated
+
+	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -1,0 +1,81 @@
+package service
+
+import "github.com/younjinjeong/microfoundry/pkg/models"
+
+// Catalog returns all available service types.
+func Catalog() []models.ServiceType {
+	return []models.ServiceType{
+		{
+			ID:          "aws-rds-aurora-mariadb",
+			Name:        "AWS RDS Aurora MariaDB",
+			Description: "Managed MySQL-compatible relational database powered by Amazon Aurora",
+			Provider:    "aws",
+			Category:    "database",
+			Tags:        []string{"mysql", "mariadb", "aurora", "rds", "relational"},
+			Plans: []models.ServicePlan{
+				{
+					ID:            "small",
+					Name:          "Small (Dev/Test)",
+					Description:   "Single instance, minimal resources for development and testing",
+					InstanceClass: "db.t4g.micro",
+					StorageGB:     20,
+					Replicas:      0,
+					MultiAZ:       false,
+					CostEstimate:  "~$15/month",
+					Customizable:  false,
+				},
+				{
+					ID:            "medium",
+					Name:          "Medium (UAT/Staging)",
+					Description:   "Moderate resources for UAT and staging environments",
+					InstanceClass: "db.r6g.large",
+					StorageGB:     100,
+					Replicas:      0,
+					MultiAZ:       false,
+					CostEstimate:  "~$200/month",
+					Customizable:  false,
+				},
+				{
+					ID:            "production",
+					Name:          "Production",
+					Description:   "Production-grade with read replicas, Multi-AZ, and customizable sizing",
+					InstanceClass: "db.r6g.xlarge",
+					StorageGB:     200,
+					Replicas:      1,
+					MultiAZ:       true,
+					CostEstimate:  "~$500+/month",
+					Customizable:  true,
+					Defaults: map[string]string{
+						"instance_class": "db.r6g.xlarge",
+						"storage_gb":     "200",
+						"replicas":       "1",
+					},
+				},
+			},
+		},
+	}
+}
+
+// FindServiceType returns a service type by ID.
+func FindServiceType(id string) (models.ServiceType, bool) {
+	for _, st := range Catalog() {
+		if st.ID == id {
+			return st, true
+		}
+	}
+	return models.ServiceType{}, false
+}
+
+// FindPlan returns a plan within a service type.
+func FindPlan(serviceTypeID, planID string) (models.ServicePlan, bool) {
+	st, ok := FindServiceType(serviceTypeID)
+	if !ok {
+		return models.ServicePlan{}, false
+	}
+	for _, p := range st.Plans {
+		if p.ID == planID {
+			return p, true
+		}
+	}
+	return models.ServicePlan{}, false
+}

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -1,0 +1,241 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	serviceConfigMapPrefix = "mf-svc-meta-"
+	labelManagedBy         = "microfoundry"
+	labelServiceInstance   = "microfoundry.io/service-instance"
+	maxRetries             = 3
+)
+
+// SecretName returns the K8s Secret name for a service instance.
+func SecretName(instanceName string) string {
+	return models.ServiceSecretPrefix + instanceName
+}
+
+// Manager handles service instance lifecycle using K8s as the backing store.
+type Manager struct {
+	k8sClient *k8s.Client
+	secrets   *secrets.Manager
+}
+
+// NewManager creates a new service manager.
+func NewManager(client *k8s.Client) *Manager {
+	return &Manager{
+		k8sClient: client,
+		secrets:   secrets.NewManager(client),
+	}
+}
+
+// List returns all service instances.
+func (m *Manager) List(ctx context.Context) ([]models.ServiceListItem, error) {
+	cms, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=" + labelManagedBy + "," + labelServiceInstance,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing service instances: %w", err)
+	}
+
+	var items []models.ServiceListItem
+	for _, cm := range cms.Items {
+		var inst models.ServiceInstance
+		if data, ok := cm.Data["instance"]; ok {
+			if err := json.Unmarshal([]byte(data), &inst); err != nil {
+				log.Printf("warning: skipping corrupted service ConfigMap %q: %v", cm.Name, err)
+				continue
+			}
+		} else {
+			log.Printf("warning: service ConfigMap %q missing 'instance' key", cm.Name)
+			continue
+		}
+		items = append(items, models.ServiceListItem{
+			Name:        inst.Name,
+			ServiceType: inst.ServiceType,
+			Plan:        inst.Plan,
+			Status:      inst.Status,
+			ClusterID:   inst.ClusterID,
+			BoundApps:   len(inst.Bindings),
+			CreatedAt:   inst.CreatedAt,
+		})
+	}
+	return items, nil
+}
+
+// Get returns a single service instance by name.
+func (m *Manager) Get(ctx context.Context, name string) (*models.ServiceInstance, error) {
+	cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("service instance %q not found", name)
+		}
+		return nil, err
+	}
+
+	data, ok := cm.Data["instance"]
+	if !ok {
+		return nil, fmt.Errorf("service instance %q has corrupted metadata (missing 'instance' key)", name)
+	}
+
+	var inst models.ServiceInstance
+	if err := json.Unmarshal([]byte(data), &inst); err != nil {
+		return nil, fmt.Errorf("unmarshalling service instance: %w", err)
+	}
+
+	// Load outputs from secret if available
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, SecretName(name), metav1.GetOptions{})
+	if err == nil {
+		inst.Outputs = models.ServiceOutputs{
+			Host:     string(secret.Data["host"]),
+			Username: string(secret.Data["username"]),
+			Password: string(secret.Data["password"]),
+			Database: string(secret.Data["database"]),
+			URI:      string(secret.Data["uri"]),
+		}
+		if p, ok := secret.Data["port"]; ok {
+			var port int
+			if _, err := fmt.Sscanf(string(p), "%d", &port); err == nil {
+				inst.Outputs.Port = port
+			}
+		}
+	}
+
+	return &inst, nil
+}
+
+// Create stores a new service instance metadata.
+func (m *Manager) Create(ctx context.Context, inst *models.ServiceInstance) error {
+	inst.CreatedAt = time.Now()
+	inst.UpdatedAt = time.Now()
+	inst.Status = models.ServiceStatusCreating
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceConfigMapPrefix + inst.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": labelManagedBy,
+				labelServiceInstance:           inst.Name,
+			},
+		},
+		Data: map[string]string{
+			"instance": string(data),
+		},
+	}
+
+	_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+// UpdateStatus updates the status of a service instance with conflict retry.
+func (m *Manager) UpdateStatus(ctx context.Context, name, status, msg string) error {
+	return m.retryOnConflict(ctx, name, func(inst *models.ServiceInstance) {
+		inst.Status = status
+		inst.StatusMsg = msg
+	})
+}
+
+// SaveOutputs stores service outputs in a K8s Secret via the secrets manager.
+func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.ServiceOutputs) error {
+	data := map[string]string{
+		"host":     outputs.Host,
+		"port":     fmt.Sprintf("%d", outputs.Port),
+		"username": outputs.Username,
+		"password": outputs.Password,
+		"database": outputs.Database,
+		"uri":      outputs.URI,
+	}
+	return m.secrets.CreateServiceSecret(ctx, name, data)
+}
+
+// Delete removes a service instance and its secret.
+func (m *Manager) Delete(ctx context.Context, name string) error {
+	cmErr := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Delete(ctx, serviceConfigMapPrefix+name, metav1.DeleteOptions{})
+	if cmErr != nil && !errors.IsNotFound(cmErr) {
+		return fmt.Errorf("deleting service ConfigMap: %w", cmErr)
+	}
+	if secErr := m.secrets.Delete(ctx, name); secErr != nil {
+		return fmt.Errorf("deleting service Secret: %w", secErr)
+	}
+	return nil
+}
+
+// AddBinding adds a binding to a service instance with conflict retry.
+func (m *Manager) AddBinding(ctx context.Context, serviceName, appName string) error {
+	return m.retryOnConflict(ctx, serviceName, func(inst *models.ServiceInstance) {
+		inst.Bindings = append(inst.Bindings, models.ServiceBinding{
+			AppName:   appName,
+			SecretRef: SecretName(serviceName),
+			BoundAt:   time.Now(),
+		})
+	})
+}
+
+// RemoveBinding removes a binding from a service instance with conflict retry.
+func (m *Manager) RemoveBinding(ctx context.Context, serviceName, appName string) error {
+	return m.retryOnConflict(ctx, serviceName, func(inst *models.ServiceInstance) {
+		var updated []models.ServiceBinding
+		for _, b := range inst.Bindings {
+			if b.AppName != appName {
+				updated = append(updated, b)
+			}
+		}
+		inst.Bindings = updated
+	})
+}
+
+// retryOnConflict performs a read-modify-write with resourceVersion conflict retry.
+func (m *Manager) retryOnConflict(ctx context.Context, name string, mutate func(*models.ServiceInstance)) error {
+	for i := 0; i < maxRetries; i++ {
+		cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		var inst models.ServiceInstance
+		if data, ok := cm.Data["instance"]; ok {
+			if err := json.Unmarshal([]byte(data), &inst); err != nil {
+				return fmt.Errorf("unmarshalling service instance: %w", err)
+			}
+		} else {
+			return fmt.Errorf("service instance %q has corrupted metadata", name)
+		}
+
+		mutate(&inst)
+		inst.UpdatedAt = time.Now()
+
+		data, err := json.Marshal(&inst)
+		if err != nil {
+			return err
+		}
+		cm.Data["instance"] = string(data)
+
+		// Update with resourceVersion — K8s rejects if another write happened since our Get
+		_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
+		}
+		// Conflict — retry with fresh read
+	}
+	return fmt.Errorf("conflict: too many retries updating service %q", name)
+}


### PR DESCRIPTION
## Summary
- Add multi-cluster Kubernetes management (EKS, GKE, AKS, Docker Desktop, native) via admin UI and CLI
- New `Kubernetes Clusters` admin page with cluster list, detail view, add/remove/activate actions
- `ClientManager` with lazy client initialization and thread-safe cluster pool
- All CLI commands now read from config instead of hardcoded `docker-desktop`
- Backwards-compatible config migration from single-cluster to multi-cluster format

## Test plan
- [x] `go build ./cmd/mf` succeeds
- [x] All 10+ admin endpoints return HTTP 200
- [x] `/api/clusters` returns cluster data with live status (connected, node count, app count, K8s version)
- [x] `/clusters/docker-desktop` detail page renders with node info and resources
- [x] `/api/clusters/docker-desktop/health` returns connected status
- [x] `POST /clusters/{id}/activate` redirects properly (303)
- [x] Active cluster shown in header on all pages
- [x] Navigation includes Kubernetes Clusters menu item
- [ ] Test adding a second cluster via the Add Cluster form
- [ ] Test removing a non-active cluster
- [ ] Test `mf push` uses config-based cluster selection

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)