### PR TITLE
feat: Real K8s service provisioning with VCAP_SERVICES

### DIFF
--- a/cmd/mf/bind_service.go
+++ b/cmd/mf/bind_service.go
@@ -25,7 +25,7 @@ func bindServiceCmd() *cobra.Command {
 			}
 
 			mgr := service.NewManager(k8sClient)
-			binder := service.NewBinder(k8sClient)
+			binder := service.NewBinder(k8sClient, mgr)
 
 			// Verify service exists and is available
 			inst, err := mgr.Get(ctx, svcName)
@@ -43,9 +43,8 @@ func bindServiceCmd() *cobra.Command {
 				return fmt.Errorf("adding binding: %w", err)
 			}
 
-			// Inject credentials into deployment
-			secretName := service.SecretName(svcName)
-			if err := binder.Bind(ctx, appName, secretName); err != nil {
+			// Inject credentials into deployment (envFrom + VCAP_SERVICES)
+			if err := binder.Bind(ctx, appName, svcName); err != nil {
 				// Rollback binding metadata
 				_ = mgr.RemoveBinding(ctx, svcName, appName)
 				return fmt.Errorf("binding to deployment: %w", err)
@@ -53,6 +52,7 @@ func bindServiceCmd() *cobra.Command {
 
 			fmt.Printf("Service '%s' bound to app '%s'.\n", svcName, appName)
 			fmt.Printf("The app will restart to pick up the new environment variables.\n")
+			fmt.Printf("VCAP_SERVICES has been injected with credentials for '%s'.\n", svcName)
 			return nil
 		},
 	}

--- a/cmd/mf/create_service.go
+++ b/cmd/mf/create_service.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/younjinjeong/microfoundry/pkg/models"
@@ -57,47 +56,43 @@ func createServiceCmd() *cobra.Command {
 			}
 
 			fmt.Printf("Creating service instance '%s'...\n", name)
-			fmt.Printf("  Service: %s\n", serviceType)
-			fmt.Printf("  Plan:    %s (%s)\n", plan, planInfo.InstanceClass)
-			fmt.Printf("  Cost:    %s\n", planInfo.CostEstimate)
+			fmt.Printf("  Service:  %s\n", serviceType)
+			fmt.Printf("  Plan:     %s\n", planInfo.Name)
+			fmt.Printf("  Memory:   %dMi\n", planInfo.Resources.MemoryMB)
+			fmt.Printf("  CPU:      %dm\n", planInfo.Resources.CPUMillis)
+			if planInfo.Resources.StorageGB > 0 {
+				fmt.Printf("  Storage:  %dGi\n", planInfo.Resources.StorageGB)
+			}
+			fmt.Printf("  Cost:     %s\n", planInfo.CostEstimate)
 
 			if err := mgr.Create(ctx, inst); err != nil {
 				return fmt.Errorf("creating service: %w", err)
 			}
 
-			// For now, immediately set to available with mock outputs
-			// In production, this would trigger async Terraform apply
-			password := generateCLIPassword(24)
-			outputs := models.ServiceOutputs{
-				Host:     fmt.Sprintf("%s.cluster.local", name),
-				Port:     3306,
-				Username: "admin",
-				Password: password,
-				Database: name,
-				URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
+			// Wait for provisioning to complete
+			fmt.Printf("\nProvisioning")
+			result, err := mgr.WaitForStatus(ctx, name, models.ServiceStatusAvailable, 120*time.Second)
+			fmt.Println()
+
+			if err != nil {
+				return fmt.Errorf("provisioning service: %w", err)
 			}
 
-			if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
-				fmt.Printf("  Warning: could not save outputs: %v\n", err)
-			}
-
-			if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
-				fmt.Printf("  Warning: could not update status: %v\n", err)
+			if result.Status == models.ServiceStatusFailed {
+				return fmt.Errorf("provisioning failed: %s", result.StatusMsg)
 			}
 
 			fmt.Printf("\nService instance '%s' created successfully.\n", name)
-			fmt.Printf("Use 'mf bind-service <app-name> %s' to bind it to an application.\n", name)
+			if result.Outputs.Host != "" {
+				fmt.Printf("  Host: %s\n", result.Outputs.Host)
+			}
+			if result.Outputs.Port > 0 {
+				fmt.Printf("  Port: %d\n", result.Outputs.Port)
+			}
+			fmt.Printf("\nUse 'mf bind-service <app-name> %s' to bind it to an application.\n", name)
 			return nil
 		},
 	}
 
 	return cmd
-}
-
-func generateCLIPassword(length int) string {
-	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		return "fallback-change-me"
-	}
-	return hex.EncodeToString(b)[:length]
 }

--- a/cmd/mf/delete_service.go
+++ b/cmd/mf/delete_service.go
@@ -35,7 +35,7 @@ func deleteServiceCmd() *cobra.Command {
 				return fmt.Errorf("service %q has %d active binding(s) — unbind all apps first", name, len(inst.Bindings))
 			}
 
-			fmt.Printf("Deleting service instance '%s'...\n", name)
+			fmt.Printf("Deleting service instance '%s' (deprovisioning K8s resources)...\n", name)
 
 			if err := mgr.Delete(ctx, name); err != nil {
 				return fmt.Errorf("deleting service: %w", err)

--- a/cmd/mf/marketplace.go
+++ b/cmd/mf/marketplace.go
@@ -20,24 +20,43 @@ func marketplaceCmd() *cobra.Command {
 				return nil
 			}
 
-			for _, svc := range catalog {
-				fmt.Printf("\n%s  (%s)\n", svc.Name, svc.ID)
-				fmt.Printf("  %s\n", svc.Description)
-				fmt.Printf("  Provider: %s  |  Category: %s\n", svc.Provider, svc.Category)
-				fmt.Println()
-				fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n", "PLAN", "INSTANCE", "STORAGE", "REPLICAS", "AZ", "COST")
-				for _, p := range svc.Plans {
-					replicas := "none"
-					if p.Replicas > 0 {
-						replicas = fmt.Sprintf("%d", p.Replicas)
+			// Group by category
+			categories := []struct {
+				name  string
+				label string
+			}{
+				{"database", "Databases"},
+				{"cache", "Caches"},
+				{"messaging", "Messaging"},
+				{"storage", "Storage"},
+				{"gateway", "API Gateways"},
+			}
+
+			for _, cat := range categories {
+				printed := false
+				for _, svc := range catalog {
+					if svc.Category != cat.name {
+						continue
 					}
-					az := "single"
-					if p.MultiAZ {
-						az = "multi"
+					if !printed {
+						fmt.Printf("\n=== %s ===\n", cat.label)
+						printed = true
 					}
-					fmt.Printf("  %-15s %-20s %-10s %-10s %-8s %s\n",
-						p.ID, p.InstanceClass, fmt.Sprintf("%dGB", p.StorageGB),
-						replicas, az, p.CostEstimate)
+					fmt.Printf("\n  %s  (%s)\n", svc.Name, svc.ID)
+					fmt.Printf("    %s\n\n", svc.Description)
+					fmt.Printf("    %-12s %-8s %-8s %-10s %s\n", "PLAN", "MEMORY", "CPU", "STORAGE", "COST")
+					for _, p := range svc.Plans {
+						stor := "—"
+						if p.Resources.StorageGB > 0 {
+							stor = fmt.Sprintf("%dGi", p.Resources.StorageGB)
+						}
+						fmt.Printf("    %-12s %-8s %-8s %-10s %s\n",
+							p.ID,
+							fmt.Sprintf("%dMi", p.Resources.MemoryMB),
+							fmt.Sprintf("%dm", p.Resources.CPUMillis),
+							stor,
+							p.CostEstimate)
+					}
 				}
 			}
 			fmt.Println()

--- a/cmd/mf/unbind_service.go
+++ b/cmd/mf/unbind_service.go
@@ -24,13 +24,12 @@ func unbindServiceCmd() *cobra.Command {
 			}
 
 			mgr := service.NewManager(k8sClient)
-			binder := service.NewBinder(k8sClient)
+			binder := service.NewBinder(k8sClient, mgr)
 
 			fmt.Printf("Unbinding service '%s' from app '%s'...\n", svcName, appName)
 
-			// Remove credentials from deployment
-			secretName := service.SecretName(svcName)
-			if err := binder.Unbind(ctx, appName, secretName); err != nil {
+			// Remove credentials from deployment (envFrom + VCAP_SERVICES)
+			if err := binder.Unbind(ctx, appName, svcName); err != nil {
 				return fmt.Errorf("unbinding from deployment: %w", err)
 			}
 

--- a/pkg/admin/service_handlers.go
+++ b/pkg/admin/service_handlers.go
@@ -1,8 +1,6 @@
 package admin
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -10,15 +8,6 @@ import (
 	"github.com/younjinjeong/microfoundry/pkg/models"
 	"github.com/younjinjeong/microfoundry/pkg/service"
 )
-
-// generatePassword returns a cryptographically random hex password.
-func generatePassword(length int) string {
-	b := make([]byte, length)
-	if _, err := rand.Read(b); err != nil {
-		return "fallback-change-me" // should never happen
-	}
-	return hex.EncodeToString(b)[:length]
-}
 
 // ServicesListHandler shows all provisioned service instances.
 func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
@@ -138,23 +127,7 @@ func (s *Server) CreateServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mock outputs with per-instance random password (will be replaced by Terraform)
-	password := generatePassword(24)
-	outputs := models.ServiceOutputs{
-		Host:     fmt.Sprintf("%s.cluster.local", name),
-		Port:     3306,
-		Username: "admin",
-		Password: password,
-		Database: name,
-		URI:      fmt.Sprintf("mysql://admin:%s@%s.cluster.local:3306/%s", password, name, name),
-	}
-	if err := mgr.SaveOutputs(ctx, name, outputs); err != nil {
-		log.Printf("error saving service outputs for %q: %v", name, err)
-	}
-	if err := mgr.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
-		log.Printf("error updating service status for %q: %v", name, err)
-	}
-
+	// Provisioning happens async in manager.Create — redirect to detail page
 	w.Header().Set("HX-Redirect", "/services/"+name)
 	w.WriteHeader(http.StatusOK)
 }
@@ -177,7 +150,7 @@ func (s *Server) BindServiceHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mgr := service.NewManager(client)
-	binder := service.NewBinder(client)
+	binder := service.NewBinder(client, mgr)
 
 	inst, err := mgr.Get(ctx, name)
 	if err != nil {
@@ -194,8 +167,7 @@ func (s *Server) BindServiceHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secretName := service.SecretName(name)
-	if err := binder.Bind(ctx, appName, secretName); err != nil {
+	if err := binder.Bind(ctx, appName, name); err != nil {
 		_ = mgr.RemoveBinding(ctx, name, appName)
 		http.Error(w, "binding to deployment: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -223,10 +195,9 @@ func (s *Server) UnbindServiceHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mgr := service.NewManager(client)
-	binder := service.NewBinder(client)
+	binder := service.NewBinder(client, mgr)
 
-	secretName := service.SecretName(name)
-	if err := binder.Unbind(ctx, appName, secretName); err != nil {
+	if err := binder.Unbind(ctx, appName, name); err != nil {
 		http.Error(w, "unbinding from deployment: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/admin/static/templates/marketplace.html
+++ b/pkg/admin/static/templates/marketplace.html
@@ -9,26 +9,34 @@
 </div>
 
 {{with .Content}}
-{{range .Catalog}}
-<div class="bg-white rounded-lg shadow mb-8">
-    <!-- Service Type Header -->
+
+{{/* Group services by category */}}
+{{$catalog := .Catalog}}
+
+{{/* Database Category */}}
+{{range $catalog}}{{if eq .Category "database"}}{{if eq .ID "mariadb"}}
+<div class="mb-8">
+    <div class="flex items-center space-x-2 mb-4">
+        <div class="w-8 h-8 rounded-lg bg-blue-100 flex items-center justify-center">
+            <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
+            </svg>
+        </div>
+        <h3 class="text-md font-semibold text-gray-900 uppercase tracking-wide">Databases</h3>
+    </div>
+{{end}}{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "database"}}
+<div class="bg-white rounded-lg shadow mb-4">
     <div class="px-6 py-4 border-b border-gray-200">
         <div class="flex items-center justify-between">
             <div class="flex items-center space-x-3">
-                <div class="w-10 h-10 rounded-lg bg-orange-100 flex items-center justify-center">
-                    <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
-                    </svg>
-                </div>
                 <div>
                     <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
                     <p class="text-sm text-gray-500">{{.Description}}</p>
                 </div>
             </div>
-            <div class="flex items-center space-x-2">
-                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">{{.Provider}}</span>
-                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{.Category}}</span>
-            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">{{.Category}}</span>
         </div>
         {{if .Tags}}
         <div class="mt-2 flex flex-wrap gap-1">
@@ -38,47 +46,34 @@
         </div>
         {{end}}
     </div>
-
-    <!-- Plans -->
     <div class="p-6">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             {{$svcID := .ID}}
             {{range .Plans}}
             <div class="border border-gray-200 rounded-lg p-5 hover:border-blue-300 hover:shadow-sm transition-all">
-                <div class="flex justify-between items-start mb-3">
-                    <div>
-                        <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
-                        <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
-                    </div>
+                <div class="mb-3">
+                    <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                    <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
                 </div>
-
                 <dl class="space-y-2 text-sm mb-4">
                     <div class="flex justify-between">
-                        <dt class="text-gray-500">Instance</dt>
-                        <dd class="font-mono text-gray-900 text-xs">{{.InstanceClass}}</dd>
+                        <dt class="text-gray-500">Memory</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.MemoryMB}}Mi</dd>
                     </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CPU</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.CPUMillis}}m</dd>
+                    </div>
+                    {{if .Resources.StorageGB}}
                     <div class="flex justify-between">
                         <dt class="text-gray-500">Storage</dt>
-                        <dd class="text-gray-900">{{.StorageGB}} GB</dd>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.StorageGB}}Gi</dd>
                     </div>
-                    <div class="flex justify-between">
-                        <dt class="text-gray-500">Replicas</dt>
-                        <dd class="text-gray-900">{{if .Replicas}}{{.Replicas}}{{else}}None{{end}}</dd>
-                    </div>
-                    <div class="flex justify-between">
-                        <dt class="text-gray-500">Multi-AZ</dt>
-                        <dd class="text-gray-900">{{if .MultiAZ}}Yes{{else}}No{{end}}</dd>
-                    </div>
+                    {{end}}
                 </dl>
-
                 <div class="flex justify-between items-center pt-3 border-t border-gray-100">
                     <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
-                    {{if .Customizable}}
-                    <span class="text-xs text-blue-600">Customizable</span>
-                    {{end}}
                 </div>
-
-                <!-- Create Service Form (inline) -->
                 <div class="mt-4">
                     <form hx-post="/services/create" hx-swap="none" class="space-y-2">
                         <input type="hidden" name="service_type" value="{{$svcID}}">
@@ -96,6 +91,313 @@
         </div>
     </div>
 </div>
-{{end}}
+{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "database"}}{{if eq .ID "mariadb"}}
+</div>
+{{end}}{{end}}{{end}}
+
+{{/* Cache Category */}}
+{{range $catalog}}{{if eq .Category "cache"}}{{if eq .ID "redis"}}
+<div class="mb-8">
+    <div class="flex items-center space-x-2 mb-4">
+        <div class="w-8 h-8 rounded-lg bg-red-100 flex items-center justify-center">
+            <svg class="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+            </svg>
+        </div>
+        <h3 class="text-md font-semibold text-gray-900 uppercase tracking-wide">Caches</h3>
+    </div>
+{{end}}{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "cache"}}
+<div class="bg-white rounded-lg shadow mb-4">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div>
+                <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                <p class="text-sm text-gray-500">{{.Description}}</p>
+            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">{{.Category}}</span>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>{{end}}
+        </div>
+        {{end}}
+    </div>
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-red-300 hover:shadow-sm transition-all">
+                <div class="mb-3">
+                    <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                    <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                </div>
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Memory</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.MemoryMB}}Mi</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CPU</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.CPUMillis}}m</dd>
+                    </div>
+                </dl>
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                </div>
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-cache)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "cache"}}{{if eq .ID "redis"}}
+</div>
+{{end}}{{end}}{{end}}
+
+{{/* Messaging Category */}}
+{{range $catalog}}{{if eq .Category "messaging"}}{{if eq .ID "rabbitmq"}}
+<div class="mb-8">
+    <div class="flex items-center space-x-2 mb-4">
+        <div class="w-8 h-8 rounded-lg bg-orange-100 flex items-center justify-center">
+            <svg class="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+            </svg>
+        </div>
+        <h3 class="text-md font-semibold text-gray-900 uppercase tracking-wide">Messaging</h3>
+    </div>
+{{end}}{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "messaging"}}
+<div class="bg-white rounded-lg shadow mb-4">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div>
+                <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                <p class="text-sm text-gray-500">{{.Description}}</p>
+            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">{{.Category}}</span>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>{{end}}
+        </div>
+        {{end}}
+    </div>
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-orange-300 hover:shadow-sm transition-all">
+                <div class="mb-3">
+                    <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                    <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                </div>
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Memory</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.MemoryMB}}Mi</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CPU</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.CPUMillis}}m</dd>
+                    </div>
+                </dl>
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                </div>
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-queue)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-orange-600 text-white rounded-md hover:bg-orange-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "messaging"}}{{if eq .ID "rabbitmq"}}
+</div>
+{{end}}{{end}}{{end}}
+
+{{/* Storage Category */}}
+{{range $catalog}}{{if eq .Category "storage"}}{{if eq .ID "minio"}}
+<div class="mb-8">
+    <div class="flex items-center space-x-2 mb-4">
+        <div class="w-8 h-8 rounded-lg bg-green-100 flex items-center justify-center">
+            <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+            </svg>
+        </div>
+        <h3 class="text-md font-semibold text-gray-900 uppercase tracking-wide">Storage</h3>
+    </div>
+{{end}}{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "storage"}}
+<div class="bg-white rounded-lg shadow mb-4">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div>
+                <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                <p class="text-sm text-gray-500">{{.Description}}</p>
+            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">{{.Category}}</span>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>{{end}}
+        </div>
+        {{end}}
+    </div>
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-green-300 hover:shadow-sm transition-all">
+                <div class="mb-3">
+                    <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                    <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                </div>
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Memory</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.MemoryMB}}Mi</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CPU</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.CPUMillis}}m</dd>
+                    </div>
+                    {{if .Resources.StorageGB}}
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Storage</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.StorageGB}}Gi</dd>
+                    </div>
+                    {{end}}
+                </dl>
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                </div>
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-store)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "storage"}}{{if eq .ID "minio"}}
+</div>
+{{end}}{{end}}{{end}}
+
+{{/* Gateway Category */}}
+{{range $catalog}}{{if eq .Category "gateway"}}{{if eq .ID "kong"}}
+<div class="mb-8">
+    <div class="flex items-center space-x-2 mb-4">
+        <div class="w-8 h-8 rounded-lg bg-purple-100 flex items-center justify-center">
+            <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/>
+            </svg>
+        </div>
+        <h3 class="text-md font-semibold text-gray-900 uppercase tracking-wide">API Gateways</h3>
+    </div>
+{{end}}{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "gateway"}}
+<div class="bg-white rounded-lg shadow mb-4">
+    <div class="px-6 py-4 border-b border-gray-200">
+        <div class="flex items-center justify-between">
+            <div>
+                <h3 class="text-lg font-semibold text-gray-900">{{.Name}}</h3>
+                <p class="text-sm text-gray-500">{{.Description}}</p>
+            </div>
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">{{.Category}}</span>
+        </div>
+        {{if .Tags}}
+        <div class="mt-2 flex flex-wrap gap-1">
+            {{range .Tags}}<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">{{.}}</span>{{end}}
+        </div>
+        {{end}}
+    </div>
+    <div class="p-6">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{$svcID := .ID}}
+            {{range .Plans}}
+            <div class="border border-gray-200 rounded-lg p-5 hover:border-purple-300 hover:shadow-sm transition-all">
+                <div class="mb-3">
+                    <h4 class="text-sm font-semibold text-gray-900">{{.Name}}</h4>
+                    <p class="text-xs text-gray-500 mt-1">{{.Description}}</p>
+                </div>
+                <dl class="space-y-2 text-sm mb-4">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Memory</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.MemoryMB}}Mi</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CPU</dt>
+                        <dd class="font-mono text-gray-900 text-xs">{{.Resources.CPUMillis}}m</dd>
+                    </div>
+                </dl>
+                <div class="flex justify-between items-center pt-3 border-t border-gray-100">
+                    <span class="text-sm font-semibold text-gray-900">{{.CostEstimate}}</span>
+                </div>
+                <div class="mt-4">
+                    <form hx-post="/services/create" hx-swap="none" class="space-y-2">
+                        <input type="hidden" name="service_type" value="{{$svcID}}">
+                        <input type="hidden" name="plan" value="{{.ID}}">
+                        <input type="text" name="name" placeholder="Instance name (e.g., my-gw)"
+                               required pattern="[a-z0-9][a-z0-9-]*"
+                               class="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit" class="w-full px-3 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 text-sm font-medium">
+                            Create Instance
+                        </button>
+                    </form>
+                </div>
+            </div>
+            {{end}}
+        </div>
+    </div>
+</div>
+{{end}}{{end}}
+
+{{range $catalog}}{{if eq .Category "gateway"}}{{if eq .ID "kong"}}
+</div>
+{{end}}{{end}}{{end}}
+
 {{end}}
 {{end}}

--- a/pkg/admin/static/templates/service_detail.html
+++ b/pkg/admin/static/templates/service_detail.html
@@ -26,7 +26,7 @@
         <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{stateBg $inst.Status}}">{{$inst.Status}}</span>
         {{if eq (len $inst.Bindings) 0}}
         <button hx-delete="/services/{{$inst.Name}}"
-                hx-confirm="Delete service '{{$inst.Name}}'? This cannot be undone."
+                hx-confirm="Delete service '{{$inst.Name}}'? This will deprovision K8s resources."
                 class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
             Delete
         </button>
@@ -62,30 +62,22 @@
                         <dt class="text-xs font-medium text-gray-500 uppercase">Created</dt>
                         <dd class="mt-1 text-sm text-gray-900">{{timeAgo $inst.CreatedAt}}</dd>
                     </div>
-                    {{if $plan.InstanceClass}}
+                    {{if $plan.Resources.MemoryMB}}
                     <div>
-                        <dt class="text-xs font-medium text-gray-500 uppercase">Instance Class</dt>
-                        <dd class="mt-1 text-sm text-gray-900">{{$plan.InstanceClass}}</dd>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">Memory</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Resources.MemoryMB}}Mi</dd>
                     </div>
                     {{end}}
-                    {{if $plan.StorageGB}}
+                    {{if $plan.Resources.CPUMillis}}
+                    <div>
+                        <dt class="text-xs font-medium text-gray-500 uppercase">CPU</dt>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Resources.CPUMillis}}m</dd>
+                    </div>
+                    {{end}}
+                    {{if $plan.Resources.StorageGB}}
                     <div>
                         <dt class="text-xs font-medium text-gray-500 uppercase">Storage</dt>
-                        <dd class="mt-1 text-sm text-gray-900">{{$plan.StorageGB}} GB</dd>
-                    </div>
-                    {{end}}
-                    {{if $plan.MultiAZ}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 uppercase">Multi-AZ</dt>
-                        <dd class="mt-1 text-sm text-gray-900">
-                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Enabled</span>
-                        </dd>
-                    </div>
-                    {{end}}
-                    {{if $plan.Replicas}}
-                    <div>
-                        <dt class="text-xs font-medium text-gray-500 uppercase">Read Replicas</dt>
-                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Replicas}}</dd>
+                        <dd class="mt-1 text-sm text-gray-900">{{$plan.Resources.StorageGB}}Gi</dd>
                     </div>
                     {{end}}
                     {{if $plan.CostEstimate}}
@@ -117,14 +109,18 @@
                         <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Port}}</dd>
                     </div>
                     {{end}}
+                    {{if $inst.Outputs.Database}}
                     <div class="flex">
                         <dt class="w-24 text-sm font-medium text-gray-500">Database</dt>
                         <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Database}}</dd>
                     </div>
+                    {{end}}
+                    {{if $inst.Outputs.Username}}
                     <div class="flex">
                         <dt class="w-24 text-sm font-medium text-gray-500">Username</dt>
                         <dd class="text-sm text-gray-900 font-mono">{{$inst.Outputs.Username}}</dd>
                     </div>
+                    {{end}}
                     <div class="flex">
                         <dt class="w-24 text-sm font-medium text-gray-500">Password</dt>
                         <dd class="text-sm text-gray-400 italic">********</dd>
@@ -135,7 +131,30 @@
                         <dd class="text-sm text-gray-400 italic">****hidden****</dd>
                     </div>
                     {{end}}
+                    {{range $key, $val := $inst.Outputs.Extra}}
+                    <div class="flex">
+                        <dt class="w-24 text-sm font-medium text-gray-500">{{$key}}</dt>
+                        <dd class="text-sm text-gray-900 font-mono">{{$val}}</dd>
+                    </div>
+                    {{end}}
                 </dl>
+            </div>
+        </div>
+        {{end}}
+
+        <!-- VCAP_SERVICES Preview -->
+        {{if $inst.Bindings}}
+        <div class="bg-white rounded-lg shadow">
+            <div class="px-6 py-4 border-b border-gray-200">
+                <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">VCAP_SERVICES</h3>
+            </div>
+            <div class="px-6 py-4">
+                <p class="text-sm text-gray-500 mb-3">
+                    This service is injected into bound applications via the <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">VCAP_SERVICES</code> environment variable (CloudFoundry compatible).
+                </p>
+                <div class="bg-gray-50 rounded-md p-4">
+                    <pre class="text-xs text-gray-700 font-mono overflow-x-auto">{"{{$inst.ServiceType}}": [{"name": "{{$inst.Name}}", "label": "{{$inst.ServiceType}}", "plan": "{{$inst.Plan}}", "credentials": {"host": "...", "port": "...", ...}}]}</pre>
+                </div>
             </div>
         </div>
         {{end}}

--- a/pkg/admin/static/templates/services.html
+++ b/pkg/admin/static/templates/services.html
@@ -50,7 +50,7 @@
                     <button hx-delete="/services/{{.Name}}"
                             hx-target="#svc-row-{{.Name}}"
                             hx-swap="outerHTML swap:0.3s"
-                            hx-confirm="Delete service '{{.Name}}'? This cannot be undone."
+                            hx-confirm="Delete service '{{.Name}}'? This will deprovision the K8s resources."
                             class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
                 </td>
             </tr>
@@ -65,7 +65,7 @@
     </svg>
     <h3 class="text-xl font-bold text-gray-900 mt-2">No Services Provisioned</h3>
     <p class="text-gray-500 mt-2 max-w-md mx-auto">
-        You haven't created any backing services yet. Browse the marketplace to provision databases, caches, and more.
+        You haven't created any backing services yet. Browse the marketplace to provision databases, caches, message queues, and more.
     </p>
     <div class="mt-6">
         <a href="/marketplace" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -34,22 +34,25 @@ type ServiceType struct {
 	Description string        `json:"description"`
 	Provider    string        `json:"provider"`
 	Category    string        `json:"category"`
+	Label       string        `json:"label"` // VCAP_SERVICES label (e.g., "mariadb")
 	Plans       []ServicePlan `json:"plans"`
 	Tags        []string      `json:"tags,omitempty"`
 }
 
 // ServicePlan defines a sizing tier within a service type.
 type ServicePlan struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	Description   string            `json:"description"`
-	InstanceClass string            `json:"instance_class"`
-	StorageGB     int               `json:"storage_gb"`
-	Replicas      int               `json:"replicas"`
-	MultiAZ       bool              `json:"multi_az"`
-	CostEstimate  string            `json:"cost_estimate"`
-	Customizable  bool              `json:"customizable"`
-	Defaults      map[string]string `json:"defaults,omitempty"`
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	Description  string        `json:"description"`
+	Resources    PlanResources `json:"resources"`
+	CostEstimate string        `json:"cost_estimate"`
+}
+
+// PlanResources defines K8s resource allocation for a service plan.
+type PlanResources struct {
+	MemoryMB  int `json:"memory_mb"`  // container memory limit in MiB
+	CPUMillis int `json:"cpu_millis"` // container CPU request in millicores
+	StorageGB int `json:"storage_gb"` // PVC size in GiB, 0 = no PVC
 }
 
 // ServiceInstance represents a provisioned backing service.
@@ -77,12 +80,13 @@ func (si *ServiceInstance) Redacted() ServiceInstance {
 
 // ServiceOutputs holds the provisioned resource connection details.
 type ServiceOutputs struct {
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Database string `json:"database,omitempty"`
-	URI      string `json:"uri,omitempty"`
+	Host     string            `json:"host,omitempty"`
+	Port     int               `json:"port,omitempty"`
+	Username string            `json:"username,omitempty"`
+	Password string            `json:"password,omitempty"`
+	Database string            `json:"database,omitempty"`
+	URI      string            `json:"uri,omitempty"`
+	Extra    map[string]string `json:"extra,omitempty"` // service-specific: access_key, bucket, mgmt_url, etc.
 }
 
 // Redacted returns a copy with password and URI masked.

--- a/pkg/service/binder.go
+++ b/pkg/service/binder.go
@@ -3,89 +3,197 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Binder handles injecting service credentials into app deployments.
 type Binder struct {
-	k8sClient *k8s.Client
+	k8sClient  *k8s.Client
+	mgr        *Manager
+	secretsMgr *secrets.Manager
 }
 
-// NewBinder creates a new binder.
-func NewBinder(client *k8s.Client) *Binder {
-	return &Binder{k8sClient: client}
+// NewBinder creates a new binder with VCAP_SERVICES support.
+func NewBinder(client *k8s.Client, mgr *Manager) *Binder {
+	return &Binder{
+		k8sClient:  client,
+		mgr:        mgr,
+		secretsMgr: mgr.SecretsManager(),
+	}
 }
 
-// Bind injects service credentials from a K8s Secret into an app's Deployment as env vars.
-func (b *Binder) Bind(ctx context.Context, appName, secretName string) error {
-	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("deployment %q not found: %w", appName, err)
-	}
+// Bind injects service credentials from a K8s Secret into an app's Deployment as env vars
+// and builds/updates the VCAP_SERVICES env var. Retries on conflict.
+func (b *Binder) Bind(ctx context.Context, appName, serviceName string) error {
+	secretName := SecretName(serviceName)
 
-	// Add envFrom reference to the service secret
-	envFrom := corev1.EnvFromSource{
-		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
-		},
-	}
+	for i := 0; i < maxRetries; i++ {
+		deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("deployment %q not found: %w", appName, err)
+		}
 
-	// Check if already bound
-	containers := deploy.Spec.Template.Spec.Containers
-	if len(containers) == 0 {
-		return fmt.Errorf("deployment %q has no containers", appName)
-	}
+		containers := deploy.Spec.Template.Spec.Containers
+		if len(containers) == 0 {
+			return fmt.Errorf("deployment %q has no containers", appName)
+		}
 
-	for _, ef := range containers[0].EnvFrom {
-		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
-			return nil // Already bound
+		// Add envFrom reference to the service secret (idempotent)
+		envFrom := corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			},
+		}
+
+		alreadyBound := false
+		for _, ef := range containers[0].EnvFrom {
+			if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+				alreadyBound = true
+				break
+			}
+		}
+		if !alreadyBound {
+			deploy.Spec.Template.Spec.Containers[0].EnvFrom = append(
+				deploy.Spec.Template.Spec.Containers[0].EnvFrom,
+				envFrom,
+			)
+		}
+
+		// Update bound services annotation
+		if deploy.Spec.Template.Annotations == nil {
+			deploy.Spec.Template.Annotations = make(map[string]string)
+		}
+		boundServices := parseBoundServices(deploy.Spec.Template.Annotations["microfoundry.io/bound-services"])
+		if !contains(boundServices, serviceName) {
+			boundServices = append(boundServices, serviceName)
+		}
+		deploy.Spec.Template.Annotations["microfoundry.io/bound-services"] = strings.Join(boundServices, ",")
+
+		// Build VCAP_SERVICES from all bound services
+		vcapJSON, err := BuildVCAPServices(ctx, b.mgr, b.secretsMgr, boundServices)
+		if err != nil {
+			return fmt.Errorf("building VCAP_SERVICES: %w", err)
+		}
+		setEnvVar(&deploy.Spec.Template.Spec.Containers[0], "VCAP_SERVICES", vcapJSON)
+
+		_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
 		}
 	}
-
-	deploy.Spec.Template.Spec.Containers[0].EnvFrom = append(
-		deploy.Spec.Template.Spec.Containers[0].EnvFrom,
-		envFrom,
-	)
-
-	// Add annotation
-	if deploy.Spec.Template.Annotations == nil {
-		deploy.Spec.Template.Annotations = make(map[string]string)
-	}
-	existing := deploy.Spec.Template.Annotations["microfoundry.io/bound-services"]
-	if existing != "" {
-		existing += ","
-	}
-	deploy.Spec.Template.Annotations["microfoundry.io/bound-services"] = existing + secretName
-
-	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
-	return err
+	return fmt.Errorf("conflict: too many retries updating deployment %q", appName)
 }
 
-// Unbind removes service credentials from an app's Deployment.
-func (b *Binder) Unbind(ctx context.Context, appName, secretName string) error {
-	deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("deployment %q not found: %w", appName, err)
-	}
+// Unbind removes service credentials from an app's Deployment and rebuilds VCAP_SERVICES.
+// Retries on conflict.
+func (b *Binder) Unbind(ctx context.Context, appName, serviceName string) error {
+	secretName := SecretName(serviceName)
 
-	containers := deploy.Spec.Template.Spec.Containers
-	if len(containers) == 0 {
+	for i := 0; i < maxRetries; i++ {
+		deploy, err := b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Get(ctx, appName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("deployment %q not found: %w", appName, err)
+		}
+
+		containers := deploy.Spec.Template.Spec.Containers
+		if len(containers) == 0 {
+			return nil
+		}
+
+		// Remove envFrom reference
+		var updated []corev1.EnvFromSource
+		for _, ef := range containers[0].EnvFrom {
+			if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
+				continue
+			}
+			updated = append(updated, ef)
+		}
+		deploy.Spec.Template.Spec.Containers[0].EnvFrom = updated
+
+		// Update bound services annotation
+		if deploy.Spec.Template.Annotations == nil {
+			deploy.Spec.Template.Annotations = make(map[string]string)
+		}
+		boundServices := parseBoundServices(deploy.Spec.Template.Annotations["microfoundry.io/bound-services"])
+		var remaining []string
+		for _, s := range boundServices {
+			if s != serviceName {
+				remaining = append(remaining, s)
+			}
+		}
+
+		if len(remaining) > 0 {
+			deploy.Spec.Template.Annotations["microfoundry.io/bound-services"] = strings.Join(remaining, ",")
+			vcapJSON, err := BuildVCAPServices(ctx, b.mgr, b.secretsMgr, remaining)
+			if err != nil {
+				return fmt.Errorf("building VCAP_SERVICES: %w", err)
+			}
+			setEnvVar(&deploy.Spec.Template.Spec.Containers[0], "VCAP_SERVICES", vcapJSON)
+		} else {
+			delete(deploy.Spec.Template.Annotations, "microfoundry.io/bound-services")
+			removeEnvVar(&deploy.Spec.Template.Spec.Containers[0], "VCAP_SERVICES")
+		}
+
+		_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !errors.IsConflict(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("conflict: too many retries updating deployment %q", appName)
+}
+
+func parseBoundServices(annotation string) []string {
+	if annotation == "" {
 		return nil
 	}
-
-	// Remove envFrom reference
-	var updated []corev1.EnvFromSource
-	for _, ef := range containers[0].EnvFrom {
-		if ef.SecretRef != nil && ef.SecretRef.Name == secretName {
-			continue
+	var services []string
+	for _, s := range strings.Split(annotation, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			s = strings.TrimPrefix(s, "mf-svc-")
+			services = append(services, s)
 		}
-		updated = append(updated, ef)
 	}
-	deploy.Spec.Template.Spec.Containers[0].EnvFrom = updated
+	return services
+}
 
-	_, err = b.k8sClient.Clientset.AppsV1().Deployments(b.k8sClient.Namespace).Update(ctx, deploy, metav1.UpdateOptions{})
-	return err
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func setEnvVar(container *corev1.Container, name, value string) {
+	for i, e := range container.Env {
+		if e.Name == name {
+			container.Env[i].Value = value
+			return
+		}
+	}
+	container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: value})
+}
+
+func removeEnvVar(container *corev1.Container, name string) {
+	var updated []corev1.EnvVar
+	for _, e := range container.Env {
+		if e.Name != name {
+			updated = append(updated, e)
+		}
+	}
+	container.Env = updated
 }

--- a/pkg/service/catalog.go
+++ b/pkg/service/catalog.go
@@ -2,57 +2,139 @@ package service
 
 import "github.com/younjinjeong/microfoundry/pkg/models"
 
-// Catalog returns all available service types.
+// Catalog returns all available service types grouped by category.
 func Catalog() []models.ServiceType {
 	return []models.ServiceType{
+		// Database
 		{
-			ID:          "aws-rds-aurora-mariadb",
-			Name:        "AWS RDS Aurora MariaDB",
-			Description: "Managed MySQL-compatible relational database powered by Amazon Aurora",
-			Provider:    "aws",
-			Category:    "database",
-			Tags:        []string{"mysql", "mariadb", "aurora", "rds", "relational"},
-			Plans: []models.ServicePlan{
-				{
-					ID:            "small",
-					Name:          "Small (Dev/Test)",
-					Description:   "Single instance, minimal resources for development and testing",
-					InstanceClass: "db.t4g.micro",
-					StorageGB:     20,
-					Replicas:      0,
-					MultiAZ:       false,
-					CostEstimate:  "~$15/month",
-					Customizable:  false,
-				},
-				{
-					ID:            "medium",
-					Name:          "Medium (UAT/Staging)",
-					Description:   "Moderate resources for UAT and staging environments",
-					InstanceClass: "db.r6g.large",
-					StorageGB:     100,
-					Replicas:      0,
-					MultiAZ:       false,
-					CostEstimate:  "~$200/month",
-					Customizable:  false,
-				},
-				{
-					ID:            "production",
-					Name:          "Production",
-					Description:   "Production-grade with read replicas, Multi-AZ, and customizable sizing",
-					InstanceClass: "db.r6g.xlarge",
-					StorageGB:     200,
-					Replicas:      1,
-					MultiAZ:       true,
-					CostEstimate:  "~$500+/month",
-					Customizable:  true,
-					Defaults: map[string]string{
-						"instance_class": "db.r6g.xlarge",
-						"storage_gb":     "200",
-						"replicas":       "1",
-					},
-				},
-			},
+			ID: "mariadb", Name: "MariaDB", Label: "mariadb",
+			Description: "Open-source relational database, MySQL-compatible",
+			Provider: "local", Category: "database",
+			Tags:  []string{"mysql", "mariadb", "relational", "database"},
+			Plans: dbPlans("MariaDB"),
 		},
+		{
+			ID: "postgresql", Name: "PostgreSQL", Label: "postgresql",
+			Description: "Advanced open-source relational database",
+			Provider: "local", Category: "database",
+			Tags:  []string{"postgresql", "postgres", "relational", "database"},
+			Plans: dbPlans("PostgreSQL"),
+		},
+		{
+			ID: "clickhouse", Name: "ClickHouse", Label: "clickhouse",
+			Description: "Column-oriented OLAP database for real-time analytics",
+			Provider: "local", Category: "database",
+			Tags:  []string{"clickhouse", "analytics", "columnar", "database"},
+			Plans: dbPlans("ClickHouse"),
+		},
+		// Cache
+		{
+			ID: "redis", Name: "Redis", Label: "redis",
+			Description: "In-memory data store for caching, sessions, and pub/sub",
+			Provider: "local", Category: "cache",
+			Tags:  []string{"redis", "cache", "key-value", "in-memory"},
+			Plans: cachePlans("Redis"),
+		},
+		{
+			ID: "memcached", Name: "Memcached", Label: "memcached",
+			Description: "High-performance distributed memory caching system",
+			Provider: "local", Category: "cache",
+			Tags:  []string{"memcached", "cache", "key-value", "in-memory"},
+			Plans: cachePlans("Memcached"),
+		},
+		// Messaging
+		{
+			ID: "rabbitmq", Name: "RabbitMQ", Label: "rabbitmq",
+			Description: "Open-source message broker with management console",
+			Provider: "local", Category: "messaging",
+			Tags:  []string{"rabbitmq", "amqp", "message-queue", "messaging"},
+			Plans: standardPlans("RabbitMQ"),
+		},
+		{
+			ID: "activemq", Name: "ActiveMQ Artemis", Label: "activemq",
+			Description: "High-performance multi-protocol messaging broker",
+			Provider: "local", Category: "messaging",
+			Tags:  []string{"activemq", "artemis", "jms", "message-queue", "messaging"},
+			Plans: standardPlans("ActiveMQ"),
+		},
+		// Storage
+		{
+			ID: "minio", Name: "MinIO", Label: "minio",
+			Description: "S3-compatible object storage for local development",
+			Provider: "local", Category: "storage",
+			Tags:  []string{"minio", "s3", "object-storage", "storage"},
+			Plans: storagePlans("MinIO"),
+		},
+		// API Gateway
+		{
+			ID: "kong", Name: "Kong Gateway", Label: "kong",
+			Description: "Cloud-native API gateway and service mesh",
+			Provider: "local", Category: "gateway",
+			Tags:  []string{"kong", "api-gateway", "proxy", "gateway"},
+			Plans: gatewayPlans("Kong"),
+		},
+		{
+			ID: "nginx", Name: "Nginx", Label: "nginx",
+			Description: "High-performance HTTP server and reverse proxy",
+			Provider: "local", Category: "gateway",
+			Tags:  []string{"nginx", "http", "reverse-proxy", "gateway"},
+			Plans: gatewayPlans("Nginx"),
+		},
+	}
+}
+
+func dbPlans(name string) []models.ServicePlan {
+	return []models.ServicePlan{
+		{ID: "small", Name: "Small (Dev)", Description: "Single instance for development — " + name,
+			Resources: models.PlanResources{MemoryMB: 256, CPUMillis: 250, StorageGB: 1}, CostEstimate: "Free (local)"},
+		{ID: "medium", Name: "Medium (Staging)", Description: "Moderate resources for staging — " + name,
+			Resources: models.PlanResources{MemoryMB: 512, CPUMillis: 500, StorageGB: 5}, CostEstimate: "Free (local)"},
+		{ID: "large", Name: "Large (Production)", Description: "Production-grade resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 1024, CPUMillis: 1000, StorageGB: 10}, CostEstimate: "Free (local)"},
+	}
+}
+
+func cachePlans(name string) []models.ServicePlan {
+	return []models.ServicePlan{
+		{ID: "small", Name: "Small (Dev)", Description: "256MB cache — " + name,
+			Resources: models.PlanResources{MemoryMB: 256, CPUMillis: 250}, CostEstimate: "Free (local)"},
+		{ID: "medium", Name: "Medium (Staging)", Description: "512MB cache — " + name,
+			Resources: models.PlanResources{MemoryMB: 512, CPUMillis: 500}, CostEstimate: "Free (local)"},
+		{ID: "large", Name: "Large (Production)", Description: "1GB cache — " + name,
+			Resources: models.PlanResources{MemoryMB: 1024, CPUMillis: 1000}, CostEstimate: "Free (local)"},
+	}
+}
+
+func storagePlans(name string) []models.ServicePlan {
+	return []models.ServicePlan{
+		{ID: "small", Name: "Small (Dev)", Description: "1GB storage — " + name,
+			Resources: models.PlanResources{MemoryMB: 256, CPUMillis: 250, StorageGB: 1}, CostEstimate: "Free (local)"},
+		{ID: "medium", Name: "Medium (Staging)", Description: "10GB storage — " + name,
+			Resources: models.PlanResources{MemoryMB: 512, CPUMillis: 500, StorageGB: 10}, CostEstimate: "Free (local)"},
+		{ID: "large", Name: "Large (Production)", Description: "50GB storage — " + name,
+			Resources: models.PlanResources{MemoryMB: 1024, CPUMillis: 1000, StorageGB: 50}, CostEstimate: "Free (local)"},
+	}
+}
+
+func standardPlans(name string) []models.ServicePlan {
+	return []models.ServicePlan{
+		{ID: "small", Name: "Small (Dev)", Description: "Minimal resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 256, CPUMillis: 250}, CostEstimate: "Free (local)"},
+		{ID: "medium", Name: "Medium (Staging)", Description: "Moderate resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 512, CPUMillis: 500}, CostEstimate: "Free (local)"},
+		{ID: "large", Name: "Large (Production)", Description: "Production resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 1024, CPUMillis: 1000}, CostEstimate: "Free (local)"},
+	}
+}
+
+func gatewayPlans(name string) []models.ServicePlan {
+	return []models.ServicePlan{
+		{ID: "small", Name: "Small (Dev)", Description: "Minimal resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 256, CPUMillis: 250}, CostEstimate: "Free (local)"},
+		{ID: "medium", Name: "Medium (Staging)", Description: "Moderate resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 512, CPUMillis: 500}, CostEstimate: "Free (local)"},
+		{ID: "large", Name: "Large (Production)", Description: "Production resources — " + name,
+			Resources: models.PlanResources{MemoryMB: 1024, CPUMillis: 1000}, CostEstimate: "Free (local)"},
 	}
 }
 

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -29,16 +29,23 @@ func SecretName(instanceName string) string {
 
 // Manager handles service instance lifecycle using K8s as the backing store.
 type Manager struct {
-	k8sClient *k8s.Client
-	secrets   *secrets.Manager
+	k8sClient   *k8s.Client
+	secrets     *secrets.Manager
+	provisioner *Provisioner
 }
 
 // NewManager creates a new service manager.
 func NewManager(client *k8s.Client) *Manager {
 	return &Manager{
-		k8sClient: client,
-		secrets:   secrets.NewManager(client),
+		k8sClient:   client,
+		secrets:     secrets.NewManager(client),
+		provisioner: NewProvisioner(client),
 	}
+}
+
+// SecretsManager returns the underlying secrets manager (for VCAP_SERVICES).
+func (m *Manager) SecretsManager() *secrets.Manager {
+	return m.secrets
 }
 
 // List returns all service instances.
@@ -111,12 +118,23 @@ func (m *Manager) Get(ctx context.Context, name string) (*models.ServiceInstance
 				inst.Outputs.Port = port
 			}
 		}
+		// Load extra fields
+		extra := make(map[string]string)
+		known := map[string]bool{"host": true, "port": true, "username": true, "password": true, "database": true, "uri": true}
+		for k, v := range secret.Data {
+			if !known[k] {
+				extra[k] = string(v)
+			}
+		}
+		if len(extra) > 0 {
+			inst.Outputs.Extra = extra
+		}
 	}
 
 	return &inst, nil
 }
 
-// Create stores a new service instance metadata.
+// Create stores service instance metadata and starts async provisioning.
 func (m *Manager) Create(ctx context.Context, inst *models.ServiceInstance) error {
 	inst.CreatedAt = time.Now()
 	inst.UpdatedAt = time.Now()
@@ -140,8 +158,51 @@ func (m *Manager) Create(ctx context.Context, inst *models.ServiceInstance) erro
 		},
 	}
 
-	_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Create(ctx, cm, metav1.CreateOptions{})
-	return err
+	if _, err := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	// Start async provisioning
+	go m.provisionAsync(inst.Name, inst.ServiceType, inst.Plan)
+	return nil
+}
+
+// provisionAsync deploys the service in a background goroutine and updates status.
+func (m *Manager) provisionAsync(name, serviceTypeID, planID string) {
+	ctx := context.Background()
+
+	outputs, err := m.provisioner.Provision(ctx, name, serviceTypeID, planID)
+	if err != nil {
+		log.Printf("error provisioning service %q: %v", name, err)
+		_ = m.UpdateStatus(ctx, name, models.ServiceStatusFailed, err.Error())
+		return
+	}
+
+	if err := m.secrets.CreateServiceSecret(ctx, name, outputs); err != nil {
+		log.Printf("error saving outputs for service %q: %v", name, err)
+		_ = m.UpdateStatus(ctx, name, models.ServiceStatusFailed, "failed to save credentials: "+err.Error())
+		return
+	}
+
+	if err := m.UpdateStatus(ctx, name, models.ServiceStatusAvailable, ""); err != nil {
+		log.Printf("error updating status for service %q: %v", name, err)
+	}
+}
+
+// WaitForStatus polls until the service reaches the target status or timeout.
+func (m *Manager) WaitForStatus(ctx context.Context, name, targetStatus string, timeout time.Duration) (*models.ServiceInstance, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		inst, err := m.Get(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if inst.Status == targetStatus || inst.Status == models.ServiceStatusFailed {
+			return inst, nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return nil, fmt.Errorf("timeout waiting for service %q to reach status %q", name, targetStatus)
 }
 
 // UpdateStatus updates the status of a service instance with conflict retry.
@@ -153,24 +214,24 @@ func (m *Manager) UpdateStatus(ctx context.Context, name, status, msg string) er
 }
 
 // SaveOutputs stores service outputs in a K8s Secret via the secrets manager.
-func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs models.ServiceOutputs) error {
-	data := map[string]string{
-		"host":     outputs.Host,
-		"port":     fmt.Sprintf("%d", outputs.Port),
-		"username": outputs.Username,
-		"password": outputs.Password,
-		"database": outputs.Database,
-		"uri":      outputs.URI,
-	}
-	return m.secrets.CreateServiceSecret(ctx, name, data)
+func (m *Manager) SaveOutputs(ctx context.Context, name string, outputs map[string]string) error {
+	return m.secrets.CreateServiceSecret(ctx, name, outputs)
 }
 
-// Delete removes a service instance and its secret.
+// Delete removes a service instance, its K8s workloads, and its secret.
 func (m *Manager) Delete(ctx context.Context, name string) error {
+	// Deprovision K8s workloads (Deployment, Service, PVC)
+	if err := m.provisioner.Deprovision(ctx, name); err != nil {
+		log.Printf("warning: deprovision error for %q: %v", name, err)
+	}
+
+	// Delete metadata ConfigMap
 	cmErr := m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Delete(ctx, serviceConfigMapPrefix+name, metav1.DeleteOptions{})
 	if cmErr != nil && !errors.IsNotFound(cmErr) {
 		return fmt.Errorf("deleting service ConfigMap: %w", cmErr)
 	}
+
+	// Delete credential secret
 	if secErr := m.secrets.Delete(ctx, name); secErr != nil {
 		return fmt.Errorf("deleting service Secret: %w", secErr)
 	}
@@ -227,7 +288,6 @@ func (m *Manager) retryOnConflict(ctx context.Context, name string, mutate func(
 		}
 		cm.Data["instance"] = string(data)
 
-		// Update with resourceVersion — K8s rejects if another write happened since our Get
 		_, err = m.k8sClient.Clientset.CoreV1().ConfigMaps(m.k8sClient.Namespace).Update(ctx, cm, metav1.UpdateOptions{})
 		if err == nil {
 			return nil
@@ -235,7 +295,6 @@ func (m *Manager) retryOnConflict(ctx context.Context, name string, mutate func(
 		if !errors.IsConflict(err) {
 			return err
 		}
-		// Conflict — retry with fresh read
 	}
 	return fmt.Errorf("conflict: too many retries updating service %q", name)
 }

--- a/pkg/service/provisioner.go
+++ b/pkg/service/provisioner.go
@@ -1,0 +1,317 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Provisioner deploys real K8s resources for backing services.
+type Provisioner struct {
+	k8sClient *k8s.Client
+}
+
+// NewProvisioner creates a new service provisioner.
+func NewProvisioner(client *k8s.Client) *Provisioner {
+	return &Provisioner{k8sClient: client}
+}
+
+// Provision creates K8s Deployment + Service + optional PVC for a service instance.
+// Returns the credential map to be stored in a K8s Secret.
+func (p *Provisioner) Provision(ctx context.Context, instanceName, serviceTypeID, planID string) (map[string]string, error) {
+	tmpl, ok := GetTemplate(serviceTypeID)
+	if !ok {
+		return nil, fmt.Errorf("no template for service type %q", serviceTypeID)
+	}
+
+	plan, ok := FindPlan(serviceTypeID, planID)
+	if !ok {
+		return nil, fmt.Errorf("no plan %q for service type %q", planID, serviceTypeID)
+	}
+
+	password := generatePassword(24)
+	k8sName := models.ServiceSecretPrefix + instanceName
+	labels := serviceLabels(instanceName, serviceTypeID)
+
+	// 1. Create PVC if needed
+	if tmpl.NeedsPVC && plan.Resources.StorageGB > 0 {
+		if err := p.createPVC(ctx, k8sName, plan.Resources.StorageGB, labels); err != nil {
+			return nil, fmt.Errorf("creating PVC: %w", err)
+		}
+	}
+
+	// 2. Create Deployment
+	if err := p.createDeployment(ctx, k8sName, instanceName, tmpl, plan, password, labels); err != nil {
+		return nil, fmt.Errorf("creating Deployment: %w", err)
+	}
+
+	// 3. Create ClusterIP Service
+	if err := p.createService(ctx, k8sName, tmpl, labels); err != nil {
+		return nil, fmt.Errorf("creating Service: %w", err)
+	}
+
+	// 4. Wait for readiness
+	if err := p.waitForReady(ctx, k8sName, 90*time.Second); err != nil {
+		return nil, fmt.Errorf("waiting for readiness: %w", err)
+	}
+
+	// 5. Build outputs
+	host := fmt.Sprintf("%s.%s.svc.cluster.local", k8sName, p.k8sClient.Namespace)
+	outputs := tmpl.BuildOutputs(host, int(tmpl.ServicePort), password, instanceName)
+	return outputs, nil
+}
+
+// Deprovision removes all K8s resources for a service instance.
+func (p *Provisioner) Deprovision(ctx context.Context, instanceName string) error {
+	k8sName := models.ServiceSecretPrefix + instanceName
+	ns := p.k8sClient.Namespace
+	propagation := metav1.DeletePropagationForeground
+	opts := metav1.DeleteOptions{PropagationPolicy: &propagation}
+
+	// Delete Deployment
+	err := p.k8sClient.Clientset.AppsV1().Deployments(ns).Delete(ctx, k8sName, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting deployment: %w", err)
+	}
+
+	// Delete Service
+	err = p.k8sClient.Clientset.CoreV1().Services(ns).Delete(ctx, k8sName, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting service: %w", err)
+	}
+
+	// Delete PVC
+	err = p.k8sClient.Clientset.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, k8sName, opts)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting PVC: %w", err)
+	}
+
+	return nil
+}
+
+func serviceLabels(instanceName, serviceTypeID string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by":      "microfoundry",
+		"microfoundry.io/service-instance":  instanceName,
+		"microfoundry.io/service-type":      serviceTypeID,
+		"microfoundry.io/component":         "backing-service",
+	}
+}
+
+func (p *Provisioner) createPVC(ctx context.Context, name string, storageGB int, labels map[string]string) error {
+	ns := p.k8sClient.Namespace
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(fmt.Sprintf("%dGi", storageGB)),
+				},
+			},
+		},
+	}
+
+	_, err := p.k8sClient.Clientset.CoreV1().PersistentVolumeClaims(ns).Create(ctx, pvc, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		return nil // idempotent
+	}
+	return err
+}
+
+func (p *Provisioner) createDeployment(ctx context.Context, k8sName, instanceName string, tmpl ServiceTemplate, plan models.ServicePlan, password string, labels map[string]string) error {
+	ns := p.k8sClient.Namespace
+	replicas := int32(1)
+
+	// Build environment variables with substitution
+	var envVars []corev1.EnvVar
+	for k, v := range tmpl.Env {
+		v = strings.ReplaceAll(v, "${PASSWORD}", password)
+		v = strings.ReplaceAll(v, "${INSTANCE_NAME}", instanceName)
+		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
+	}
+
+	// Build container ports
+	var ports []corev1.ContainerPort
+	for _, p := range tmpl.Ports {
+		ports = append(ports, corev1.ContainerPort{ContainerPort: p})
+	}
+
+	// Build command
+	var command []string
+	if len(tmpl.Command) > 0 {
+		command = make([]string, len(tmpl.Command))
+		for i, c := range tmpl.Command {
+			c = strings.ReplaceAll(c, "${PASSWORD}", password)
+			c = strings.ReplaceAll(c, "${INSTANCE_NAME}", instanceName)
+			command[i] = c
+		}
+	}
+
+	// Build readiness probe
+	var probe *corev1.Probe
+	switch tmpl.Probe.Type {
+	case "tcp":
+		probe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(tmpl.Probe.Port)},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       5,
+		}
+	case "http":
+		probe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: tmpl.Probe.Path,
+					Port: intstr.FromInt32(tmpl.Probe.Port),
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       5,
+		}
+	}
+
+	container := corev1.Container{
+		Name:            "service",
+		Image:           tmpl.Image,
+		Ports:           ports,
+		Env:             envVars,
+		Command:         command,
+		ReadinessProbe:  probe,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", plan.Resources.MemoryMB/2)),
+				corev1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%dm", plan.Resources.CPUMillis)),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", plan.Resources.MemoryMB)),
+			},
+		},
+	}
+
+	// Volume mount if PVC
+	var volumes []corev1.Volume
+	if tmpl.NeedsPVC && tmpl.PVCMountPath != "" {
+		container.VolumeMounts = []corev1.VolumeMount{
+			{Name: "data", MountPath: tmpl.PVCMountPath},
+		}
+		volumes = []corev1.Volume{
+			{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: k8sName,
+					},
+				},
+			},
+		}
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sName,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{container},
+					Volumes:    volumes,
+				},
+			},
+		},
+	}
+
+	existing, err := p.k8sClient.Clientset.AppsV1().Deployments(ns).Get(ctx, k8sName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = p.k8sClient.Clientset.AppsV1().Deployments(ns).Create(ctx, deployment, metav1.CreateOptions{})
+	} else if err == nil {
+		deployment.ResourceVersion = existing.ResourceVersion
+		_, err = p.k8sClient.Clientset.AppsV1().Deployments(ns).Update(ctx, deployment, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+func (p *Provisioner) createService(ctx context.Context, k8sName string, tmpl ServiceTemplate, labels map[string]string) error {
+	ns := p.k8sClient.Namespace
+
+	var svcPorts []corev1.ServicePort
+	for i, port := range tmpl.Ports {
+		name := fmt.Sprintf("port-%d", i)
+		if port == tmpl.ServicePort {
+			name = "primary"
+		}
+		svcPorts = append(svcPorts, corev1.ServicePort{
+			Name:       name,
+			Port:       port,
+			TargetPort: intstr.FromInt32(port),
+		})
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sName,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: labels,
+			Ports:    svcPorts,
+		},
+	}
+
+	existing, err := p.k8sClient.Clientset.CoreV1().Services(ns).Get(ctx, k8sName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = p.k8sClient.Clientset.CoreV1().Services(ns).Create(ctx, svc, metav1.CreateOptions{})
+	} else if err == nil {
+		svc.ResourceVersion = existing.ResourceVersion
+		svc.Spec.ClusterIP = existing.Spec.ClusterIP
+		_, err = p.k8sClient.Clientset.CoreV1().Services(ns).Update(ctx, svc, metav1.UpdateOptions{})
+	}
+	return err
+}
+
+func (p *Provisioner) waitForReady(ctx context.Context, k8sName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		dep, err := p.k8sClient.Clientset.AppsV1().Deployments(p.k8sClient.Namespace).Get(ctx, k8sName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if dep.Status.ReadyReplicas >= 1 {
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for %s to become ready", k8sName)
+}
+
+func generatePassword(length int) string {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "fallback-change-me"
+	}
+	return hex.EncodeToString(b)[:length]
+}

--- a/pkg/service/templates.go
+++ b/pkg/service/templates.go
@@ -1,0 +1,242 @@
+package service
+
+import "fmt"
+
+// ServiceTemplate defines how to deploy a service as K8s resources.
+type ServiceTemplate struct {
+	Image        string
+	Command      []string
+	Ports        []int32
+	ServicePort  int32
+	Env          map[string]string // ${PASSWORD} and ${INSTANCE_NAME} are substituted
+	NeedsPVC     bool
+	PVCMountPath string
+	Probe        ProbeSpec
+	BuildOutputs func(host string, port int, password, instanceName string) map[string]string
+}
+
+// ProbeSpec defines a readiness probe for a service container.
+type ProbeSpec struct {
+	Type string // "tcp" or "http"
+	Port int32
+	Path string // for http probes only
+}
+
+// GetTemplate returns the provisioning template for a service type.
+func GetTemplate(serviceTypeID string) (ServiceTemplate, bool) {
+	t, ok := serviceTemplates[serviceTypeID]
+	return t, ok
+}
+
+var serviceTemplates = map[string]ServiceTemplate{
+	"mariadb": {
+		Image:       "mariadb:11",
+		Ports:       []int32{3306},
+		ServicePort: 3306,
+		Env: map[string]string{
+			"MARIADB_ROOT_PASSWORD": "${PASSWORD}",
+			"MARIADB_DATABASE":      "${INSTANCE_NAME}",
+			"MARIADB_USER":          "admin",
+			"MARIADB_PASSWORD":      "${PASSWORD}",
+		},
+		NeedsPVC:     true,
+		PVCMountPath: "/var/lib/mysql",
+		Probe:        ProbeSpec{Type: "tcp", Port: 3306},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":     host,
+				"port":     fmt.Sprintf("%d", port),
+				"username": "admin",
+				"password": password,
+				"database": instanceName,
+				"uri":      fmt.Sprintf("mysql://admin:%s@%s:%d/%s", password, host, port, instanceName),
+			}
+		},
+	},
+	"postgresql": {
+		Image:       "postgres:16-alpine",
+		Ports:       []int32{5432},
+		ServicePort: 5432,
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "${PASSWORD}",
+			"POSTGRES_DB":       "${INSTANCE_NAME}",
+			"POSTGRES_USER":     "admin",
+		},
+		NeedsPVC:     true,
+		PVCMountPath: "/var/lib/postgresql/data",
+		Probe:        ProbeSpec{Type: "tcp", Port: 5432},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":     host,
+				"port":     fmt.Sprintf("%d", port),
+				"username": "admin",
+				"password": password,
+				"database": instanceName,
+				"uri":      fmt.Sprintf("postgresql://admin:%s@%s:%d/%s", password, host, port, instanceName),
+			}
+		},
+	},
+	"clickhouse": {
+		Image:       "clickhouse/clickhouse-server:24-alpine",
+		Ports:       []int32{8123, 9000},
+		ServicePort: 8123,
+		Env: map[string]string{
+			"CLICKHOUSE_PASSWORD": "${PASSWORD}",
+			"CLICKHOUSE_DB":       "${INSTANCE_NAME}",
+			"CLICKHOUSE_USER":     "admin",
+		},
+		NeedsPVC:     true,
+		PVCMountPath: "/var/lib/clickhouse",
+		Probe:        ProbeSpec{Type: "http", Port: 8123, Path: "/ping"},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":        host,
+				"port":        fmt.Sprintf("%d", port),
+				"native_port": "9000",
+				"username":    "admin",
+				"password":    password,
+				"database":    instanceName,
+				"uri":         fmt.Sprintf("clickhouse://admin:%s@%s:%d/%s", password, host, port, instanceName),
+			}
+		},
+	},
+	"redis": {
+		Image:       "redis:7-alpine",
+		Ports:       []int32{6379},
+		ServicePort: 6379,
+		Env: map[string]string{},
+		Command:     []string{"redis-server", "--requirepass", "${PASSWORD}"},
+		NeedsPVC:    false,
+		Probe:       ProbeSpec{Type: "tcp", Port: 6379},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":     host,
+				"port":     fmt.Sprintf("%d", port),
+				"password": password,
+				"uri":      fmt.Sprintf("redis://:%s@%s:%d/0", password, host, port),
+			}
+		},
+	},
+	"memcached": {
+		Image:       "memcached:1-alpine",
+		Ports:       []int32{11211},
+		ServicePort: 11211,
+		Env:         map[string]string{},
+		NeedsPVC:    false,
+		Probe:       ProbeSpec{Type: "tcp", Port: 11211},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host": host,
+				"port": fmt.Sprintf("%d", port),
+				"uri":  fmt.Sprintf("%s:%d", host, port),
+			}
+		},
+	},
+	"rabbitmq": {
+		Image:       "rabbitmq:4-management-alpine",
+		Ports:       []int32{5672, 15672},
+		ServicePort: 5672,
+		Env: map[string]string{
+			"RABBITMQ_DEFAULT_USER": "admin",
+			"RABBITMQ_DEFAULT_PASS": "${PASSWORD}",
+		},
+		NeedsPVC: false,
+		Probe:    ProbeSpec{Type: "tcp", Port: 5672},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":           host,
+				"port":           fmt.Sprintf("%d", port),
+				"management_port": "15672",
+				"username":       "admin",
+				"password":       password,
+				"vhost":          "/",
+				"uri":            fmt.Sprintf("amqp://admin:%s@%s:%d/", password, host, port),
+				"management_uri": fmt.Sprintf("http://%s:15672", host),
+			}
+		},
+	},
+	"activemq": {
+		Image:       "apache/activemq-artemis:2",
+		Ports:       []int32{61616, 8161},
+		ServicePort: 61616,
+		Env: map[string]string{
+			"ARTEMIS_USER":     "admin",
+			"ARTEMIS_PASSWORD": "${PASSWORD}",
+		},
+		NeedsPVC: false,
+		Probe:    ProbeSpec{Type: "tcp", Port: 61616},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":           host,
+				"port":           fmt.Sprintf("%d", port),
+				"console_port":   "8161",
+				"username":       "admin",
+				"password":       password,
+				"uri":            fmt.Sprintf("tcp://admin:%s@%s:%d", password, host, port),
+				"console_uri":    fmt.Sprintf("http://%s:8161/console", host),
+			}
+		},
+	},
+	"minio": {
+		Image:       "minio/minio:latest",
+		Command:     []string{"server", "/data", "--console-address", ":9001"},
+		Ports:       []int32{9000, 9001},
+		ServicePort: 9000,
+		Env: map[string]string{
+			"MINIO_ROOT_USER":     "admin",
+			"MINIO_ROOT_PASSWORD": "${PASSWORD}",
+		},
+		NeedsPVC:     true,
+		PVCMountPath: "/data",
+		Probe:        ProbeSpec{Type: "http", Port: 9000, Path: "/minio/health/live"},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":         host,
+				"port":         fmt.Sprintf("%d", port),
+				"console_port": "9001",
+				"access_key":   "admin",
+				"secret_key":   password,
+				"endpoint":     fmt.Sprintf("http://%s:%d", host, port),
+				"console_uri":  fmt.Sprintf("http://%s:9001", host),
+				"uri":          fmt.Sprintf("s3://admin:%s@%s:%d", password, host, port),
+			}
+		},
+	},
+	"kong": {
+		Image:       "kong:3",
+		Ports:       []int32{8000, 8001},
+		ServicePort: 8000,
+		Env: map[string]string{
+			"KONG_DATABASE":       "off",
+			"KONG_PROXY_LISTEN":   "0.0.0.0:8000",
+			"KONG_ADMIN_LISTEN":   "0.0.0.0:8001",
+			"KONG_ADMIN_GUI_URL":  "http://localhost:8002",
+		},
+		NeedsPVC: false,
+		Probe:    ProbeSpec{Type: "http", Port: 8001, Path: "/status"},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host":       host,
+				"proxy_port": fmt.Sprintf("%d", port),
+				"admin_port": "8001",
+				"proxy_url":  fmt.Sprintf("http://%s:%d", host, port),
+				"admin_url":  fmt.Sprintf("http://%s:8001", host),
+			}
+		},
+	},
+	"nginx": {
+		Image:       "nginx:1-alpine",
+		Ports:       []int32{80},
+		ServicePort: 80,
+		Env:         map[string]string{},
+		NeedsPVC:    false,
+		Probe:       ProbeSpec{Type: "http", Port: 80, Path: "/"},
+		BuildOutputs: func(host string, port int, password, instanceName string) map[string]string {
+			return map[string]string{
+				"host": host,
+				"port": fmt.Sprintf("%d", port),
+				"url":  fmt.Sprintf("http://%s:%d", host, port),
+			}
+		},
+	},
+}

--- a/pkg/service/vcap.go
+++ b/pkg/service/vcap.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/younjinjeong/microfoundry/pkg/secrets"
+)
+
+// VCAPServiceEntry represents a single service entry in VCAP_SERVICES.
+type VCAPServiceEntry struct {
+	Name        string            `json:"name"`
+	Label       string            `json:"label"`
+	Plan        string            `json:"plan"`
+	Tags        []string          `json:"tags"`
+	Credentials map[string]string `json:"credentials"`
+}
+
+// BuildVCAPServices constructs the VCAP_SERVICES JSON for the given bound service names.
+func BuildVCAPServices(ctx context.Context, mgr *Manager, secretsMgr *secrets.Manager, serviceNames []string) (string, error) {
+	vcap := make(map[string][]VCAPServiceEntry)
+
+	for _, svcName := range serviceNames {
+		inst, err := mgr.Get(ctx, svcName)
+		if err != nil {
+			log.Printf("warning: VCAP_SERVICES: skipping %q: %v", svcName, err)
+			continue
+		}
+
+		svcType, ok := FindServiceType(inst.ServiceType)
+		if !ok {
+			log.Printf("warning: VCAP_SERVICES: unknown type %q for %q", inst.ServiceType, svcName)
+			continue
+		}
+
+		// Get credentials from secret
+		detail, err := secretsMgr.Get(ctx, svcName)
+		if err != nil {
+			log.Printf("warning: VCAP_SERVICES: no secret for %q: %v", svcName, err)
+			continue
+		}
+
+		creds := make(map[string]string)
+		for _, key := range detail.Keys {
+			val, err := secretsMgr.GetValue(ctx, svcName, key)
+			if err != nil {
+				continue
+			}
+			creds[key] = val
+		}
+
+		entry := VCAPServiceEntry{
+			Name:        svcName,
+			Label:       svcType.Label,
+			Plan:        inst.Plan,
+			Tags:        svcType.Tags,
+			Credentials: creds,
+		}
+
+		vcap[svcType.Label] = append(vcap[svcType.Label], entry)
+	}
+
+	data, err := json.Marshal(vcap)
+	if err != nil {
+		return "{}", err
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
## Summary
- **Real K8s deployment** for 10 backing services (MariaDB, PostgreSQL, ClickHouse, Redis, Memcached, RabbitMQ, ActiveMQ, MinIO, Kong, Nginx) across 5 categories
- **VCAP_SERVICES injection** — CloudFoundry-compatible JSON env var injected on `mf bind-service`, grouped by service label
- **Template-driven provisioner** — each service type defines image, ports, env vars, probes, volume mounts, and output builder
- **Async provisioning** with status polling; conflict retry on bind/unbind
- **Categorized marketplace** UI with per-category colors/icons, generic plan display (Memory/CPU/Storage)

### New files
| File | Purpose |
|------|---------|
| `pkg/service/provisioner.go` | K8s Deployment + Service + PVC lifecycle |
| `pkg/service/templates.go` | Service template definitions for all 10 services |
| `pkg/service/vcap.go` | VCAP_SERVICES JSON builder |

### Modified files
| File | Change |
|------|--------|
| `pkg/models/service.go` | `PlanResources` replaces AWS-specific fields; `Label` + `Extra` added |
| `pkg/service/catalog.go` | 10 services in 5 categories (was 1 AWS service) |
| `pkg/service/manager.go` | Integrated provisioner; async Create; Deprovision on Delete |
| `pkg/service/binder.go` | VCAP_SERVICES injection; conflict retry |
| `pkg/admin/service_handlers.go` | Removed mock provisioning; updated binder API |
| CLI commands | Updated for new APIs; marketplace grouped by category |
| UI templates | Categorized marketplace; generic plan display; VCAP_SERVICES preview |

## Test plan
- [x] `go build ./cmd/mf` and `go vet ./...` pass
- [x] `mf marketplace` shows 10 services in 5 categories
- [x] `mf create-service redis small test-cache` deploys real Redis pod
- [x] `mf create-service mariadb small test-db` deploys MariaDB with PVC
- [x] `kubectl get pods -n microfoundry` confirms running pods
- [x] `mf bind-service hello-world test-db` injects VCAP_SERVICES
- [x] Back-to-back binds succeed (conflict retry works)
- [x] VCAP_SERVICES contains all bound services grouped by label
- [x] `mf unbind-service` removes from VCAP_SERVICES
- [x] `mf delete-service` deprovisions all K8s resources (Deployment, Service, PVC)
- [x] Admin dashboard marketplace, services, and service detail pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)