### PR TITLE
Epic #8: Backing Services — catalog, provisioning, binding

### DIFF
--- a/cmd/mf/bind_service.go
+++ b/cmd/mf/bind_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
 	"github.com/younjinjeong/microfoundry/pkg/service"
 )
 
@@ -31,7 +32,7 @@ func bindServiceCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if inst.Status != "available" {
+			if inst.Status != models.ServiceStatusAvailable {
 				return fmt.Errorf("service %q is not available (status: %s)", svcName, inst.Status)
 			}
 
@@ -43,7 +44,7 @@ func bindServiceCmd() *cobra.Command {
 			}
 
 			// Inject credentials into deployment
-			secretName := "mf-svc-" + svcName
+			secretName := service.SecretName(svcName)
 			if err := binder.Bind(ctx, appName, secretName); err != nil {
 				// Rollback binding metadata
 				_ = mgr.RemoveBinding(ctx, svcName, appName)

--- a/cmd/mf/bind_service.go
+++ b/cmd/mf/bind_service.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func bindServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bind-service <app-name> <service-instance>",
+		Short: "Bind a service instance to an application",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			appName := args[0]
+			svcName := args[1]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			binder := service.NewBinder(k8sClient)
+
+			// Verify service exists and is available
+			inst, err := mgr.Get(ctx, svcName)
+			if err != nil {
+				return err
+			}
+			if inst.Status != "available" {
+				return fmt.Errorf("service %q is not available (status: %s)", svcName, inst.Status)
+			}
+
+			fmt.Printf("Binding service '%s' to app '%s'...\n", svcName, appName)
+
+			// Add binding metadata
+			if err := mgr.AddBinding(ctx, svcName, appName); err != nil {
+				return fmt.Errorf("adding binding: %w", err)
+			}
+
+			// Inject credentials into deployment
+			secretName := "mf-svc-" + svcName
+			if err := binder.Bind(ctx, appName, secretName); err != nil {
+				// Rollback binding metadata
+				_ = mgr.RemoveBinding(ctx, svcName, appName)
+				return fmt.Errorf("binding to deployment: %w", err)
+			}
+
+			fmt.Printf("Service '%s' bound to app '%s'.\n", svcName, appName)
+			fmt.Printf("The app will restart to pick up the new environment variables.\n")
+			return nil
+		},
+	}
+}

--- a/cmd/mf/create_service.go
+++ b/cmd/mf/create_service.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func createServiceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create-service <service-type> <plan> <instance-name>",
+		Short: "Provision a new backing service instance",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			serviceType := args[0]
+			plan := args[1]
+			name := args[2]
+
+			// Validate service type and plan exist
+			_, ok := service.FindServiceType(serviceType)
+			if !ok {
+				return fmt.Errorf("unknown service type %q — run 'mf marketplace' to see available services", serviceType)
+			}
+			planInfo, ok := service.FindPlan(serviceType, plan)
+			if !ok {
+				return fmt.Errorf("unknown plan %q for service %q", plan, serviceType)
+			}
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+
+			// Check if already exists
+			if existing, _ := mgr.Get(ctx, name); existing != nil {
+				return fmt.Errorf("service instance %q already exists (status: %s)", name, existing.Status)
+			}
+
+			inst := &models.ServiceInstance{
+				Name:        name,
+				ServiceType: serviceType,
+				Plan:        plan,
+				ClusterID:   "active",
+			}
+
+			fmt.Printf("Creating service instance '%s'...\n", name)
+			fmt.Printf("  Service: %s\n", serviceType)
+			fmt.Printf("  Plan:    %s (%s)\n", plan, planInfo.InstanceClass)
+			fmt.Printf("  Cost:    %s\n", planInfo.CostEstimate)
+
+			if err := mgr.Create(ctx, inst); err != nil {
+				return fmt.Errorf("creating service: %w", err)
+			}
+
+			// For now, immediately set to available with mock outputs
+			// In production, this would trigger async Terraform apply
+			outputs := models.ServiceOutputs{
+				Host:     fmt.Sprintf("%s.cluster.local", name),
+				Port:     3306,
+				Username: "admin",
+				Password: "changeme",
+				Database: name,
+				URI:      fmt.Sprintf("mysql://admin:changeme@%s.cluster.local:3306/%s", name, name),
+			}
+
+			if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
+				fmt.Printf("  Warning: could not save outputs: %v\n", err)
+			}
+
+			if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
+				fmt.Printf("  Warning: could not update status: %v\n", err)
+			}
+
+			fmt.Printf("\nService instance '%s' created successfully.\n", name)
+			fmt.Printf("Use 'mf bind-service <app-name> %s' to bind it to an application.\n", name)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/mf/create_service.go
+++ b/cmd/mf/create_service.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -19,6 +21,11 @@ func createServiceCmd() *cobra.Command {
 			serviceType := args[0]
 			plan := args[1]
 			name := args[2]
+
+			// Validate instance name
+			if !models.ValidServiceName.MatchString(name) {
+				return fmt.Errorf("invalid service name %q: must be lowercase alphanumeric with hyphens, 2-42 characters", name)
+			}
 
 			// Validate service type and plan exist
 			_, ok := service.FindServiceType(serviceType)
@@ -60,13 +67,14 @@ func createServiceCmd() *cobra.Command {
 
 			// For now, immediately set to available with mock outputs
 			// In production, this would trigger async Terraform apply
+			password := generateCLIPassword(24)
 			outputs := models.ServiceOutputs{
 				Host:     fmt.Sprintf("%s.cluster.local", name),
 				Port:     3306,
 				Username: "admin",
-				Password: "changeme",
+				Password: password,
 				Database: name,
-				URI:      fmt.Sprintf("mysql://admin:changeme@%s.cluster.local:3306/%s", name, name),
+				URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
 			}
 
 			if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
@@ -84,4 +92,12 @@ func createServiceCmd() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func generateCLIPassword(length int) string {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-change-me"
+	}
+	return hex.EncodeToString(b)[:length]
 }

--- a/cmd/mf/delete_service.go
+++ b/cmd/mf/delete_service.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func deleteServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete-service <instance-name>",
+		Short: "Delete a provisioned service instance",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+
+			// Verify exists
+			inst, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			// Check for active bindings
+			if len(inst.Bindings) > 0 {
+				return fmt.Errorf("service %q has %d active binding(s) — unbind all apps first", name, len(inst.Bindings))
+			}
+
+			fmt.Printf("Deleting service instance '%s'...\n", name)
+
+			if err := mgr.Delete(ctx, name); err != nil {
+				return fmt.Errorf("deleting service: %w", err)
+			}
+
+			fmt.Printf("Service instance '%s' deleted.\n", name)
+			return nil
+		},
+	}
+}

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -34,6 +34,10 @@ func main() {
 		bindServiceCmd(),
 		unbindServiceCmd(),
 		deleteServiceCmd(),
+		secretsListCmd(),
+		secretDetailCmd(),
+		createSecretCmd(),
+		deleteSecretCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -27,6 +27,13 @@ func main() {
 		deleteCmd(),
 		scaleCmd(),
 		adminCmd(),
+		marketplaceCmd(),
+		createServiceCmd(),
+		servicesCmd(),
+		serviceCmd(),
+		bindServiceCmd(),
+		unbindServiceCmd(),
+		deleteServiceCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/mf/marketplace.go
+++ b/cmd/mf/marketplace.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func marketplaceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "marketplace",
+		Short:   "List available backing services and plans",
+		Aliases: []string{"m"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			catalog := service.Catalog()
+
+			if len(catalog) == 0 {
+				fmt.Println("No services available.")
+				return nil
+			}
+
+			for _, svc := range catalog {
+				fmt.Printf("\n%s  (%s)\n", svc.Name, svc.ID)
+				fmt.Printf("  %s\n", svc.Description)
+				fmt.Printf("  Provider: %s  |  Category: %s\n", svc.Provider, svc.Category)
+				fmt.Println()
+				fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n", "PLAN", "INSTANCE", "STORAGE", "REPLICAS", "AZ", "COST")
+				for _, p := range svc.Plans {
+					replicas := "none"
+					if p.Replicas > 0 {
+						replicas = fmt.Sprintf("%d", p.Replicas)
+					}
+					az := "single"
+					if p.MultiAZ {
+						az = "multi"
+					}
+					fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n",
+						p.ID, p.InstanceClass, fmt.Sprintf("%dGB", p.StorageGB),
+						replicas, az, p.CostEstimate)
+				}
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+}

--- a/cmd/mf/secrets.go
+++ b/cmd/mf/secrets.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+)
+
+func secretsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "secrets",
+		Short: "List all managed secrets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+			items, err := mgr.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No managed secrets found.")
+				fmt.Println("Use 'mf create-secret <name> key=value...' to create a secret.")
+				return nil
+			}
+
+			fmt.Printf("%-25s %-15s %-20s %-6s %-10s\n", "NAME", "TYPE", "SERVICE", "KEYS", "CREATED")
+			for _, item := range items {
+				svc := "—"
+				if item.ServiceInstance != "" {
+					svc = item.ServiceInstance
+				}
+				fmt.Printf("%-25s %-15s %-20s %-6d %-10s\n",
+					item.K8sName, item.Type, svc, item.KeyCount, item.CreatedAt.Format("2006-01-02"))
+			}
+			return nil
+		},
+	}
+}
+
+func secretDetailCmd() *cobra.Command {
+	var reveal bool
+
+	cmd := &cobra.Command{
+		Use:   "secret <name>",
+		Short: "Show secret details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+			detail, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("name:         %s\n", detail.Name)
+			fmt.Printf("k8s-name:     %s\n", detail.K8sName)
+			fmt.Printf("type:         %s\n", detail.Type)
+			if detail.ServiceInstance != "" {
+				fmt.Printf("service:      %s\n", detail.ServiceInstance)
+			}
+			if detail.Description != "" {
+				fmt.Printf("description:  %s\n", detail.Description)
+			}
+			fmt.Printf("keys:         %s\n", strings.Join(detail.Keys, ", "))
+			fmt.Printf("created:      %s\n", detail.CreatedAt.Format("2006-01-02T15:04:05Z"))
+
+			if len(detail.Keys) > 0 {
+				fmt.Println()
+				fmt.Println("Key-Value Pairs:")
+				for _, key := range detail.Keys {
+					if reveal {
+						val, err := mgr.GetValue(ctx, name, key)
+						if err != nil {
+							fmt.Printf("  %-15s %s\n", key+":", "(error: "+err.Error()+")")
+						} else {
+							fmt.Printf("  %-15s %s\n", key+":", val)
+						}
+					} else {
+						fmt.Printf("  %-15s %s\n", key+":", "********")
+					}
+				}
+			}
+
+			if len(detail.BoundApps) > 0 {
+				fmt.Println()
+				fmt.Println("Bound Applications:")
+				for _, app := range detail.BoundApps {
+					fmt.Printf("  %s\n", app)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&reveal, "reveal", false, "Show actual secret values")
+	return cmd
+}
+
+func createSecretCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create-secret <name> [key=value...]",
+		Short: "Create a user-defined secret",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			if !models.ValidSecretName.MatchString(name) {
+				return fmt.Errorf("invalid secret name %q: must be lowercase alphanumeric with hyphens, 2-42 characters", name)
+			}
+
+			// Parse key=value pairs
+			data := make(map[string]string)
+			for _, kv := range args[1:] {
+				parts := strings.SplitN(kv, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid key=value pair: %q (expected KEY=VALUE format)", kv)
+				}
+				if parts[0] == "" {
+					return fmt.Errorf("empty key in pair: %q", kv)
+				}
+				data[parts[0]] = parts[1]
+			}
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+
+			fmt.Printf("Creating secret '%s' with %d key(s)...\n", name, len(data))
+			if err := mgr.CreateUserSecret(ctx, name, "", data); err != nil {
+				return fmt.Errorf("creating secret: %w", err)
+			}
+
+			fmt.Printf("Secret '%s' created successfully.\n", name)
+			fmt.Printf("K8s Secret name: %s%s\n", models.UserSecretPrefix, name)
+			return nil
+		},
+	}
+}
+
+func deleteSecretCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete-secret <name>",
+		Short: "Delete a user-defined secret",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := secrets.NewManager(k8sClient)
+
+			// Check if it's a service secret
+			detail, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			if detail.Type == models.SecretTypeService {
+				return fmt.Errorf("cannot delete service secret %q — use 'mf delete-service %s' instead", name, detail.ServiceInstance)
+			}
+
+			if len(detail.BoundApps) > 0 {
+				return fmt.Errorf("secret %q has %d active binding(s) — unbind all apps first", name, len(detail.BoundApps))
+			}
+
+			fmt.Printf("Deleting secret '%s'...\n", name)
+			if err := mgr.Delete(ctx, name); err != nil {
+				return fmt.Errorf("deleting secret: %w", err)
+			}
+
+			fmt.Printf("Secret '%s' deleted.\n", name)
+			return nil
+		},
+	}
+}

--- a/cmd/mf/services.go
+++ b/cmd/mf/services.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func servicesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "services",
+		Short: "List provisioned service instances",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			items, err := mgr.List(ctx)
+			if err != nil {
+				return err
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No service instances found.")
+				fmt.Println("Use 'mf marketplace' to see available services.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %-12s %-12s %-5s\n", "NAME", "SERVICE", "PLAN", "STATUS", "APPS")
+			for _, item := range items {
+				fmt.Printf("%-20s %-30s %-12s %-12s %-5d\n",
+					item.Name, item.ServiceType, item.Plan, item.Status, item.BoundApps)
+			}
+			return nil
+		},
+	}
+}
+
+func serviceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "service [name]",
+		Short: "Show service instance details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			name := args[0]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			inst, err := mgr.Get(ctx, name)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("name:         %s\n", inst.Name)
+			fmt.Printf("service:      %s\n", inst.ServiceType)
+			fmt.Printf("plan:         %s\n", inst.Plan)
+			fmt.Printf("status:       %s\n", inst.Status)
+			if inst.StatusMsg != "" {
+				fmt.Printf("message:      %s\n", inst.StatusMsg)
+			}
+			fmt.Printf("cluster:      %s\n", inst.ClusterID)
+
+			if inst.Outputs.Host != "" {
+				fmt.Println()
+				fmt.Println("Connection Info:")
+				fmt.Printf("  host:       %s\n", inst.Outputs.Host)
+				fmt.Printf("  port:       %d\n", inst.Outputs.Port)
+				fmt.Printf("  database:   %s\n", inst.Outputs.Database)
+				fmt.Printf("  username:   %s\n", inst.Outputs.Username)
+				fmt.Printf("  uri:        %s\n", inst.Outputs.URI)
+			}
+
+			if len(inst.Bindings) > 0 {
+				fmt.Println()
+				fmt.Println("Bound Applications:")
+				var apps []string
+				for _, b := range inst.Bindings {
+					apps = append(apps, b.AppName)
+				}
+				fmt.Printf("  %s\n", strings.Join(apps, ", "))
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/mf/services.go
+++ b/cmd/mf/services.go
@@ -79,7 +79,6 @@ func serviceCmd() *cobra.Command {
 				fmt.Printf("  port:       %d\n", inst.Outputs.Port)
 				fmt.Printf("  database:   %s\n", inst.Outputs.Database)
 				fmt.Printf("  username:   %s\n", inst.Outputs.Username)
-				fmt.Printf("  uri:        %s\n", inst.Outputs.URI)
 			}
 
 			if len(inst.Bindings) > 0 {

--- a/cmd/mf/unbind_service.go
+++ b/cmd/mf/unbind_service.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+func unbindServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unbind-service <app-name> <service-instance>",
+		Short: "Unbind a service instance from an application",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			appName := args[0]
+			svcName := args[1]
+
+			k8sClient, err := newK8sClient()
+			if err != nil {
+				return err
+			}
+
+			mgr := service.NewManager(k8sClient)
+			binder := service.NewBinder(k8sClient)
+
+			fmt.Printf("Unbinding service '%s' from app '%s'...\n", svcName, appName)
+
+			// Remove credentials from deployment
+			secretName := "mf-svc-" + svcName
+			if err := binder.Unbind(ctx, appName, secretName); err != nil {
+				return fmt.Errorf("unbinding from deployment: %w", err)
+			}
+
+			// Remove binding metadata
+			if err := mgr.RemoveBinding(ctx, svcName, appName); err != nil {
+				return fmt.Errorf("removing binding: %w", err)
+			}
+
+			fmt.Printf("Service '%s' unbound from app '%s'.\n", svcName, appName)
+			return nil
+		},
+	}
+}

--- a/cmd/mf/unbind_service.go
+++ b/cmd/mf/unbind_service.go
@@ -29,7 +29,7 @@ func unbindServiceCmd() *cobra.Command {
 			fmt.Printf("Unbinding service '%s' from app '%s'...\n", svcName, appName)
 
 			// Remove credentials from deployment
-			secretName := "mf-svc-" + svcName
+			secretName := service.SecretName(svcName)
 			if err := binder.Unbind(ctx, appName, secretName); err != nil {
 				return fmt.Errorf("unbinding from deployment: %w", err)
 			}

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -247,11 +247,6 @@ func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	s.templates.Render(w, "config.html", data)
 }
 
-func (s *Server) SecretsHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Secrets", "secrets")
-	s.templates.Render(w, "secrets.html", data)
-}
-
 func (s *Server) UsersHandler(w http.ResponseWriter, r *http.Request) {
 	data := s.pageData("Users & Organizations", "users")
 	s.templates.Render(w, "users.html", data)

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -247,11 +247,6 @@ func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	s.templates.Render(w, "config.html", data)
 }
 
-func (s *Server) ServicesHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Backing Services", "services")
-	s.templates.Render(w, "services.html", data)
-}
-
 func (s *Server) SecretsHandler(w http.ResponseWriter, r *http.Request) {
 	data := s.pageData("Secrets", "secrets")
 	s.templates.Render(w, "secrets.html", data)

--- a/pkg/admin/secret_handlers.go
+++ b/pkg/admin/secret_handlers.go
@@ -1,0 +1,291 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+)
+
+// SecretsListHandler shows all managed secrets.
+func (s *Server) SecretsListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		log.Printf("error listing secrets: %v", err)
+		items = []models.SecretListItem{}
+	}
+
+	// Apply type filter
+	filter := r.URL.Query().Get("type")
+	if filter == "" {
+		filter = "all"
+	}
+	if filter != "all" {
+		var filtered []models.SecretListItem
+		for _, item := range items {
+			if item.Type == filter {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+
+	data := s.pageData("Secrets Manager", "secrets")
+	data.Content = map[string]any{
+		"Secrets": items,
+		"Filter":  filter,
+	}
+	s.templates.Render(w, "secrets.html", data)
+}
+
+// SecretDetailHandler shows details of a single secret.
+func (s *Server) SecretDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Secret not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	data := s.pageData(name, "secrets")
+	data.Content = map[string]any{
+		"Detail": detail,
+	}
+	s.templates.Render(w, "secret_detail.html", data)
+}
+
+// SecretRevealHandler returns the actual value of a single key (HTMX partial).
+func (s *Server) SecretRevealHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	key := r.PathValue("key")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	value, err := mgr.GetValue(ctx, name, key)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<span class="font-mono text-sm text-gray-900 break-all">%s</span>`, value)
+}
+
+// CreateSecretFormHandler renders the secret creation form.
+func (s *Server) CreateSecretFormHandler(w http.ResponseWriter, r *http.Request) {
+	data := s.pageData("Create Secret", "secrets")
+	s.templates.Render(w, "secret_create.html", data)
+}
+
+// CreateSecretHandler creates a user-defined secret.
+func (s *Server) CreateSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	name := r.FormValue("name")
+	description := r.FormValue("description")
+
+	if name == "" {
+		http.Error(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	if !models.ValidSecretName.MatchString(name) {
+		http.Error(w, "invalid secret name: must be lowercase alphanumeric with hyphens, 2-42 characters", http.StatusBadRequest)
+		return
+	}
+
+	// Parse key-value pairs from form
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "parsing form: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	keyNames := r.Form["key_name"]
+	keyValues := r.Form["key_value"]
+
+	if len(keyNames) == 0 {
+		http.Error(w, "at least one key-value pair is required", http.StatusBadRequest)
+		return
+	}
+
+	data := make(map[string]string)
+	for i, k := range keyNames {
+		if k == "" {
+			continue
+		}
+		v := ""
+		if i < len(keyValues) {
+			v = keyValues[i]
+		}
+		data[k] = v
+	}
+
+	if len(data) == 0 {
+		http.Error(w, "at least one non-empty key is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	if err := mgr.CreateUserSecret(ctx, name, description, data); err != nil {
+		http.Error(w, "creating secret: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/secrets/"+name, http.StatusSeeOther)
+}
+
+// DeleteSecretHandler deletes a user-defined secret.
+func (s *Server) DeleteSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+
+	// Check if it's a service secret — those must be deleted via delete-service
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Secret not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if detail.Type == models.SecretTypeService {
+		http.Error(w, fmt.Sprintf("cannot delete service secret %q — use 'mf delete-service %s' instead", name, detail.ServiceInstance), http.StatusBadRequest)
+		return
+	}
+
+	// Check for bound apps
+	if len(detail.BoundApps) > 0 {
+		http.Error(w, fmt.Sprintf("secret %q has %d active binding(s) — unbind all apps first", name, len(detail.BoundApps)), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.Delete(ctx, name); err != nil {
+		http.Error(w, "deleting secret: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// API handlers
+
+// APISecretsListHandler returns secrets as JSON.
+func (s *Server) APISecretsListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+// APISecretDetailHandler returns a single secret as JSON (values redacted).
+func (s *Server) APISecretDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	detail, err := mgr.Get(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, detail)
+}
+
+// APICreateSecretHandler creates a user-defined secret from JSON.
+func (s *Server) APICreateSecretHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req struct {
+		Name        string            `json:"name"`
+		Description string            `json:"description"`
+		Data        map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	if !models.ValidSecretName.MatchString(req.Name) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid secret name"})
+		return
+	}
+	if len(req.Data) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one key-value pair is required"})
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := secrets.NewManager(client)
+	if err := mgr.CreateUserSecret(ctx, req.Name, req.Description, req.Data); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"name": req.Name, "status": "created"})
+}

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -55,7 +55,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("POST /services/{name}/bind", s.BindServiceHandler)
 	s.mux.HandleFunc("POST /services/{name}/unbind", s.UnbindServiceHandler)
 	s.mux.HandleFunc("DELETE /services/{name}", s.DeleteServiceHandler)
-	s.mux.HandleFunc("GET /secrets", s.SecretsHandler)
+	// Secret routes
+	s.mux.HandleFunc("GET /secrets", s.SecretsListHandler)
+	s.mux.HandleFunc("GET /secrets/new", s.CreateSecretFormHandler)
+	s.mux.HandleFunc("GET /secrets/{name}", s.SecretDetailHandler)
+	s.mux.HandleFunc("GET /secrets/{name}/reveal/{key}", s.SecretRevealHandler)
+	s.mux.HandleFunc("POST /secrets", s.CreateSecretHandler)
+	s.mux.HandleFunc("DELETE /secrets/{name}", s.DeleteSecretHandler)
 	s.mux.HandleFunc("GET /users", s.UsersHandler)
 
 	// Cluster routes
@@ -80,6 +86,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/services", s.APIServicesListHandler)
 	s.mux.HandleFunc("GET /api/services/{name}", s.APIServiceDetailHandler)
 	s.mux.HandleFunc("GET /api/marketplace", s.APIMarketplaceHandler)
+	s.mux.HandleFunc("GET /api/secrets", s.APISecretsListHandler)
+	s.mux.HandleFunc("GET /api/secrets/{name}", s.APISecretDetailHandler)
+	s.mux.HandleFunc("POST /api/secrets", s.APICreateSecretHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -48,7 +48,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /apps/{name}/instances", s.AppInstancesHandler)
 	s.mux.HandleFunc("GET /apps/{name}/logs/stream", s.LogStreamHandler)
 	s.mux.HandleFunc("GET /config", s.ConfigHandler)
-	s.mux.HandleFunc("GET /services", s.ServicesHandler)
+	s.mux.HandleFunc("GET /services", s.ServicesListHandler)
+	s.mux.HandleFunc("GET /services/{name}", s.ServiceDetailHandler)
+	s.mux.HandleFunc("GET /marketplace", s.MarketplaceHandler)
+	s.mux.HandleFunc("POST /services/create", s.CreateServiceHandler)
+	s.mux.HandleFunc("POST /services/{name}/bind", s.BindServiceHandler)
+	s.mux.HandleFunc("POST /services/{name}/unbind", s.UnbindServiceHandler)
+	s.mux.HandleFunc("DELETE /services/{name}", s.DeleteServiceHandler)
 	s.mux.HandleFunc("GET /secrets", s.SecretsHandler)
 	s.mux.HandleFunc("GET /users", s.UsersHandler)
 
@@ -71,6 +77,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("DELETE /api/apps/{name}", s.APIDeleteAppHandler)
 	s.mux.HandleFunc("GET /api/clusters", s.APIClustersListHandler)
 	s.mux.HandleFunc("GET /api/clusters/{id}/health", s.APIClusterHealthHandler)
+	s.mux.HandleFunc("GET /api/services", s.APIServicesListHandler)
+	s.mux.HandleFunc("GET /api/services/{name}", s.APIServiceDetailHandler)
+	s.mux.HandleFunc("GET /api/marketplace", s.APIMarketplaceHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/service_handlers.go
+++ b/pkg/admin/service_handlers.go
@@ -1,12 +1,24 @@
 package admin
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/younjinjeong/microfoundry/pkg/models"
 	"github.com/younjinjeong/microfoundry/pkg/service"
 )
+
+// generatePassword returns a cryptographically random hex password.
+func generatePassword(length int) string {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-change-me" // should never happen
+	}
+	return hex.EncodeToString(b)[:length]
+}
 
 // ServicesListHandler shows all provisioned service instances.
 func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +33,8 @@ func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
 	mgr := service.NewManager(client)
 	items, err := mgr.List(ctx)
 	if err != nil {
-		items = []models.ServiceListItem{} // empty on error
+		log.Printf("error listing services: %v", err)
+		items = []models.ServiceListItem{}
 	}
 
 	data := s.pageData("Backing Services", "services")
@@ -84,6 +97,11 @@ func (s *Server) CreateServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !models.ValidServiceName.MatchString(name) {
+		http.Error(w, "invalid service name: must be lowercase alphanumeric with hyphens, 2-42 characters", http.StatusBadRequest)
+		return
+	}
+
 	_, ok := service.FindServiceType(serviceType)
 	if !ok {
 		http.Error(w, fmt.Sprintf("unknown service type: %s", serviceType), http.StatusBadRequest)
@@ -120,17 +138,22 @@ func (s *Server) CreateServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mock outputs (will be replaced by Terraform in future)
+	// Mock outputs with per-instance random password (will be replaced by Terraform)
+	password := generatePassword(24)
 	outputs := models.ServiceOutputs{
 		Host:     fmt.Sprintf("%s.cluster.local", name),
 		Port:     3306,
 		Username: "admin",
-		Password: "changeme",
+		Password: password,
 		Database: name,
-		URI:      fmt.Sprintf("mysql://admin:changeme@%s.cluster.local:3306/%s", name, name),
+		URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
 	}
-	_ = mgr.SaveOutputs(ctx, name, outputs)
-	_ = mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, "")
+	if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
+		log.Printf("error saving service outputs for %q: %v", name, err)
+	}
+	if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
+		log.Printf("error updating service status for %q: %v", name, err)
+	}
 
 	w.Header().Set("HX-Redirect", "/services/"+name)
 	w.WriteHeader(http.StatusOK)
@@ -171,7 +194,7 @@ func (s *Server) BindServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secretName := "mf-svc-" + name
+	secretName := service.SecretName(name)
 	if err := binder.Bind(ctx, appName, secretName); err != nil {
 		_ = mgr.RemoveBinding(ctx, name, appName)
 		http.Error(w, "binding to deployment: "+err.Error(), http.StatusInternalServerError)
@@ -202,7 +225,7 @@ func (s *Server) UnbindServiceHandler(w http.ResponseWriter, r *http.Request) {
 	mgr := service.NewManager(client)
 	binder := service.NewBinder(client)
 
-	secretName := "mf-svc-" + name
+	secretName := service.SecretName(name)
 	if err := binder.Unbind(ctx, appName, secretName); err != nil {
 		http.Error(w, "unbinding from deployment: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -271,7 +294,7 @@ func (s *Server) APIServicesListHandler(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, items)
 }
 
-// APIServiceDetailHandler returns a single service instance as JSON.
+// APIServiceDetailHandler returns a single service instance as JSON (credentials redacted).
 func (s *Server) APIServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
@@ -289,7 +312,9 @@ func (s *Server) APIServiceDetailHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, inst)
+	// Redact sensitive fields in API response
+	redacted := inst.Redacted()
+	writeJSON(w, http.StatusOK, redacted)
 }
 
 // APIMarketplaceHandler returns the service catalog as JSON.

--- a/pkg/admin/service_handlers.go
+++ b/pkg/admin/service_handlers.go
@@ -1,0 +1,298 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/service"
+)
+
+// ServicesListHandler shows all provisioned service instances.
+func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		items = []models.ServiceListItem{} // empty on error
+	}
+
+	data := s.pageData("Backing Services", "services")
+	data.Content = map[string]any{
+		"Services": items,
+	}
+	s.templates.Render(w, "services.html", data)
+}
+
+// ServiceDetailHandler shows details of a single service instance.
+func (s *Server) ServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Find plan details from catalog
+	plan, _ := service.FindPlan(inst.ServiceType, inst.Plan)
+
+	data := s.pageData(name, "services")
+	data.Content = map[string]any{
+		"Instance": inst,
+		"Plan":     plan,
+	}
+	s.templates.Render(w, "service_detail.html", data)
+}
+
+// MarketplaceHandler shows the service catalog.
+func (s *Server) MarketplaceHandler(w http.ResponseWriter, r *http.Request) {
+	catalog := service.Catalog()
+
+	data := s.pageData("Service Marketplace", "marketplace")
+	data.Content = map[string]any{
+		"Catalog": catalog,
+	}
+	s.templates.Render(w, "marketplace.html", data)
+}
+
+// CreateServiceHandler provisions a new service instance from the marketplace.
+func (s *Server) CreateServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	serviceType := r.FormValue("service_type")
+	plan := r.FormValue("plan")
+	name := r.FormValue("name")
+
+	if serviceType == "" || plan == "" || name == "" {
+		http.Error(w, "service_type, plan, and name are required", http.StatusBadRequest)
+		return
+	}
+
+	_, ok := service.FindServiceType(serviceType)
+	if !ok {
+		http.Error(w, fmt.Sprintf("unknown service type: %s", serviceType), http.StatusBadRequest)
+		return
+	}
+	if _, ok := service.FindPlan(serviceType, plan); !ok {
+		http.Error(w, fmt.Sprintf("unknown plan %q for service %q", plan, serviceType), http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+
+	// Check if already exists
+	if existing, _ := mgr.Get(ctx, name); existing != nil {
+		http.Error(w, fmt.Sprintf("service instance %q already exists", name), http.StatusConflict)
+		return
+	}
+
+	inst := &models.ServiceInstance{
+		Name:        name,
+		ServiceType: serviceType,
+		Plan:        plan,
+		ClusterID:   s.clientManager.GetActive(),
+	}
+
+	if err := mgr.Create(ctx, inst); err != nil {
+		http.Error(w, "creating service: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Mock outputs (will be replaced by Terraform in future)
+	outputs := models.ServiceOutputs{
+		Host:     fmt.Sprintf("%s.cluster.local", name),
+		Port:     3306,
+		Username: "admin",
+		Password: "changeme",
+		Database: name,
+		URI:      fmt.Sprintf("mysql://admin:changeme@%s.cluster.local:3306/%s", name, name),
+	}
+	_ = mgr.SaveOutputs(ctx, name, outputs)
+	_ = mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, "")
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// BindServiceHandler binds a service instance to an app.
+func (s *Server) BindServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	appName := r.FormValue("app_name")
+
+	if appName == "" {
+		http.Error(w, "app_name is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	binder := service.NewBinder(client)
+
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+	if inst.Status != models.ServiceStatusAvailable {
+		http.Error(w, fmt.Sprintf("service %q is not available (status: %s)", name, inst.Status), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.AddBinding(ctx, name, appName); err != nil {
+		http.Error(w, "adding binding: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	secretName := "mf-svc-" + name
+	if err := binder.Bind(ctx, appName, secretName); err != nil {
+		_ = mgr.RemoveBinding(ctx, name, appName)
+		http.Error(w, "binding to deployment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// UnbindServiceHandler unbinds a service instance from an app.
+func (s *Server) UnbindServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	appName := r.FormValue("app_name")
+
+	if appName == "" {
+		http.Error(w, "app_name is required", http.StatusBadRequest)
+		return
+	}
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+	binder := service.NewBinder(client)
+
+	secretName := "mf-svc-" + name
+	if err := binder.Unbind(ctx, appName, secretName); err != nil {
+		http.Error(w, "unbinding from deployment: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := mgr.RemoveBinding(ctx, name, appName); err != nil {
+		http.Error(w, "removing binding: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/services/"+name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeleteServiceHandler deletes a service instance.
+func (s *Server) DeleteServiceHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	mgr := service.NewManager(client)
+
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		http.Error(w, "Service not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if len(inst.Bindings) > 0 {
+		http.Error(w, fmt.Sprintf("service %q has %d active binding(s) — unbind all apps first", name, len(inst.Bindings)), http.StatusBadRequest)
+		return
+	}
+
+	if err := mgr.Delete(ctx, name); err != nil {
+		http.Error(w, "deleting service: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// API handlers
+
+// APIServicesListHandler returns service instances as JSON.
+func (s *Server) APIServicesListHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := service.NewManager(client)
+	items, err := mgr.List(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+// APIServiceDetailHandler returns a single service instance as JSON.
+func (s *Server) APIServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	client, err := s.getClient(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	mgr := service.NewManager(client)
+	inst, err := mgr.Get(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, inst)
+}
+
+// APIMarketplaceHandler returns the service catalog as JSON.
+func (s *Server) APIMarketplaceHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, service.Catalog())
+}

--- a/pkg/admin/static/templates/marketplace.html
+++ b/pkg/admin/static/templates/marketplace.html
@@ -1,0 +1,101 @@
+{{define "marketplace.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<div class="mb-6">
+    <h2 class="text-lg font-semibold text-gray-900">Service Marketplace</h2>
+    <p class="text-sm text-gray-500">Browse available backing services and provision new instances</p>
+</div>
+
+{{with .Content}}
+{{range .Catalog}}
+<div class="bg-white rounded-lg shadow mb-8">
+    <!-- Service Type Header -->
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-3">
+                <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center">
+                    <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
+                    </svg>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                    <p class="text-sm text-gray-500">{{.Description}}</p>
+                </div>
+            </div>
+            <div class="flex items-center space-x-2">
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">{{.Provider}}</span>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{.Category}}</span>
+            </div>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>
+            {{end}}
+        </div>
+        {{end}}
+    </div>
+
+    <!-- Plans -->
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-blue-300 hover:shadow-sm transition-all">
+                <div class="flex justify-between items-start mb-3">
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                        <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                    </div>
+                </div>
+
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Instance</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.InstanceClass}}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Storage</dt>
+                        <dd class="text-gray-900">{{.StorageGB}} GB</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Replicas</dt>
+                        <dd class="text-gray-900">{{if .Replicas}}{{.Replicas}}{{else}}None{{end}}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Multi-AZ</dt>
+                        <dd class="text-gray-900">{{if .MultiAZ}}Yes{{else}}No{{end}}</dd>
+                    </div>
+                </dl>
+
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                    {{if .Customizable}}
+                    <span class="text-xs text-blue-600">Customizable</span>
+                    {{end}}
+                </div>
+
+                <!-- Create Service Form (inline) -->
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-db)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -33,6 +33,13 @@
             </svg>
             Services
         </a>
+        <a href="/marketplace"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "marketplace"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"/>
+            </svg>
+            Marketplace
+        </a>
         <a href="/secrets"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "secrets"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pkg/admin/static/templates/secret_create.html
+++ b/pkg/admin/static/templates/secret_create.html
@@ -1,0 +1,92 @@
+{{define "secret_create.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/secrets" class="hover:text-blue-600">Secrets</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">Create</span>
+    </nav>
+</div>
+
+<!-- Form Card -->
+<div class="max-w-2xl">
+    <div class="bg-white rounded-lg shadow p-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-6">Create Secret</h3>
+
+        <form method="POST" action="/secrets" class="space-y-6">
+            <!-- Name -->
+            <div>
+                <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+                <input type="text" id="name" name="name"
+                       required
+                       pattern="[a-z][a-z0-9-]*[a-z0-9]"
+                       placeholder="my-secret"
+                       class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500">
+                <p class="mt-1 text-xs text-gray-500">Lowercase letters, numbers, and hyphens only. Must start with a letter and end with a letter or number.</p>
+            </div>
+
+            <!-- Description -->
+            <div>
+                <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
+                <textarea id="description" name="description"
+                          rows="2"
+                          placeholder="Optional description..."
+                          class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500"></textarea>
+            </div>
+
+            <!-- Key-Value Pairs -->
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2">Key-Value Pairs</label>
+                <div id="kv-pairs" class="space-y-2">
+                    <div class="kv-row flex items-center space-x-2">
+                        <input type="text" name="key_name" placeholder="KEY_NAME" required
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-mono focus:ring-blue-500 focus:border-blue-500">
+                        <input type="text" name="key_value" placeholder="value" required
+                               class="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="button" onclick="this.parentElement.remove()"
+                                class="inline-flex items-center p-2 text-red-500 hover:text-red-700">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <button type="button" onclick="addKVRow()"
+                        class="mt-2 inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium">
+                    <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                    </svg>
+                    Add Key
+                </button>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex justify-end space-x-3 pt-4 border-t border-gray-200">
+                <a href="/secrets" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium">
+                    Cancel
+                </a>
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+                    Create Secret
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+function addKVRow() {
+    var container = document.getElementById('kv-pairs');
+    var firstRow = container.querySelector('.kv-row');
+    var newRow = firstRow.cloneNode(true);
+    var inputs = newRow.querySelectorAll('input');
+    for (var i = 0; i < inputs.length; i++) {
+        inputs[i].value = '';
+    }
+    container.appendChild(newRow);
+}
+</script>
+{{end}}

--- a/pkg/admin/static/templates/secret_detail.html
+++ b/pkg/admin/static/templates/secret_detail.html
@@ -1,0 +1,151 @@
+{{define "secret_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{with .Content}}
+{{$detail := .Detail}}
+
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/secrets" class="hover:text-blue-600">Secrets</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">{{$detail.Name}}</span>
+    </nav>
+</div>
+
+<!-- Header -->
+<div class="flex justify-between items-start mb-6">
+    <div>
+        <h2 class="text-2xl font-bold text-gray-900">{{$detail.Name}}</h2>
+        {{if eq $detail.Type "service"}}
+        <p class="text-sm text-gray-500 mt-1">
+            Part of service instance:
+            <a href="/services/{{$detail.ServiceInstance}}" class="text-blue-600 hover:text-blue-800">{{$detail.ServiceInstance}}</a>
+        </p>
+        {{end}}
+    </div>
+    <div class="flex items-center space-x-3">
+        {{if eq $detail.Type "service"}}
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">Service</span>
+        {{else}}
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">User-defined</span>
+        {{end}}
+        {{if eq $detail.Type "user-defined"}}
+        <button hx-delete="/secrets/{{$detail.Name}}"
+                hx-confirm="Delete secret '{{$detail.Name}}'? This cannot be undone."
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+            Delete
+        </button>
+        {{end}}
+    </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- Left Column: Key-Value Pairs -->
+    <div class="lg:col-span-2 space-y-6">
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Key-Value Pairs</h3>
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{$detail.KeyCount}} keys</span>
+            </div>
+            <div class="overflow-hidden">
+                {{if $detail.Keys}}
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Key</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Value</th>
+                            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        {{range $detail.Keys}}
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="text-sm font-mono {{if isSensitive .}}text-red-600 font-semibold{{else}}text-gray-900{{end}}">{{.}}</span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span id="val-{{.}}" class="text-sm text-gray-400 italic">********</span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-right">
+                                <button hx-get="/secrets/{{$detail.Name}}/reveal/{{.}}"
+                                        hx-target="#val-{{.}}"
+                                        hx-swap="innerHTML"
+                                        class="text-blue-600 hover:text-blue-800 text-sm font-medium">Reveal</button>
+                            </td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+                {{else}}
+                <div class="px-6 py-8 text-center">
+                    <p class="text-sm text-gray-500">No keys defined in this secret.</p>
+                </div>
+                {{end}}
+            </div>
+        </div>
+    </div>
+
+    <!-- Right Sidebar -->
+    <div class="space-y-6">
+        <!-- Bound Applications -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Bound Applications</h3>
+            </div>
+            <div class="px-6 py-4">
+                {{if $detail.BoundApps}}
+                <ul class="divide-y divide-gray-200">
+                    {{range $detail.BoundApps}}
+                    <li class="py-3">
+                        <a href="/apps/{{.}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.}}</a>
+                    </li>
+                    {{end}}
+                </ul>
+                {{else}}
+                <p class="text-sm text-gray-500">No applications bound.</p>
+                {{end}}
+            </div>
+        </div>
+
+        <!-- Metadata -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Metadata</h3>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="space-y-3">
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">K8s Secret Name</dt>
+                        <dd class="mt-1 text-sm text-gray-900 font-mono">{{$detail.K8sName}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Type</dt>
+                        <dd class="mt-1">
+                            {{if eq $detail.Type "service"}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Service</span>
+                            {{else}}
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">User-defined</span>
+                            {{end}}
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Created</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{timeAgo $detail.CreatedAt}}</dd>
+                    </div>
+                    {{if $detail.Description}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Description</dt>
+                        <dd class="mt-1 text-sm text-gray-700">{{$detail.Description}}</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/secrets.html
+++ b/pkg/admin/static/templates/secrets.html
@@ -3,21 +3,108 @@
 {{end}}
 
 {{define "content"}}
+<div class="flex justify-between items-center mb-6">
+    <div>
+        <h2 class="text-lg font-semibold text-gray-900">Secrets Manager</h2>
+        <p class="text-sm text-gray-500">Manage application secrets and environment variables</p>
+    </div>
+    <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        Create Secret
+    </a>
+</div>
+
+{{with .Content}}
+<!-- Filter Tabs -->
+<div class="border-b border-gray-200 mb-6">
+    <nav class="-mb-px flex space-x-4">
+        <a href="/secrets?type=all"
+           hx-get="/secrets?type=all" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "all"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            All
+        </a>
+        <a href="/secrets?type=service"
+           hx-get="/secrets?type=service" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "service"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            Service
+        </a>
+        <a href="/secrets?type=user-defined"
+           hx-get="/secrets?type=user-defined" hx-target="#secret-list" hx-swap="innerHTML" hx-push-url="true"
+           class="inline-flex items-center py-2 px-4 border-b-2 font-medium text-sm {{if eq .Filter "user-defined"}}border-blue-500 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+            User-defined
+        </a>
+    </nav>
+</div>
+
+{{if .Secrets}}
+<div class="bg-white rounded-lg shadow overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Service</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Keys</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bound Apps</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200" id="secret-list"
+               hx-trigger="every 15s" hx-get="/secrets?type={{.Filter}}" hx-swap="innerHTML">
+            {{range .Secrets}}
+            <tr id="secret-row-{{.Name}}" class="hover:bg-gray-50">
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <a href="/secrets/{{.Name}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.Name}}</a>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    {{if eq .Type "service"}}
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Service</span>
+                    {{else}}
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">User-defined</span>
+                    {{end}}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {{if .ServiceInstance}}
+                    <a href="/services/{{.ServiceInstance}}" class="text-blue-600 hover:text-blue-800">{{.ServiceInstance}}</a>
+                    {{else}}
+                    &mdash;
+                    {{end}}
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.KeyCount}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.BoundApps}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{timeAgo .CreatedAt}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-right">
+                    {{if eq .Type "user-defined"}}
+                    <button hx-delete="/secrets/{{.Name}}"
+                            hx-target="closest tr"
+                            hx-swap="outerHTML swap:500ms"
+                            hx-confirm="Delete secret '{{.Name}}'? This cannot be undone."
+                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                    {{end}}
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
 <div class="bg-white rounded-lg shadow p-12 text-center">
     <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
     </svg>
-    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
-        Coming Soon
-    </span>
-    <h3 class="text-xl font-bold text-gray-900 mt-2">Secrets Management</h3>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">No Secrets Found</h3>
     <p class="text-gray-500 mt-2 max-w-md mx-auto">
-        Configure and manage application secrets and environment variables.
-        MicroFoundry integrates with CSP-native secret managers
-        (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault).
+        You haven't created any secrets yet. Create a secret to store sensitive configuration for your applications.
     </p>
-    <div class="mt-6 text-sm text-gray-400">
-        <p>Equivalent to: cf set-env, cf bind-service (user-provided)</p>
+    <div class="mt-6">
+        <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+            Create Secret
+        </a>
     </div>
 </div>
+{{end}}
+{{end}}
 {{end}}

--- a/pkg/admin/static/templates/service_detail.html
+++ b/pkg/admin/static/templates/service_detail.html
@@ -101,8 +101,9 @@
         <!-- Connection Info -->
         {{if $inst.Outputs.Host}}
         <div class="bg-white rounded-lg shadow">
-            <div class="px-6 py-4 border-b border-gray-200">
+            <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
                 <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Connection Details</h3>
+                <a href="/secrets/{{$inst.Name}}" class="text-sm text-blue-600 hover:text-blue-800 font-medium">View in Secrets Manager &rarr;</a>
             </div>
             <div class="px-6 py-4">
                 <dl class="space-y-3">

--- a/pkg/admin/static/templates/service_detail.html
+++ b/pkg/admin/static/templates/service_detail.html
@@ -1,0 +1,199 @@
+{{define "service_detail.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{with .Content}}
+{{$inst := .Instance}}
+{{$plan := .Plan}}
+
+<!-- Breadcrumb -->
+<div class="mb-6">
+    <nav class="text-sm text-gray-500">
+        <a href="/services" class="hover:text-blue-600">Services</a>
+        <span class="mx-2">/</span>
+        <span class="text-gray-900 font-medium">{{$inst.Name}}</span>
+    </nav>
+</div>
+
+<!-- Header -->
+<div class="flex justify-between items-start mb-6">
+    <div>
+        <h2 class="text-2xl font-bold text-gray-900">{{$inst.Name}}</h2>
+        <p class="text-sm text-gray-500 mt-1">{{$inst.ServiceType}} &middot; {{$inst.Plan}} plan</p>
+    </div>
+    <div class="flex items-center space-x-3">
+        <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{stateBg $inst.Status}}">{{$inst.Status}}</span>
+        {{if eq (len $inst.Bindings) 0}}
+        <button hx-delete="/services/{{$inst.Name}}"
+                hx-confirm="Delete service '{{$inst.Name}}'? This cannot be undone."
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+            Delete
+        </button>
+        {{end}}
+    </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- Service Info -->
+    <div class="lg:col-span-2 space-y-6">
+        <!-- Overview Card -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Service Information</h3>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="grid grid-cols-2 gap-4">
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Service Type</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$inst.ServiceType}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Plan</dt>
+                        <dd class="mt-1 text-sm text-gray-900">
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">{{$inst.Plan}}</span>
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Cluster</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$inst.ClusterID}}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Created</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{timeAgo $inst.CreatedAt}}</dd>
+                    </div>
+                    {{if $plan.InstanceClass}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Instance Class</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.InstanceClass}}</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.StorageGB}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Storage</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.StorageGB}} GB</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.MultiAZ}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Multi-AZ</dt>
+                        <dd class="mt-1 text-sm text-gray-900">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Enabled</span>
+                        </dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.Replicas}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Read Replicas</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Replicas}}</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.CostEstimate}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Estimated Cost</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.CostEstimate}}</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+
+        <!-- Connection Info -->
+        {{if $inst.Outputs.Host}}
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Connection Details</h3>
+            </div>
+            <div class="px-6 py-4">
+                <dl class="space-y-3">
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Host</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Host}}</dd>
+                    </div>
+                    {{if $inst.Outputs.Port}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Port</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Port}}</dd>
+                    </div>
+                    {{end}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Database</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Database}}</dd>
+                    </div>
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Username</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Username}}</dd>
+                    </div>
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">Password</dt>
+                        <dd class="text-sm text-gray-400 italic">********</dd>
+                    </div>
+                    {{if $inst.Outputs.URI}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">URI</dt>
+                        <dd class="text-sm text-gray-400 italic">****hidden****</dd>
+                    </div>
+                    {{end}}
+                </dl>
+            </div>
+        </div>
+        {{end}}
+    </div>
+
+    <!-- Sidebar: Bindings -->
+    <div class="space-y-6">
+        <!-- Bound Applications -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Bound Applications</h3>
+            </div>
+            <div class="px-6 py-4">
+                {{if $inst.Bindings}}
+                <ul class="divide-y divide-gray-200">
+                    {{range $inst.Bindings}}
+                    <li class="py-3 flex justify-between items-center">
+                        <div>
+                            <a href="/apps/{{.AppName}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.AppName}}</a>
+                            <p class="text-xs text-gray-500">bound {{timeAgo .BoundAt}}</p>
+                        </div>
+                        <form>
+                            <input type="hidden" name="app_name" value="{{.AppName}}">
+                            <button hx-post="/services/{{$inst.Name}}/unbind"
+                                    hx-include="closest form"
+                                    hx-confirm="Unbind '{{.AppName}}' from '{{$inst.Name}}'?"
+                                    class="text-xs text-red-600 hover:text-red-800 font-medium">Unbind</button>
+                        </form>
+                    </li>
+                    {{end}}
+                </ul>
+                {{else}}
+                <p class="text-sm text-gray-500">No applications bound.</p>
+                {{end}}
+
+                <!-- Bind form -->
+                <div class="mt-4 pt-4 border-t border-gray-200">
+                    <form hx-post="/services/{{$inst.Name}}/bind" hx-swap="none" class="flex space-x-2">
+                        <input type="text" name="app_name" placeholder="App name"
+                               class="flex-1 px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">Bind</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        {{if $inst.StatusMsg}}
+        <!-- Status Message -->
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Status Message</h3>
+            </div>
+            <div class="px-6 py-4">
+                <p class="text-sm text-gray-700">{{$inst.StatusMsg}}</p>
+            </div>
+        </div>
+        {{end}}
+    </div>
+</div>
+
+{{end}}
+{{end}}

--- a/pkg/admin/static/templates/services.html
+++ b/pkg/admin/static/templates/services.html
@@ -3,20 +3,76 @@
 {{end}}
 
 {{define "content"}}
+<div class="flex justify-between items-center mb-6">
+    <div>
+        <h2 class="text-lg font-semibold text-gray-900">Provisioned Services</h2>
+        <p class="text-sm text-gray-500">Backing services bound to your applications</p>
+    </div>
+    <a href="/marketplace" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+        </svg>
+        Create Service
+    </a>
+</div>
+
+{{with .Content}}
+{{if .Services}}
+<div class="bg-white rounded-lg shadow overflow-hidden">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Service</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Plan</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Bound Apps</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200" id="service-table-body" hx-trigger="every 15s" hx-get="/services" hx-select="#service-table-body" hx-swap="outerHTML">
+            {{range .Services}}
+            <tr id="svc-row-{{.Name}}" class="hover:bg-gray-50">
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <a href="/services/{{.Name}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.Name}}</a>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700">{{.ServiceType}}</td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">{{.Plan}}</span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{stateBg .Status}}">{{.Status}}</span>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{.BoundApps}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{timeAgo .CreatedAt}}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-right">
+                    <button hx-delete="/services/{{.Name}}"
+                            hx-target="#svc-row-{{.Name}}"
+                            hx-swap="outerHTML swap:0.3s"
+                            hx-confirm="Delete service '{{.Name}}'? This cannot be undone."
+                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                </td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</div>
+{{else}}
 <div class="bg-white rounded-lg shadow p-12 text-center">
     <svg class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
     </svg>
-    <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 mb-4">
-        Coming Soon
-    </span>
-    <h3 class="text-xl font-bold text-gray-900 mt-2">Backing Services</h3>
+    <h3 class="text-xl font-bold text-gray-900 mt-2">No Services Provisioned</h3>
     <p class="text-gray-500 mt-2 max-w-md mx-auto">
-        Manage backing services like databases, message queues, and caches.
-        MicroFoundry uses OSBAPI-compatible service brokers to provision and bind services to your applications.
+        You haven't created any backing services yet. Browse the marketplace to provision databases, caches, and more.
     </p>
-    <div class="mt-6 text-sm text-gray-400">
-        <p>Planned services: AWS RDS, Cloud SQL, Azure Database, Redis, RabbitMQ</p>
+    <div class="mt-6">
+        <a href="/marketplace" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+            Browse Marketplace
+        </a>
     </div>
 </div>
+{{end}}
+{{end}}
 {{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -31,13 +31,13 @@ func templateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"stateColor": func(state string) string {
 			switch strings.ToLower(state) {
-			case "started", "running":
+			case "started", "running", "connected", "available":
 				return "green"
 			case "stopped", "down":
 				return "red"
-			case "starting", "staging", "deploying", "uploading":
+			case "starting", "staging", "deploying", "uploading", "creating", "deleting":
 				return "yellow"
-			case "crashed", "failed":
+			case "crashed", "failed", "error":
 				return "red"
 			default:
 				return "gray"
@@ -45,11 +45,11 @@ func templateFuncs() template.FuncMap {
 		},
 		"stateBg": func(state string) string {
 			switch strings.ToLower(state) {
-			case "started", "running", "connected":
+			case "started", "running", "connected", "available":
 				return "bg-green-100 text-green-800"
 			case "stopped", "down":
 				return "bg-red-100 text-red-800"
-			case "starting", "staging", "deploying", "uploading":
+			case "starting", "staging", "deploying", "uploading", "creating", "deleting":
 				return "bg-yellow-100 text-yellow-800"
 			case "crashed", "failed", "error":
 				return "bg-red-100 text-red-800"
@@ -149,6 +149,8 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"users.html",
 		"clusters.html",
 		"cluster_detail.html",
+		"service_detail.html",
+		"marketplace.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -151,6 +151,8 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"cluster_detail.html",
 		"service_detail.html",
 		"marketplace.html",
+		"secret_detail.html",
+		"secret_create.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/models/secret.go
+++ b/pkg/models/secret.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"regexp"
+	"time"
+)
+
+// UserSecretPrefix is the K8s Secret name prefix for user-defined secrets.
+const UserSecretPrefix = "mf-secret-"
+
+// ValidSecretName matches valid secret names (lowercase alphanumeric + hyphens, 2-42 chars).
+var ValidSecretName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,40}[a-z0-9]$`)
+
+// Secret type constants.
+const (
+	SecretTypeService = "service"
+	SecretTypeUser    = "user-defined"
+)
+
+// SecretInfo represents K8s Secret metadata (no values exposed).
+// Used in app detail views to show bound secrets.
+type SecretInfo struct {
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	KeyCount  int    `json:"key_count"`
+	CreatedAt string `json:"created_at"`
+}
+
+// SecretListItem is the summary for secrets list views.
+type SecretListItem struct {
+	Name            string    `json:"name"`
+	K8sName         string    `json:"k8s_name"`
+	Type            string    `json:"type"`
+	ServiceInstance string    `json:"service_instance,omitempty"`
+	KeyCount        int       `json:"key_count"`
+	BoundApps       int       `json:"bound_apps"`
+	Description     string    `json:"description,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// SecretDetail is the full view for secret detail pages (values NOT included).
+type SecretDetail struct {
+	Name            string    `json:"name"`
+	K8sName         string    `json:"k8s_name"`
+	Type            string    `json:"type"`
+	ServiceInstance string    `json:"service_instance,omitempty"`
+	Keys            []string  `json:"keys"`
+	KeyCount        int       `json:"key_count"`
+	BoundApps       []string  `json:"bound_apps"`
+	Description     string    `json:"description,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
 
 // Service status constants
 const (
@@ -10,6 +13,12 @@ const (
 	ServiceStatusDeleting  = "deleting"
 	ServiceStatusDeleted   = "deleted"
 )
+
+// ServiceSecretPrefix is the K8s Secret name prefix for service credentials.
+const ServiceSecretPrefix = "mf-svc-"
+
+// ValidServiceName matches valid service instance names (lowercase alphanumeric + hyphens, 2-42 chars).
+var ValidServiceName = regexp.MustCompile(`^[a-z][a-z0-9-]{0,40}[a-z0-9]$`)
 
 // ServiceBindingInfo represents a service bound to an app (display only).
 type ServiceBindingInfo struct {
@@ -67,6 +76,13 @@ type ServiceInstance struct {
 	UpdatedAt   time.Time         `json:"updated_at"`
 }
 
+// Redacted returns a copy with sensitive fields masked.
+func (si *ServiceInstance) Redacted() ServiceInstance {
+	out := *si
+	out.Outputs = si.Outputs.Redacted()
+	return out
+}
+
 // ServiceOutputs holds the provisioned resource connection details.
 type ServiceOutputs struct {
 	Host     string `json:"host,omitempty"`
@@ -75,6 +91,18 @@ type ServiceOutputs struct {
 	Password string `json:"password,omitempty"`
 	Database string `json:"database,omitempty"`
 	URI      string `json:"uri,omitempty"`
+}
+
+// Redacted returns a copy with password and URI masked.
+func (o ServiceOutputs) Redacted() ServiceOutputs {
+	out := o
+	if out.Password != "" {
+		out.Password = "********"
+	}
+	if out.URI != "" {
+		out.URI = "********"
+	}
+	return out
 }
 
 // ServiceBinding represents a binding between an app and a service instance.

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -1,16 +1,96 @@
 package models
 
+import "time"
+
+// Service status constants
+const (
+	ServiceStatusCreating  = "creating"
+	ServiceStatusAvailable = "available"
+	ServiceStatusFailed    = "failed"
+	ServiceStatusDeleting  = "deleting"
+	ServiceStatusDeleted   = "deleted"
+)
+
 // ServiceBindingInfo represents a service bound to an app (display only).
 type ServiceBindingInfo struct {
 	Name   string `json:"name"`
-	Type   string `json:"type"`   // managed, user-provided
-	Status string `json:"status"` // bound, binding, failed
+	Type   string `json:"type"`
+	Status string `json:"status"`
 }
 
 // SecretInfo represents K8s Secret metadata (no values exposed).
 type SecretInfo struct {
 	Name      string `json:"name"`
-	Type      string `json:"type"` // Opaque, kubernetes.io/tls, etc.
+	Type      string `json:"type"`
 	KeyCount  int    `json:"key_count"`
 	CreatedAt string `json:"created_at"`
+}
+
+// ServiceType defines a backing service offering in the catalog.
+type ServiceType struct {
+	ID          string        `json:"id"`
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Provider    string        `json:"provider"`
+	Category    string        `json:"category"`
+	Plans       []ServicePlan `json:"plans"`
+	Tags        []string      `json:"tags,omitempty"`
+}
+
+// ServicePlan defines a sizing tier within a service type.
+type ServicePlan struct {
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	InstanceClass string            `json:"instance_class"`
+	StorageGB     int               `json:"storage_gb"`
+	Replicas      int               `json:"replicas"`
+	MultiAZ       bool              `json:"multi_az"`
+	CostEstimate  string            `json:"cost_estimate"`
+	Customizable  bool              `json:"customizable"`
+	Defaults      map[string]string `json:"defaults,omitempty"`
+}
+
+// ServiceInstance represents a provisioned backing service.
+type ServiceInstance struct {
+	Name        string            `json:"name"`
+	ServiceType string            `json:"service_type"`
+	Plan        string            `json:"plan"`
+	Status      string            `json:"status"`
+	StatusMsg   string            `json:"status_message,omitempty"`
+	ClusterID   string            `json:"cluster_id"`
+	Region      string            `json:"region,omitempty"`
+	Parameters  map[string]string `json:"parameters,omitempty"`
+	Outputs     ServiceOutputs    `json:"outputs,omitempty"`
+	Bindings    []ServiceBinding  `json:"bindings,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// ServiceOutputs holds the provisioned resource connection details.
+type ServiceOutputs struct {
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Database string `json:"database,omitempty"`
+	URI      string `json:"uri,omitempty"`
+}
+
+// ServiceBinding represents a binding between an app and a service instance.
+type ServiceBinding struct {
+	AppName   string    `json:"app_name"`
+	SecretRef string    `json:"secret_ref"`
+	BoundAt   time.Time `json:"bound_at"`
+}
+
+// ServiceListItem is a summary view for list pages.
+type ServiceListItem struct {
+	Name        string    `json:"name"`
+	ServiceType string    `json:"service_type"`
+	Plan        string    `json:"plan"`
+	Status      string    `json:"status"`
+	ClusterID   string    `json:"cluster_id"`
+	BoundApps   int       `json:"bound_apps"`
+	CreatedAt   time.Time `json:"created_at"`
 }

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -27,14 +27,6 @@ type ServiceBindingInfo struct {
 	Status string `json:"status"`
 }
 
-// SecretInfo represents K8s Secret metadata (no values exposed).
-type SecretInfo struct {
-	Name      string `json:"name"`
-	Type      string `json:"type"`
-	KeyCount  int    `json:"key_count"`
-	CreatedAt string `json:"created_at"`
-}
-
 // ServiceType defines a backing service offering in the catalog.
 type ServiceType struct {
 	ID          string        `json:"id"`

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -1,0 +1,317 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	labelManagedBy       = "microfoundry"
+	labelManagedByKey    = "app.kubernetes.io/managed-by"
+	labelSecretType      = "microfoundry.io/secret-type"
+	labelServiceInstance = "microfoundry.io/service-instance"
+	annotationCreatedBy  = "microfoundry.io/created-by"
+	annotationDesc       = "microfoundry.io/description"
+)
+
+// Manager provides a vault-like interface for managing K8s Secrets.
+type Manager struct {
+	k8sClient *k8s.Client
+}
+
+// NewManager creates a new secrets manager.
+func NewManager(client *k8s.Client) *Manager {
+	return &Manager{k8sClient: client}
+}
+
+// List returns all MicroFoundry-managed secrets.
+func (m *Manager) List(ctx context.Context) ([]models.SecretListItem, error) {
+	secrets, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelManagedByKey + "=" + labelManagedBy,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing secrets: %w", err)
+	}
+
+	var items []models.SecretListItem
+	for _, s := range secrets.Items {
+		// Only include MicroFoundry-managed secrets (mf-svc-* or mf-secret-*)
+		if !strings.HasPrefix(s.Name, models.ServiceSecretPrefix) &&
+			!strings.HasPrefix(s.Name, models.UserSecretPrefix) {
+			continue
+		}
+
+		item := models.SecretListItem{
+			K8sName:  s.Name,
+			KeyCount: len(s.Data),
+		}
+
+		// Determine logical name and type
+		if strings.HasPrefix(s.Name, models.ServiceSecretPrefix) {
+			item.Name = strings.TrimPrefix(s.Name, models.ServiceSecretPrefix)
+			item.Type = models.SecretTypeService
+			item.ServiceInstance = s.Labels[labelServiceInstance]
+		} else {
+			item.Name = strings.TrimPrefix(s.Name, models.UserSecretPrefix)
+			item.Type = models.SecretTypeUser
+		}
+
+		// Override type from label if present (for forward compatibility)
+		if t, ok := s.Labels[labelSecretType]; ok {
+			item.Type = t
+		}
+
+		// Read annotations
+		item.Description = s.Annotations[annotationDesc]
+
+		// CreatedAt from K8s metadata
+		item.CreatedAt = s.CreationTimestamp.Time
+
+		// Count bound apps
+		boundApps, err := m.GetBoundApps(ctx, s.Name)
+		if err != nil {
+			log.Printf("warning: could not get bound apps for secret %q: %v", s.Name, err)
+		}
+		item.BoundApps = len(boundApps)
+
+		items = append(items, item)
+	}
+
+	// Sort by creation time descending (newest first)
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
+
+	return items, nil
+}
+
+// Get returns secret metadata, key names (no values), and bound apps.
+func (m *Manager) Get(ctx context.Context, name string) (*models.SecretDetail, error) {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("secret %q not found", name)
+		}
+		return nil, err
+	}
+
+	detail := &models.SecretDetail{
+		K8sName:   secret.Name,
+		KeyCount:  len(secret.Data),
+		CreatedAt: secret.CreationTimestamp.Time,
+	}
+
+	// Determine logical name and type
+	if strings.HasPrefix(secret.Name, models.ServiceSecretPrefix) {
+		detail.Name = strings.TrimPrefix(secret.Name, models.ServiceSecretPrefix)
+		detail.Type = models.SecretTypeService
+		detail.ServiceInstance = secret.Labels[labelServiceInstance]
+	} else if strings.HasPrefix(secret.Name, models.UserSecretPrefix) {
+		detail.Name = strings.TrimPrefix(secret.Name, models.UserSecretPrefix)
+		detail.Type = models.SecretTypeUser
+	} else {
+		detail.Name = secret.Name
+		detail.Type = models.SecretTypeUser
+	}
+
+	// Override type from label if present
+	if t, ok := secret.Labels[labelSecretType]; ok {
+		detail.Type = t
+	}
+
+	detail.Description = secret.Annotations[annotationDesc]
+
+	// Collect key names (sorted)
+	keys := make([]string, 0, len(secret.Data))
+	for k := range secret.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	detail.Keys = keys
+
+	// Bound apps
+	boundApps, err := m.GetBoundApps(ctx, secret.Name)
+	if err != nil {
+		log.Printf("warning: could not get bound apps for secret %q: %v", secret.Name, err)
+	}
+	detail.BoundApps = boundApps
+
+	return detail, nil
+}
+
+// GetValue returns the decoded value of a single key in a secret.
+func (m *Manager) GetValue(ctx context.Context, name, key string) (string, error) {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting secret %q: %w", name, err)
+	}
+
+	val, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret %q", key, name)
+	}
+
+	return string(val), nil
+}
+
+// CreateServiceSecret creates a K8s Secret for a service instance with proper labels.
+func (m *Manager) CreateServiceSecret(ctx context.Context, serviceName string, data map[string]string) error {
+	k8sName := models.ServiceSecretPrefix + serviceName
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: k8sName,
+			Labels: map[string]string{
+				labelManagedByKey:    labelManagedBy,
+				labelSecretType:     models.SecretTypeService,
+				labelServiceInstance: serviceName,
+			},
+			Annotations: map[string]string{
+				annotationCreatedBy: "create-service",
+			},
+		},
+		StringData: data,
+	}
+
+	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			return err
+		}
+		return err
+	}
+
+	// Update existing secret
+	existing.StringData = data
+	// Ensure labels are set (for backward compatibility migration)
+	if existing.Labels == nil {
+		existing.Labels = make(map[string]string)
+	}
+	existing.Labels[labelManagedByKey] = labelManagedBy
+	existing.Labels[labelSecretType] = models.SecretTypeService
+	existing.Labels[labelServiceInstance] = serviceName
+	if existing.Annotations == nil {
+		existing.Annotations = make(map[string]string)
+	}
+	existing.Annotations[annotationCreatedBy] = "create-service"
+
+	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// CreateUserSecret creates a user-defined K8s Secret.
+func (m *Manager) CreateUserSecret(ctx context.Context, name, description string, data map[string]string) error {
+	k8sName := models.UserSecretPrefix + name
+
+	labels := map[string]string{
+		labelManagedByKey: labelManagedBy,
+		labelSecretType:  models.SecretTypeUser,
+	}
+
+	annotations := map[string]string{
+		annotationCreatedBy: "admin-ui",
+	}
+	if description != "" {
+		annotations[annotationDesc] = description
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        k8sName,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		StringData: data,
+	}
+
+	_, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			return fmt.Errorf("secret %q already exists", name)
+		}
+		return err
+	}
+	return nil
+}
+
+// Delete removes a K8s Secret by its logical name.
+func (m *Manager) Delete(ctx context.Context, name string) error {
+	k8sName, err := m.resolveK8sName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, k8sName, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting secret %q: %w", name, err)
+	}
+	return nil
+}
+
+// GetBoundApps lists Deployments whose envFrom references the given K8s Secret name.
+func (m *Manager) GetBoundApps(ctx context.Context, k8sSecretName string) ([]string, error) {
+	deployments, err := m.k8sClient.Clientset.AppsV1().Deployments(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing deployments: %w", err)
+	}
+
+	var apps []string
+	for _, d := range deployments.Items {
+		for _, c := range d.Spec.Template.Spec.Containers {
+			for _, ef := range c.EnvFrom {
+				if ef.SecretRef != nil && ef.SecretRef.Name == k8sSecretName {
+					apps = append(apps, d.Name)
+					break
+				}
+			}
+		}
+	}
+
+	sort.Strings(apps)
+	return apps, nil
+}
+
+// resolveK8sName maps a logical name to the actual K8s Secret name.
+// It tries the service prefix first, then user prefix, then the raw name.
+func (m *Manager) resolveK8sName(ctx context.Context, name string) (string, error) {
+	// If name already has a known prefix, use it directly
+	if strings.HasPrefix(name, models.ServiceSecretPrefix) || strings.HasPrefix(name, models.UserSecretPrefix) {
+		return name, nil
+	}
+
+	// Try service secret first
+	svcName := models.ServiceSecretPrefix + name
+	_, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err == nil {
+		return svcName, nil
+	}
+
+	// Try user-defined secret
+	userName := models.UserSecretPrefix + name
+	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, userName, metav1.GetOptions{})
+	if err == nil {
+		return userName, nil
+	}
+
+	return "", fmt.Errorf("secret %q not found (tried %s and %s)", name, svcName, userName)
+}

--- a/pkg/service/binder.go
+++ b/pkg/service/binder.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Binder handles injecting service credentials into app deployments.
+type Binder struct {
+	k8sClient *k8s.Client
+}
+
+// NewBinder creates a new binder.
+func NewBinder(client *k8s.Client) *Binder {
+	return &Binder{k8sClient: client}
+}
+
+// Bind injects service credentials from a K8s Secret into an app's Deployment as env vars.
+func (b *Binder) Bind(ctx context.Context, appName, secretName string) error {
+	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("deployment %q not found: %w", appName, err)
+	}
+
+	// Add envFrom reference to the service secret
+	envFrom := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+		},
+	}
+
+	// Check if already bound
+	containers := deploy.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return fmt.Errorf("deployment %q has no containers", appName)
+	}
+
+	for _, ef := range containers[0].EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+			return nil // Already bound
+		}
+	}
+
+	deploy.Spec.Template.Spec.Containers[0].EnvFrom = append(
+		deploy.Spec.Template.Spec.Containers[0].EnvFrom,
+		envFrom,
+	)
+
+	// Add annotation
+	if deploy.Spec.Template.Annotations == nil {
+		deploy.Spec.Template.Annotations = make(map[string]string)
+	}
+	existing := deploy.Spec.Template.Annotations["microfoundry.io/bound-services"]
+	if existing != "" {
+		existing += ","
+	}
+	deploy.Spec.Template.Annotations["microfoundry.io/bound-services"] = existing + secretName
+
+	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	return err
+}
+
+// Unbind removes service credentials from an app's Deployment.
+func (b *Binder) Unbind(ctx context.Context, appName, secretName string) error {
+	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("deployment %q not found: %w", appName, err)
+	}
+
+	containers := deploy.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return nil
+	}
+
+	// Remove envFrom reference
+	var updated []corev1.EnvFromSource
+	for _, ef := range containers[0].EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+			continue
+		}
+		updated = append(updated, ef)
+	}
+	deploy.Spec.Template.Spec.Containers[0].EnvFrom = updated
+
+	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -1,0 +1,81 @@
+package service
+
+import "github.com/younjinjeong/microfoundry/pkg/models"
+
+// Catalog returns all available service types.
+func Catalog() []models.ServiceType {
+	return []models.ServiceType{
+		{
+			ID:          "aws-rds-aurora-mariadb",
+			Name:        "AWS RDS Aurora MariaDB",
+			Description: "Managed MySQL-compatible relational database powered by Amazon Aurora",
+			Provider:    "aws",
+			Category:    "database",
+			Tags:        []string{"mysql", "mariadb", "aurora", "rds", "relational"},
+			Plans: []models.ServicePlan{
+				{
+					ID:            "small",
+					Name:          "Small (Dev/Test)",
+					Description:   "Single instance, minimal resources for development and testing",
+					InstanceClass: "db.t4g.micro",
+					StorageGB:     20,
+					Replicas:      0,
+					MultiAZ:       false,
+					CostEstimate:  "~$15/month",
+					Customizable:  false,
+				},
+				{
+					ID:            "medium",
+					Name:          "Medium (UAT/Staging)",
+					Description:   "Moderate resources for UAT and staging environments",
+					InstanceClass: "db.r6g.large",
+					StorageGB:     100,
+					Replicas:      0,
+					MultiAZ:       false,
+					CostEstimate:  "~$200/month",
+					Customizable:  false,
+				},
+				{
+					ID:            "production",
+					Name:          "Production",
+					Description:   "Production-grade with read replicas, Multi-AZ, and customizable sizing",
+					InstanceClass: "db.r6g.xlarge",
+					StorageGB:     200,
+					Replicas:      1,
+					MultiAZ:       true,
+					CostEstimate:  "~$500+/month",
+					Customizable:  true,
+					Defaults: map[string]string{
+						"instance_class": "db.r6g.xlarge",
+						"storage_gb":     "200",
+						"replicas":       "1",
+					},
+				},
+			},
+		},
+	}
+}
+
+// FindServiceType returns a service type by ID.
+func FindServiceType(id string) (models.ServiceType, bool) {
+	for _, st := range Catalog() {
+		if st.ID == id {
+			return st, true
+		}
+	}
+	return models.ServiceType{}, false
+}
+
+// FindPlan returns a plan within a service type.
+func FindPlan(serviceTypeID, planID string) (models.ServicePlan, bool) {
+	st, ok := FindServiceType(serviceTypeID)
+	if !ok {
+		return models.ServicePlan{}, false
+	}
+	for _, p := range st.Plans {
+		if p.ID == planID {
+			return p, true
+		}
+	}
+	return models.ServicePlan{}, false
+}

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/younjinjeong/microfoundry/pkg/k8s"
@@ -15,10 +16,15 @@ import (
 
 const (
 	serviceConfigMapPrefix = "mf-svc-meta-"
-	serviceSecretPrefix    = "mf-svc-"
 	labelManagedBy         = "microfoundry"
 	labelServiceInstance   = "microfoundry.io/service-instance"
+	maxRetries             = 3
 )
+
+// SecretName returns the K8s Secret name for a service instance.
+func SecretName(instanceName string) string {
+	return models.ServiceSecretPrefix + instanceName
+}
 
 // Manager handles service instance lifecycle using K8s as the backing store.
 type Manager struct {
@@ -44,8 +50,12 @@ func (m *Manager) List(ctx context.Context) ([]models.ServiceListItem, error) {
 		var inst models.ServiceInstance
 		if data, ok := cm.Data["instance"]; ok {
 			if err := json.Unmarshal([]byte(data), &inst); err != nil {
+				log.Printf("warning: skipping corrupted service ConfigMap %q: %v", cm.Name, err)
 				continue
 			}
+		} else {
+			log.Printf("warning: service ConfigMap %q missing 'instance' key", cm.Name)
+			continue
 		}
 		items = append(items, models.ServiceListItem{
 			Name:        inst.Name,
@@ -70,15 +80,18 @@ func (m *Manager) Get(ctx context.Context, name string) (*models.ServiceInstance
 		return nil, err
 	}
 
+	data, ok := cm.Data["instance"]
+	if !ok {
+		return nil, fmt.Errorf("service instance %q has corrupted metadata (missing 'instance' key)", name)
+	}
+
 	var inst models.ServiceInstance
-	if data, ok := cm.Data["instance"]; ok {
-		if err := json.Unmarshal([]byte(data), &inst); err != nil {
-			return nil, fmt.Errorf("unmarshalling service instance: %w", err)
-		}
+	if err := json.Unmarshal([]byte(data), &inst); err != nil {
+		return nil, fmt.Errorf("unmarshalling service instance: %w", err)
 	}
 
 	// Load outputs from secret if available
-	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, serviceSecretPrefix+name, metav1.GetOptions{})
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, SecretName(name), metav1.GetOptions{})
 	if err == nil {
 		inst.Outputs = models.ServiceOutputs{
 			Host:     string(secret.Data["host"]),
@@ -88,7 +101,10 @@ func (m *Manager) Get(ctx context.Context, name string) (*models.ServiceInstance
 			URI:      string(secret.Data["uri"]),
 		}
 		if p, ok := secret.Data["port"]; ok {
-			fmt.Sscanf(string(p), "%d", &inst.Outputs.Port)
+			var port int
+			if _, err := fmt.Sscanf(string(p), "%d", &port); err == nil {
+				inst.Outputs.Port = port
+			}
 		}
 	}
 
@@ -123,23 +139,19 @@ func (m *Manager) Create(ctx context.Context, inst *models.ServiceInstance) erro
 	return err
 }
 
-// UpdateStatus updates the status of a service instance.
+// UpdateStatus updates the status of a service instance with conflict retry.
 func (m *Manager) UpdateStatus(ctx context.Context, name, status, msg string) error {
-	inst, err := m.Get(ctx, name)
-	if err != nil {
-		return err
-	}
-	inst.Status = status
-	inst.StatusMsg = msg
-	inst.UpdatedAt = time.Now()
-	return m.save(ctx, inst)
+	return m.retryOnConflict(ctx, name, func(inst *models.ServiceInstance) {
+		inst.Status = status
+		inst.StatusMsg = msg
+	})
 }
 
 // SaveOutputs stores service outputs in a K8s Secret.
 func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.ServiceOutputs) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceSecretPrefix + name,
+			Name: SecretName(name),
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": labelManagedBy,
 				labelServiceInstance:           name,
@@ -155,7 +167,7 @@ func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.S
 		},
 	}
 
-	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, serviceSecretPrefix+name, metav1.GetOptions{})
+	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, SecretName(name), metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
@@ -170,73 +182,76 @@ func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.S
 
 // Delete removes a service instance and its secret.
 func (m *Manager) Delete(ctx context.Context, name string) error {
-	// Delete ConfigMap
-	_ = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Delete(ctx, serviceConfigMapPrefix+name, metav1.DeleteOptions{})
-	// Delete Secret
-	_ = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, serviceSecretPrefix+name, metav1.DeleteOptions{})
+	cmErr := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Delete(ctx, serviceConfigMapPrefix+name, metav1.DeleteOptions{})
+	if cmErr != nil && !errors.IsNotFound(cmErr) {
+		return fmt.Errorf("deleting service ConfigMap: %w", cmErr)
+	}
+	secErr := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, SecretName(name), metav1.DeleteOptions{})
+	if secErr != nil && !errors.IsNotFound(secErr) {
+		return fmt.Errorf("deleting service Secret: %w", secErr)
+	}
 	return nil
 }
 
-// AddBinding adds a binding to a service instance.
+// AddBinding adds a binding to a service instance with conflict retry.
 func (m *Manager) AddBinding(ctx context.Context, serviceName, appName string) error {
-	inst, err := m.Get(ctx, serviceName)
-	if err != nil {
-		return err
-	}
-
-	// Check not already bound
-	for _, b := range inst.Bindings {
-		if b.AppName == appName {
-			return fmt.Errorf("app %q already bound to service %q", appName, serviceName)
-		}
-	}
-
-	inst.Bindings = append(inst.Bindings, models.ServiceBinding{
-		AppName:   appName,
-		SecretRef: serviceSecretPrefix + serviceName,
-		BoundAt:   time.Now(),
+	return m.retryOnConflict(ctx, serviceName, func(inst *models.ServiceInstance) {
+		inst.Bindings = append(inst.Bindings, models.ServiceBinding{
+			AppName:   appName,
+			SecretRef: SecretName(serviceName),
+			BoundAt:   time.Now(),
+		})
 	})
-	inst.UpdatedAt = time.Now()
-	return m.save(ctx, inst)
 }
 
-// RemoveBinding removes a binding from a service instance.
+// RemoveBinding removes a binding from a service instance with conflict retry.
 func (m *Manager) RemoveBinding(ctx context.Context, serviceName, appName string) error {
-	inst, err := m.Get(ctx, serviceName)
-	if err != nil {
-		return err
-	}
-
-	var updated []models.ServiceBinding
-	found := false
-	for _, b := range inst.Bindings {
-		if b.AppName == appName {
-			found = true
-			continue
+	return m.retryOnConflict(ctx, serviceName, func(inst *models.ServiceInstance) {
+		var updated []models.ServiceBinding
+		for _, b := range inst.Bindings {
+			if b.AppName != appName {
+				updated = append(updated, b)
+			}
 		}
-		updated = append(updated, b)
-	}
-	if !found {
-		return fmt.Errorf("app %q not bound to service %q", appName, serviceName)
-	}
-
-	inst.Bindings = updated
-	inst.UpdatedAt = time.Now()
-	return m.save(ctx, inst)
+		inst.Bindings = updated
+	})
 }
 
-func (m *Manager) save(ctx context.Context, inst *models.ServiceInstance) error {
-	data, err := json.Marshal(inst)
-	if err != nil {
-		return err
-	}
+// retryOnConflict performs a read-modify-write with resourceVersion conflict retry.
+func (m *Manager) retryOnConflict(ctx context.Context, name string, mutate func(*models.ServiceInstance)) error {
+	for i := 0; i < maxRetries; i++ {
+		cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 
-	cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+inst.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
+		var inst models.ServiceInstance
+		if data, ok := cm.Data["instance"]; ok {
+			if err := json.Unmarshal([]byte(data), &inst); err != nil {
+				return fmt.Errorf("unmarshalling service instance: %w", err)
+			}
+		} else {
+			return fmt.Errorf("service instance %q has corrupted metadata", name)
+		}
 
-	cm.Data["instance"] = string(data)
-	_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
-	return err
+		mutate(&inst)
+		inst.UpdatedAt = time.Now()
+
+		data, err := json.Marshal(&inst)
+		if err != nil {
+			return err
+		}
+		cm.Data["instance"] = string(data)
+
+		// Update with resourceVersion — K8s rejects if another write happened since our Get
+		_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
+		}
+		// Conflict — retry with fresh read
+	}
+	return fmt.Errorf("conflict: too many retries updating service %q", name)
 }

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	serviceConfigMapPrefix = "mf-svc-meta-"
+	serviceSecretPrefix    = "mf-svc-"
+	labelManagedBy         = "microfoundry"
+	labelServiceInstance   = "microfoundry.io/service-instance"
+)
+
+// Manager handles service instance lifecycle using K8s as the backing store.
+type Manager struct {
+	k8sClient *k8s.Client
+}
+
+// NewManager creates a new service manager.
+func NewManager(client *k8s.Client) *Manager {
+	return &Manager{k8sClient: client}
+}
+
+// List returns all service instances.
+func (m *Manager) List(ctx context.Context) ([]models.ServiceListItem, error) {
+	cms, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/managed-by=" + labelManagedBy + "," + labelServiceInstance,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing service instances: %w", err)
+	}
+
+	var items []models.ServiceListItem
+	for _, cm := range cms.Items {
+		var inst models.ServiceInstance
+		if data, ok := cm.Data["instance"]; ok {
+			if err := json.Unmarshal([]byte(data), &inst); err != nil {
+				continue
+			}
+		}
+		items = append(items, models.ServiceListItem{
+			Name:        inst.Name,
+			ServiceType: inst.ServiceType,
+			Plan:        inst.Plan,
+			Status:      inst.Status,
+			ClusterID:   inst.ClusterID,
+			BoundApps:   len(inst.Bindings),
+			CreatedAt:   inst.CreatedAt,
+		})
+	}
+	return items, nil
+}
+
+// Get returns a single service instance by name.
+func (m *Manager) Get(ctx context.Context, name string) (*models.ServiceInstance, error) {
+	cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("service instance %q not found", name)
+		}
+		return nil, err
+	}
+
+	var inst models.ServiceInstance
+	if data, ok := cm.Data["instance"]; ok {
+		if err := json.Unmarshal([]byte(data), &inst); err != nil {
+			return nil, fmt.Errorf("unmarshalling service instance: %w", err)
+		}
+	}
+
+	// Load outputs from secret if available
+	secret, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, serviceSecretPrefix+name, metav1.GetOptions{})
+	if err == nil {
+		inst.Outputs = models.ServiceOutputs{
+			Host:     string(secret.Data["host"]),
+			Username: string(secret.Data["username"]),
+			Password: string(secret.Data["password"]),
+			Database: string(secret.Data["database"]),
+			URI:      string(secret.Data["uri"]),
+		}
+		if p, ok := secret.Data["port"]; ok {
+			fmt.Sscanf(string(p), "%d", &inst.Outputs.Port)
+		}
+	}
+
+	return &inst, nil
+}
+
+// Create stores a new service instance metadata.
+func (m *Manager) Create(ctx context.Context, inst *models.ServiceInstance) error {
+	inst.CreatedAt = time.Now()
+	inst.UpdatedAt = time.Now()
+	inst.Status = models.ServiceStatusCreating
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceConfigMapPrefix + inst.Name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": labelManagedBy,
+				labelServiceInstance:           inst.Name,
+			},
+		},
+		Data: map[string]string{
+			"instance": string(data),
+		},
+	}
+
+	_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+	return err
+}
+
+// UpdateStatus updates the status of a service instance.
+func (m *Manager) UpdateStatus(ctx context.Context, name, status, msg string) error {
+	inst, err := m.Get(ctx, name)
+	if err != nil {
+		return err
+	}
+	inst.Status = status
+	inst.StatusMsg = msg
+	inst.UpdatedAt = time.Now()
+	return m.save(ctx, inst)
+}
+
+// SaveOutputs stores service outputs in a K8s Secret.
+func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.ServiceOutputs) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceSecretPrefix + name,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": labelManagedBy,
+				labelServiceInstance:           name,
+			},
+		},
+		StringData: map[string]string{
+			"host":     outputs.Host,
+			"port":     fmt.Sprintf("%d", outputs.Port),
+			"username": outputs.Username,
+			"password": outputs.Password,
+			"database": outputs.Database,
+			"uri":      outputs.URI,
+		},
+	}
+
+	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, serviceSecretPrefix+name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
+			return err
+		}
+		return err
+	}
+	existing.StringData = secret.StringData
+	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// Delete removes a service instance and its secret.
+func (m *Manager) Delete(ctx context.Context, name string) error {
+	// Delete ConfigMap
+	_ = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Delete(ctx, serviceConfigMapPrefix+name, metav1.DeleteOptions{})
+	// Delete Secret
+	_ = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, serviceSecretPrefix+name, metav1.DeleteOptions{})
+	return nil
+}
+
+// AddBinding adds a binding to a service instance.
+func (m *Manager) AddBinding(ctx context.Context, serviceName, appName string) error {
+	inst, err := m.Get(ctx, serviceName)
+	if err != nil {
+		return err
+	}
+
+	// Check not already bound
+	for _, b := range inst.Bindings {
+		if b.AppName == appName {
+			return fmt.Errorf("app %q already bound to service %q", appName, serviceName)
+		}
+	}
+
+	inst.Bindings = append(inst.Bindings, models.ServiceBinding{
+		AppName:   appName,
+		SecretRef: serviceSecretPrefix + serviceName,
+		BoundAt:   time.Now(),
+	})
+	inst.UpdatedAt = time.Now()
+	return m.save(ctx, inst)
+}
+
+// RemoveBinding removes a binding from a service instance.
+func (m *Manager) RemoveBinding(ctx context.Context, serviceName, appName string) error {
+	inst, err := m.Get(ctx, serviceName)
+	if err != nil {
+		return err
+	}
+
+	var updated []models.ServiceBinding
+	found := false
+	for _, b := range inst.Bindings {
+		if b.AppName == appName {
+			found = true
+			continue
+		}
+		updated = append(updated, b)
+	}
+	if !found {
+		return fmt.Errorf("app %q not bound to service %q", appName, serviceName)
+	}
+
+	inst.Bindings = updated
+	inst.UpdatedAt = time.Now()
+	return m.save(ctx, inst)
+}
+
+func (m *Manager) save(ctx context.Context, inst *models.ServiceInstance) error {
+	data, err := json.Marshal(inst)
+	if err != nil {
+		return err
+	}
+
+	cm, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Get(ctx, serviceConfigMapPrefix+inst.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	cm.Data["instance"] = string(data)
+	_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/younjinjeong/microfoundry/pkg/k8s"
 	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,11 +30,15 @@ func SecretName(instanceName string) string {
 // Manager handles service instance lifecycle using K8s as the backing store.
 type Manager struct {
 	k8sClient *k8s.Client
+	secrets   *secrets.Manager
 }
 
 // NewManager creates a new service manager.
 func NewManager(client *k8s.Client) *Manager {
-	return &Manager{k8sClient: client}
+	return &Manager{
+		k8sClient: client,
+		secrets:   secrets.NewManager(client),
+	}
 }
 
 // List returns all service instances.
@@ -147,37 +152,17 @@ func (m *Manager) UpdateStatus(ctx context.Context, name, status, msg string) er
 	})
 }
 
-// SaveOutputs stores service outputs in a K8s Secret.
+// SaveOutputs stores service outputs in a K8s Secret via the secrets manager.
 func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.ServiceOutputs) error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: SecretName(name),
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": labelManagedBy,
-				labelServiceInstance:           name,
-			},
-		},
-		StringData: map[string]string{
-			"host":     outputs.Host,
-			"port":     fmt.Sprintf("%d", outputs.Port),
-			"username": outputs.Username,
-			"password": outputs.Password,
-			"database": outputs.Database,
-			"uri":      outputs.URI,
-		},
+	data := map[string]string{
+		"host":     outputs.Host,
+		"port":     fmt.Sprintf("%d", outputs.Port),
+		"username": outputs.Username,
+		"password": outputs.Password,
+		"database": outputs.Database,
+		"uri":      outputs.URI,
 	}
-
-	existing, err := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Get(ctx, SecretName(name), metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Create(ctx, secret, metav1.CreateOptions{})
-			return err
-		}
-		return err
-	}
-	existing.StringData = secret.StringData
-	_, err = m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
-	return err
+	return m.secrets.CreateServiceSecret(ctx, name, data)
 }
 
 // Delete removes a service instance and its secret.
@@ -186,8 +171,7 @@ func (m *Manager) Delete(ctx context.Context, name string) error {
 	if cmErr != nil && !errors.IsNotFound(cmErr) {
 		return fmt.Errorf("deleting service ConfigMap: %w", cmErr)
 	}
-	secErr := m.k8sClient.Clientset.CoreV1().Secrets(m.k8sClient.Namespace).Delete(ctx, SecretName(name), metav1.DeleteOptions{})
-	if secErr != nil && !errors.IsNotFound(secErr) {
+	if secErr := m.secrets.Delete(ctx, name); secErr != nil {
 		return fmt.Errorf("deleting service Secret: %w", secErr)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- **Service Catalog**: Hardcoded catalog with AWS RDS Aurora MariaDB offering 3 plans (small/medium/production) with distinct sizing, replication, and Multi-AZ configurations
- **Service Instance Lifecycle**: K8s ConfigMap (`mf-svc-meta-{name}`) for metadata + K8s Secret (`mf-svc-{name}`) for credentials — no external database required
- **Service Binding**: Injects credentials into app Deployments via `envFrom` SecretRef, with rollback on failure
- **CLI Commands**: `mf marketplace`, `mf create-service`, `mf services`, `mf service`, `mf bind-service`, `mf unbind-service`, `mf delete-service`
- **Admin UI**: Full services list page, service detail page with connection info + binding management, marketplace page with plan cards and inline provisioning forms
- **JSON API**: `/api/services`, `/api/services/{name}`, `/api/marketplace`

## New Files
| File | Description |
|------|-------------|
| `pkg/models/service.go` | ServiceType, ServicePlan, ServiceInstance, ServiceOutputs, ServiceBinding, ServiceListItem models |
| `pkg/service/catalog.go` | Service catalog with AWS RDS Aurora MariaDB (3 plans) |
| `pkg/service/manager.go` | ConfigMap/Secret-based instance lifecycle (CRUD, binding tracking) |
| `pkg/service/binder.go` | Bind/unbind service credentials to app Deployments |
| `cmd/mf/marketplace.go` | CLI: list available services and plans |
| `cmd/mf/create_service.go` | CLI: provision new service instance |
| `cmd/mf/services.go` | CLI: list/detail service instances |
| `cmd/mf/bind_service.go` | CLI: bind service to app |
| `cmd/mf/unbind_service.go` | CLI: unbind service from app |
| `cmd/mf/delete_service.go` | CLI: delete service instance |
| `pkg/admin/service_handlers.go` | Admin handlers for services, marketplace, bind/unbind |
| `pkg/admin/static/templates/services.html` | Services list page (replaces placeholder) |
| `pkg/admin/static/templates/service_detail.html` | Service detail with connection info + bindings |
| `pkg/admin/static/templates/marketplace.html` | Service catalog browser with plan cards |

## Test plan
- [ ] `go build ./cmd/mf` succeeds
- [ ] `go vet ./...` passes
- [ ] `mf marketplace` lists AWS RDS Aurora MariaDB with 3 plans
- [ ] `mf create-service aws-rds-aurora-mariadb small my-db` creates ConfigMap + Secret in K8s
- [ ] `mf services` lists the created service instance
- [ ] `mf service my-db` shows connection details
- [ ] `mf bind-service my-app my-db` injects envFrom SecretRef into Deployment
- [ ] `mf unbind-service my-app my-db` removes envFrom and binding metadata
- [ ] `mf delete-service my-db` removes ConfigMap + Secret
- [ ] Admin UI `/services` shows services list (empty state or populated)
- [ ] Admin UI `/marketplace` shows plan cards with create form
- [ ] Admin UI `/services/{name}` shows detail with connection info, bindings, bind/unbind forms
- [ ] JSON APIs return expected responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)