### PR TITLE
feat: Netflix Atlas-inspired auto-instrumentation with Grafana Beyla

### DIFF
--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -163,6 +163,8 @@ func pushCmd() *cobra.Command {
 			}
 			fmt.Printf("memory:     %dM\n", app.MemoryMB)
 			fmt.Printf("disk:       %dM\n", app.DiskMB)
+			fmt.Printf("metrics:    auto-instrumented (Beyla eBPF)\n")
+			fmt.Printf("dashboard:  http://localhost:8080/apps/%s?tab=performance\n", app.Name)
 			fmt.Println()
 
 			return nil

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -34,3 +34,5 @@ monitoring:
   grafana_url: "http://grafana.cf-local.dev"
   loki_url: "http://loki.monitoring.svc.cluster.local:3100"
   alertmanager_url: "http://kube-prometheus-kube-prome-alertmanager.monitoring.svc.cluster.local:9093"
+  prometheus_url: "http://kube-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090"
+  beyla_enabled: true

--- a/deploy/monitoring/alerts/microfoundry-alerts.yaml
+++ b/deploy/monitoring/alerts/microfoundry-alerts.yaml
@@ -54,3 +54,37 @@ spec:
           annotations:
             summary: "Service provisioning failures detected"
             description: "Service provisioning errors occurred in the last 10 minutes."
+
+    - name: microfoundry.beyla.alerts
+      rules:
+        - alert: MFAppHighErrorRate
+          expr: microfoundry:http_error_rate:5m > 0.05
+          for: 5m
+          labels:
+            severity: warning
+            source: beyla
+          annotations:
+            summary: "App {{ $labels.k8s_deployment_name }} has >5% error rate"
+            description: "Application {{ $labels.k8s_deployment_name }} has a 5xx error rate of {{ $value | humanizePercentage }} over the last 5 minutes."
+
+        - alert: MFAppHighLatency
+          expr: microfoundry:http_latency_p99:5m > 2
+          for: 5m
+          labels:
+            severity: warning
+            source: beyla
+          annotations:
+            summary: "App {{ $labels.k8s_deployment_name }} p99 latency >2s"
+            description: "Application {{ $labels.k8s_deployment_name }} has a p99 latency of {{ $value | humanizeDuration }} over the last 5 minutes."
+
+        - alert: MFAppNoTraffic
+          expr: |
+            microfoundry:http_request_rate:5m == 0
+            and on(k8s_deployment_name) (kube_deployment_status_replicas_available{namespace="microfoundry"} > 0)
+          for: 15m
+          labels:
+            severity: info
+            source: beyla
+          annotations:
+            summary: "App {{ $labels.k8s_deployment_name }} has zero traffic"
+            description: "Application {{ $labels.k8s_deployment_name }} is running but received no HTTP traffic in the last 15 minutes."

--- a/deploy/monitoring/beyla-config.yaml
+++ b/deploy/monitoring/beyla-config.yaml
@@ -1,0 +1,153 @@
+# Grafana Beyla - eBPF auto-instrumentation for MicroFoundry applications
+# Netflix Atlas/Spectator-inspired: zero-code HTTP metrics collection
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beyla-config
+  namespace: monitoring
+data:
+  beyla-config.yml: |
+    log_level: info
+    discovery:
+      services:
+        - k8s_namespace: microfoundry
+          k8s_pod_labels:
+            app.kubernetes.io/managed-by: microfoundry
+    prometheus_export:
+      port: 9090
+      path: /metrics
+    routes:
+      patterns:
+        - /api/{_}/{_}
+        - /api/{_}
+        - /health
+        - /ready
+        - /metrics
+      unmatch: heuristic
+    attributes:
+      kubernetes:
+        enable: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: beyla
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: beyla
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: beyla
+subjects:
+  - kind: ServiceAccount
+    name: beyla
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: beyla
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: beyla
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: beyla
+    app.kubernetes.io/component: auto-instrumentation
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: beyla
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: beyla
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: beyla
+      hostPID: true
+      containers:
+        - name: beyla
+          image: grafana/beyla:latest
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          ports:
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          env:
+            - name: BEYLA_CONFIG_PATH
+              value: /config/beyla-config.yml
+          volumeMounts:
+            - name: beyla-config
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: beyla-config
+          configMap:
+            name: beyla-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: beyla-metrics
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: beyla
+spec:
+  selector:
+    app.kubernetes.io/name: beyla
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: beyla-metrics
+  namespace: monitoring
+  labels:
+    release: kube-prometheus
+    app.kubernetes.io/name: beyla
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: beyla
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: metrics
+      interval: 15s
+      path: /metrics
+      relabelings:
+        - targetLabel: cluster
+          replacement: docker-desktop
+        - targetLabel: managed_by
+          replacement: microfoundry

--- a/deploy/monitoring/dashboards/mf-app-detail.yaml
+++ b/deploy/monitoring/dashboards/mf-app-detail.yaml
@@ -10,7 +10,7 @@ data:
     {
       "uid": "mf-app-detail",
       "title": "MicroFoundry App Detail",
-      "tags": ["microfoundry", "app"],
+      "tags": ["microfoundry", "app", "red", "beyla"],
       "timezone": "browser",
       "refresh": "30s",
       "time": { "from": "now-1h", "to": "now" },
@@ -18,19 +18,146 @@ data:
         "list": [
           {
             "name": "app",
-            "type": "custom",
+            "type": "query",
+            "query": "label_values(kube_deployment_labels{namespace=\"microfoundry\", label_app_kubernetes_io_managed_by=\"microfoundry\"}, deployment)",
             "current": { "text": "hello-world", "value": "hello-world" },
-            "query": "",
-            "label": "Application"
+            "label": "Application",
+            "refresh": 2,
+            "sort": 1
           }
         ]
       },
       "panels": [
         {
+          "id": 10,
+          "title": "RED Metrics (Beyla eBPF)",
+          "type": "row",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+          "collapsed": false
+        },
+        {
+          "id": 11,
+          "title": "Request Rate",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+          "targets": [{
+            "expr": "microfoundry:http_request_rate:5m{k8s_deployment_name=\"$app\"}",
+            "legendFormat": ""
+          }],
+          "fieldConfig": { "defaults": { "unit": "reqps", "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 100}, {"color": "red", "value": 500}] } } }
+        },
+        {
+          "id": 12,
+          "title": "Error Rate",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+          "targets": [{
+            "expr": "microfoundry:http_error_rate:5m{k8s_deployment_name=\"$app\"}",
+            "legendFormat": ""
+          }],
+          "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.01}, {"color": "red", "value": 0.05}] } } }
+        },
+        {
+          "id": 13,
+          "title": "P50 Latency",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+          "targets": [{
+            "expr": "microfoundry:http_latency_p50:5m{k8s_deployment_name=\"$app\"}",
+            "legendFormat": ""
+          }],
+          "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.5}, {"color": "red", "value": 1}] } } }
+        },
+        {
+          "id": 14,
+          "title": "P95 Latency",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+          "targets": [{
+            "expr": "microfoundry:http_latency_p95:5m{k8s_deployment_name=\"$app\"}",
+            "legendFormat": ""
+          }],
+          "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 2}] } } }
+        },
+        {
+          "id": 15,
+          "title": "P99 Latency",
+          "type": "stat",
+          "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+          "targets": [{
+            "expr": "microfoundry:http_latency_p99:5m{k8s_deployment_name=\"$app\"}",
+            "legendFormat": ""
+          }],
+          "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1.5}, {"color": "red", "value": 3}] } } }
+        },
+        {
+          "id": 16,
+          "title": "Request Rate Over Time",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+          "targets": [{
+            "expr": "sum by (http_route) (rate(http_server_request_duration_seconds_count{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m]))",
+            "legendFormat": "{{ http_route }}"
+          }],
+          "fieldConfig": { "defaults": { "unit": "reqps" } }
+        },
+        {
+          "id": 17,
+          "title": "Latency Percentiles Over Time",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m])))",
+              "legendFormat": "p50"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m])))",
+              "legendFormat": "p95"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m])))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": { "defaults": { "unit": "s" } }
+        },
+        {
+          "id": 18,
+          "title": "Status Code Distribution",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
+          "targets": [{
+            "expr": "sum by (http_response_status_code) (rate(http_server_request_duration_seconds_count{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m]))",
+            "legendFormat": "{{ http_response_status_code }}"
+          }],
+          "fieldConfig": { "defaults": { "unit": "reqps" } },
+          "options": { "tooltip": { "mode": "multi" } }
+        },
+        {
+          "id": 19,
+          "title": "Request Duration Heatmap",
+          "type": "heatmap",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 13 },
+          "targets": [{
+            "expr": "sum by (le) (increase(http_server_request_duration_seconds_bucket{k8s_namespace_name=\"microfoundry\", k8s_deployment_name=\"$app\"}[5m]))",
+            "legendFormat": "{{ le }}",
+            "format": "heatmap"
+          }],
+          "options": { "yAxis": { "unit": "s" } }
+        },
+        {
+          "id": 20,
+          "title": "Resource Metrics",
+          "type": "row",
+          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
+          "collapsed": false
+        },
+        {
           "id": 1,
           "title": "CPU Usage",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
           "targets": [{
             "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"microfoundry\", pod=~\"$app.*\", container!=\"\"}[5m])) by (pod)",
             "legendFormat": "{{ pod }}"
@@ -41,7 +168,7 @@ data:
           "id": 2,
           "title": "Memory Usage",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
           "targets": [{
             "expr": "sum(container_memory_working_set_bytes{namespace=\"microfoundry\", pod=~\"$app.*\", container!=\"\"}) by (pod)",
             "legendFormat": "{{ pod }}"
@@ -52,7 +179,7 @@ data:
           "id": 3,
           "title": "Network I/O",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
           "targets": [
             {
               "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"microfoundry\", pod=~\"$app.*\"}[5m])) by (pod)",
@@ -69,7 +196,7 @@ data:
           "id": 4,
           "title": "Pod Restarts",
           "type": "timeseries",
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
           "targets": [{
             "expr": "sum(kube_pod_container_status_restarts_total{namespace=\"microfoundry\", pod=~\"$app.*\"}) by (pod)",
             "legendFormat": "{{ pod }}"
@@ -79,7 +206,7 @@ data:
           "id": 5,
           "title": "Application Logs",
           "type": "logs",
-          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 16 },
+          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 38 },
           "targets": [{
             "expr": "{namespace=\"microfoundry\", app=\"$app\"}",
             "refId": "A"

--- a/deploy/monitoring/install.sh
+++ b/deploy/monitoring/install.sh
@@ -8,31 +8,37 @@ echo "=== MicroFoundry Monitoring Stack ==="
 echo ""
 
 # Create namespace
-echo "[1/5] Creating monitoring namespace..."
+echo "[1/6] Creating monitoring namespace..."
 kubectl apply -f namespace.yaml
 
 # Add Helm repos
-echo "[2/5] Adding Helm repositories..."
+echo "[2/6] Adding Helm repositories..."
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true
 helm repo add grafana https://grafana.github.io/helm-charts 2>/dev/null || true
 helm repo update
 
 # Install kube-prometheus-stack
-echo "[3/5] Installing kube-prometheus-stack (Prometheus + Grafana + Alertmanager)..."
+echo "[3/6] Installing kube-prometheus-stack (Prometheus + Grafana + Alertmanager)..."
 helm upgrade --install kube-prometheus prometheus-community/kube-prometheus-stack \
   --namespace monitoring \
   --values kube-prometheus-values.yaml \
   --wait --timeout 10m
 
+# Deploy Grafana Beyla (eBPF auto-instrumentation)
+echo "[4/6] Deploying Grafana Beyla (eBPF auto-instrumentation)..."
+kubectl apply -f beyla-config.yaml
+kubectl apply -f prometheus-recording-rules.yaml
+echo "  Beyla DaemonSet + recording rules applied"
+
 # Install Loki + Promtail
-echo "[4/5] Installing Loki + Promtail..."
+echo "[5/6] Installing Loki + Promtail..."
 helm upgrade --install loki grafana/loki-stack \
   --namespace monitoring \
   --values loki-values.yaml \
   --wait --timeout 5m
 
 # Apply dashboards and alert rules
-echo "[5/5] Applying dashboards and alert rules..."
+echo "[6/6] Applying dashboards and alert rules..."
 kubectl apply -f dashboards/
 kubectl apply -f alerts/
 
@@ -42,5 +48,6 @@ echo ""
 echo "Grafana:      http://grafana.cf-local.dev (admin/microfoundry)"
 echo "Prometheus:   kubectl port-forward -n monitoring svc/kube-prometheus-kube-prome-prometheus 9090:9090"
 echo "Alertmanager: kubectl port-forward -n monitoring svc/kube-prometheus-kube-prome-alertmanager 9093:9093"
+echo "Beyla:        kubectl get ds beyla -n monitoring"
 echo ""
 echo "Make sure grafana.cf-local.dev resolves to 127.0.0.1 in your /etc/hosts file."

--- a/deploy/monitoring/prometheus-recording-rules.yaml
+++ b/deploy/monitoring/prometheus-recording-rules.yaml
@@ -1,0 +1,73 @@
+# Prometheus recording rules for Netflix Atlas-style normalized RED metrics
+# Pre-computes per-app request rate, error rate, and latency percentiles from Beyla data
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: microfoundry-beyla-rules
+  namespace: monitoring
+  labels:
+    release: kube-prometheus
+    app: kube-prometheus-stack
+spec:
+  groups:
+    - name: microfoundry.beyla.recording
+      interval: 15s
+      rules:
+        # Normalized request rate per app (Netflix IPC equivalent)
+        - record: microfoundry:http_request_rate:5m
+          expr: |
+            sum by (k8s_deployment_name, k8s_namespace_name) (
+              rate(http_server_request_duration_seconds_count{k8s_namespace_name="microfoundry"}[5m])
+            )
+          labels:
+            source: beyla
+
+        # Normalized error rate per app (5xx / total)
+        - record: microfoundry:http_error_rate:5m
+          expr: |
+            (
+              sum by (k8s_deployment_name, k8s_namespace_name) (
+                rate(http_server_request_duration_seconds_count{k8s_namespace_name="microfoundry", http_response_status_code=~"5.."}[5m])
+              )
+            )
+            /
+            (
+              sum by (k8s_deployment_name, k8s_namespace_name) (
+                rate(http_server_request_duration_seconds_count{k8s_namespace_name="microfoundry"}[5m])
+              ) > 0
+            )
+          labels:
+            source: beyla
+
+        # Normalized p50 latency per app
+        - record: microfoundry:http_latency_p50:5m
+          expr: |
+            histogram_quantile(0.50,
+              sum by (k8s_deployment_name, le) (
+                rate(http_server_request_duration_seconds_bucket{k8s_namespace_name="microfoundry"}[5m])
+              )
+            )
+          labels:
+            source: beyla
+
+        # Normalized p95 latency per app
+        - record: microfoundry:http_latency_p95:5m
+          expr: |
+            histogram_quantile(0.95,
+              sum by (k8s_deployment_name, le) (
+                rate(http_server_request_duration_seconds_bucket{k8s_namespace_name="microfoundry"}[5m])
+              )
+            )
+          labels:
+            source: beyla
+
+        # Normalized p99 latency per app
+        - record: microfoundry:http_latency_p99:5m
+          expr: |
+            histogram_quantile(0.99,
+              sum by (k8s_deployment_name, le) (
+                rate(http_server_request_duration_seconds_bucket{k8s_namespace_name="microfoundry"}[5m])
+              )
+            )
+          labels:
+            source: beyla

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -120,7 +120,7 @@ func (s *Server) AppDetailHandler(w http.ResponseWriter, r *http.Request) {
 var validTabs = map[string]bool{
 	"overview": true, "instances": true, "config": true,
 	"services": true, "routes": true, "logs": true,
-	"metrics": true,
+	"metrics": true, "performance": true,
 }
 
 // AppTabHandler serves individual tab content as HTMX partials.
@@ -143,6 +143,12 @@ func (s *Server) AppTabHandler(w http.ResponseWriter, r *http.Request) {
 	detail, err := client.GetAppDetail(ctx, name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Performance tab uses dedicated handler with RED metrics
+	if tab == "performance" {
+		s.AppPerformanceTabHandler(w, r, name)
 		return
 	}
 

--- a/pkg/admin/performance_handlers.go
+++ b/pkg/admin/performance_handlers.go
@@ -1,0 +1,80 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const dashboardPerfUID = "mf-app-detail"
+
+// AppPerformanceTabHandler renders the Performance tab with RED metrics and Grafana panels.
+func (s *Server) AppPerformanceTabHandler(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := r.Context()
+
+	red, _ := s.prometheus.GetAppREDMetrics(ctx, name)
+
+	appParams := map[string]string{"var-app": name}
+	data := map[string]any{
+		"Name":        name,
+		"RED":         red,
+		"BeylaEnabled": s.config.Monitoring.BeylaEnabled,
+		// Grafana panel URLs for RED metric panels (IDs 11-19 from enhanced dashboard)
+		"GrafanaAppURL":            s.grafana.FullDashboardURL(dashboardPerfUID, appParams),
+		"GrafanaReqRatePanelURL":   s.grafana.PanelURL(dashboardPerfUID, 16, appParams),
+		"GrafanaLatencyPanelURL":   s.grafana.PanelURL(dashboardPerfUID, 17, appParams),
+		"GrafanaStatusPanelURL":    s.grafana.PanelURL(dashboardPerfUID, 18, appParams),
+		"GrafanaHeatmapPanelURL":   s.grafana.PanelURL(dashboardPerfUID, 19, appParams),
+	}
+
+	s.templates.RenderPartial(w, "tab_performance.html", data)
+}
+
+// APIAppREDMetricsHandler returns RED metrics for an app as JSON.
+func (s *Server) APIAppREDMetricsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	red, err := s.prometheus.GetAppREDMetrics(ctx, name)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, red)
+}
+
+// APIAppHealthHandler returns a health summary combining RED metrics and alert status.
+func (s *Server) APIAppHealthHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	red, _ := s.prometheus.GetAppREDMetrics(ctx, name)
+
+	// Determine health status from RED metrics
+	status := "healthy"
+	var issues []string
+
+	if red.HasData {
+		if red.ErrorRate > 0.05 {
+			status = "degraded"
+			issues = append(issues, fmt.Sprintf("high error rate: %.1f%%", red.ErrorRate*100))
+		}
+		if red.LatencyP99 > 2.0 {
+			status = "degraded"
+			issues = append(issues, fmt.Sprintf("high p99 latency: %.0fms", red.LatencyP99*1000))
+		}
+		if red.RequestRate == 0 {
+			issues = append(issues, "no traffic detected")
+		}
+	} else {
+		status = "unknown"
+		issues = append(issues, "no Beyla metrics available")
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"app":     name,
+		"status":  status,
+		"issues":  issues,
+		"metrics": red,
+	})
+}

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	grafana       *monitoring.GrafanaConfig
 	loki          *monitoring.LokiClient
 	alertmanager  *monitoring.AlertmanagerClient
+	prometheus    *monitoring.PrometheusClient
 }
 
 func NewServer(clientManager *k8s.ClientManager, cfg *config.Config, version string) *Server {
@@ -43,6 +44,7 @@ func NewServer(clientManager *k8s.ClientManager, cfg *config.Config, version str
 			BaseURL:    cfg.Monitoring.AlertmanagerURL,
 			HTTPClient: &http.Client{Timeout: 10 * time.Second},
 		},
+		prometheus: monitoring.NewPrometheusClient(cfg.Monitoring.PrometheusURL),
 	}
 	s.registerRoutes()
 	return s
@@ -144,6 +146,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/topologies/{type}/{plan}", s.APITopologyDetailHandler)
 	s.mux.HandleFunc("PUT /api/topologies/{type}/{plan}", s.APISaveTopologyHandler)
 	s.mux.HandleFunc("GET /api/monitoring/alerts", s.APIAlertsHandler)
+
+	// Beyla RED metrics API routes
+	s.mux.HandleFunc("GET /api/apps/{name}/red-metrics", s.APIAppREDMetricsHandler)
+	s.mux.HandleFunc("GET /api/apps/{name}/health", s.APIAppHealthHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/static/templates/app_detail.html
+++ b/pkg/admin/static/templates/app_detail.html
@@ -77,6 +77,13 @@
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "metrics"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Metrics
                 </a>
+                <a href="/apps/{{$d.Name}}?tab=performance"
+                   hx-get="/apps/{{$d.Name}}/tab/performance"
+                   hx-target="#tab-content"
+                   hx-push-url="/apps/{{$d.Name}}?tab=performance"
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "performance"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+                    Performance
+                </a>
             </nav>
         </div>
 
@@ -96,6 +103,8 @@
                 {{template "tab_logs.html" $d}}
             {{else if eq $tab "metrics"}}
                 {{template "tab_metrics.html" $c}}
+            {{else if eq $tab "performance"}}
+                {{template "tab_performance.html" $c}}
             {{end}}
         </div>
     </div>

--- a/pkg/admin/static/templates/tabs/tab_performance.html
+++ b/pkg/admin/static/templates/tabs/tab_performance.html
@@ -1,0 +1,93 @@
+{{define "tab_performance.html"}}
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <p class="text-sm text-gray-500">Application RED metrics auto-instrumented by Grafana Beyla (eBPF)</p>
+            <p class="text-xs text-gray-400 mt-1">Rate &middot; Errors &middot; Duration &mdash; Netflix Atlas / Spectator inspired</p>
+        </div>
+        <a href="{{index . "GrafanaAppURL"}}" target="_blank"
+           class="text-sm text-blue-600 hover:underline flex items-center">
+            Open in Grafana
+            <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+            </svg>
+        </a>
+    </div>
+
+    {{$red := index . "RED"}}
+    {{if and $red $red.HasData}}
+    <!-- RED Stat Cards -->
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
+        <div class="bg-white border rounded-lg p-4 text-center">
+            <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Request Rate</p>
+            <p class="text-2xl font-bold text-gray-900 mt-1">{{fmtFloat $red.RequestRate 1}}</p>
+            <p class="text-xs text-gray-400">req/s</p>
+        </div>
+        <div class="bg-white border rounded-lg p-4 text-center {{if gt $red.ErrorRate 0.05}}border-red-300 bg-red-50{{else if gt $red.ErrorRate 0.01}}border-yellow-300 bg-yellow-50{{end}}">
+            <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Error Rate</p>
+            <p class="text-2xl font-bold {{if gt $red.ErrorRate 0.05}}text-red-600{{else if gt $red.ErrorRate 0.01}}text-yellow-600{{else}}text-green-600{{end}} mt-1">{{fmtFloat (mul $red.ErrorRate 100) 1}}%</p>
+            <p class="text-xs text-gray-400">5xx / total</p>
+        </div>
+        <div class="bg-white border rounded-lg p-4 text-center">
+            <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">P50 Latency</p>
+            <p class="text-2xl font-bold text-gray-900 mt-1">{{fmtMs $red.LatencyP50}}</p>
+            <p class="text-xs text-gray-400">median</p>
+        </div>
+        <div class="bg-white border rounded-lg p-4 text-center {{if gt $red.LatencyP95 1.0}}border-yellow-300 bg-yellow-50{{end}}">
+            <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">P95 Latency</p>
+            <p class="text-2xl font-bold {{if gt $red.LatencyP95 2.0}}text-red-600{{else if gt $red.LatencyP95 1.0}}text-yellow-600{{else}}text-gray-900{{end}} mt-1">{{fmtMs $red.LatencyP95}}</p>
+            <p class="text-xs text-gray-400">95th percentile</p>
+        </div>
+        <div class="bg-white border rounded-lg p-4 text-center {{if gt $red.LatencyP99 2.0}}border-red-300 bg-red-50{{end}}">
+            <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">P99 Latency</p>
+            <p class="text-2xl font-bold {{if gt $red.LatencyP99 3.0}}text-red-600{{else if gt $red.LatencyP99 2.0}}text-yellow-600{{else}}text-gray-900{{end}} mt-1">{{fmtMs $red.LatencyP99}}</p>
+            <p class="text-xs text-gray-400">99th percentile</p>
+        </div>
+    </div>
+
+    <!-- Grafana Panels: Request Rate + Latency -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-gray-50 rounded-lg p-2">
+            <h4 class="text-xs font-medium text-gray-500 mb-2 px-2">Request Rate by Endpoint</h4>
+            <iframe src="{{index . "GrafanaReqRatePanelURL"}}"
+                    width="100%" height="250" frameborder="0" class="rounded" loading="lazy"></iframe>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-2">
+            <h4 class="text-xs font-medium text-gray-500 mb-2 px-2">Latency Percentiles</h4>
+            <iframe src="{{index . "GrafanaLatencyPanelURL"}}"
+                    width="100%" height="250" frameborder="0" class="rounded" loading="lazy"></iframe>
+        </div>
+    </div>
+
+    <!-- Grafana Panels: Status Codes + Heatmap -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-gray-50 rounded-lg p-2">
+            <h4 class="text-xs font-medium text-gray-500 mb-2 px-2">Status Code Distribution</h4>
+            <iframe src="{{index . "GrafanaStatusPanelURL"}}"
+                    width="100%" height="250" frameborder="0" class="rounded" loading="lazy"></iframe>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-2">
+            <h4 class="text-xs font-medium text-gray-500 mb-2 px-2">Request Duration Heatmap</h4>
+            <iframe src="{{index . "GrafanaHeatmapPanelURL"}}"
+                    width="100%" height="250" frameborder="0" class="rounded" loading="lazy"></iframe>
+        </div>
+    </div>
+
+    {{else}}
+    <!-- No data state -->
+    <div class="bg-gray-50 border-2 border-dashed border-gray-300 rounded-lg p-12 text-center">
+        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
+        </svg>
+        <h3 class="mt-4 text-lg font-medium text-gray-900">No performance data yet</h3>
+        <p class="mt-2 text-sm text-gray-500">
+            Grafana Beyla is collecting HTTP metrics via eBPF.<br>
+            Send some traffic to this application and metrics will appear automatically.
+        </p>
+        <p class="mt-4 text-xs text-gray-400">
+            Beyla auto-instruments all HTTP traffic without code changes — like Netflix Spectator for any language.
+        </p>
+    </div>
+    {{end}}
+</div>
+{{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -117,6 +117,21 @@ func templateFuncs() template.FuncMap {
 			}
 			return d
 		},
+		"mul": func(a, b float64) float64 {
+			return a * b
+		},
+		"fmtFloat": func(f float64, prec int) string {
+			return fmt.Sprintf("%.*f", prec, f)
+		},
+		"fmtMs": func(seconds float64) string {
+			if seconds < 0.001 {
+				return fmt.Sprintf("%.0fus", seconds*1e6)
+			}
+			if seconds < 1 {
+				return fmt.Sprintf("%.1fms", seconds*1000)
+			}
+			return fmt.Sprintf("%.2fs", seconds)
+		},
 	}
 }
 
@@ -182,9 +197,10 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"tab_services.html":  base,
 		"tab_routes.html":    base,
 		"tab_logs.html":      base,
-		"tab_metrics.html":   base,
-		"alerts_list.html":   base,
-		"log_history.html":   base,
+		"tab_metrics.html":      base,
+		"tab_performance.html":  base,
+		"alerts_list.html":      base,
+		"log_history.html":      base,
 	}
 
 	return &TemplateRenderer{base: base, pages: pages, partials: partials}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,8 @@ type MonitoringConfig struct {
 	GrafanaURL      string `mapstructure:"grafana_url"`
 	LokiURL         string `mapstructure:"loki_url"`
 	AlertmanagerURL string `mapstructure:"alertmanager_url"`
+	PrometheusURL   string `mapstructure:"prometheus_url"`
+	BeylaEnabled    bool   `mapstructure:"beyla_enabled"`
 }
 
 type GitHubConfig struct {
@@ -127,6 +129,8 @@ func Load() (*Config, error) {
 	v.SetDefault("monitoring.grafana_url", "http://grafana.cf-local.dev")
 	v.SetDefault("monitoring.loki_url", "http://loki.monitoring.svc.cluster.local:3100")
 	v.SetDefault("monitoring.alertmanager_url", "http://kube-prometheus-kube-prome-alertmanager.monitoring.svc.cluster.local:9093")
+	v.SetDefault("monitoring.prometheus_url", "http://kube-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090")
+	v.SetDefault("monitoring.beyla_enabled", true)
 
 	// Read config file (optional — not an error if missing)
 	if err := v.ReadInConfig(); err != nil {

--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -121,7 +121,15 @@ func (c *Client) DeployApp(ctx context.Context, app models.App, routes []models.
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+					Annotations: map[string]string{
+						"microfoundry.io/observable": "true",
+						"prometheus.io/scrape":       "true",
+						"prometheus.io/port":         fmt.Sprintf("%d", app.Port),
+						"prometheus.io/path":         "/metrics",
+					},
+				},
 				Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
 			},
 		},

--- a/pkg/monitoring/prometheus.go
+++ b/pkg/monitoring/prometheus.go
@@ -1,0 +1,116 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// PrometheusClient queries Prometheus for pre-computed recording rule values.
+type PrometheusClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// REDMetrics holds Rate, Error rate, and Duration percentiles for an app.
+type REDMetrics struct {
+	RequestRate float64 `json:"request_rate"`
+	ErrorRate   float64 `json:"error_rate"`
+	LatencyP50  float64 `json:"latency_p50"`
+	LatencyP95  float64 `json:"latency_p95"`
+	LatencyP99  float64 `json:"latency_p99"`
+	HasData     bool    `json:"has_data"`
+}
+
+// prometheusResponse is the JSON envelope from the Prometheus instant query API.
+type prometheusResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			Value  [2]any            `json:"value"` // [timestamp, "value"]
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// GetAppREDMetrics queries Prometheus for pre-computed RED metrics for an app.
+func (p *PrometheusClient) GetAppREDMetrics(ctx context.Context, appName string) (*REDMetrics, error) {
+	metrics := &REDMetrics{}
+
+	queries := map[string]*float64{
+		fmt.Sprintf(`microfoundry:http_request_rate:5m{k8s_deployment_name="%s"}`, appName): &metrics.RequestRate,
+		fmt.Sprintf(`microfoundry:http_error_rate:5m{k8s_deployment_name="%s"}`, appName):   &metrics.ErrorRate,
+		fmt.Sprintf(`microfoundry:http_latency_p50:5m{k8s_deployment_name="%s"}`, appName):  &metrics.LatencyP50,
+		fmt.Sprintf(`microfoundry:http_latency_p95:5m{k8s_deployment_name="%s"}`, appName):  &metrics.LatencyP95,
+		fmt.Sprintf(`microfoundry:http_latency_p99:5m{k8s_deployment_name="%s"}`, appName):  &metrics.LatencyP99,
+	}
+
+	for query, dest := range queries {
+		val, err := p.instantQuery(ctx, query)
+		if err != nil {
+			continue
+		}
+		if !math.IsNaN(val) {
+			*dest = val
+			metrics.HasData = true
+		}
+	}
+
+	return metrics, nil
+}
+
+// instantQuery executes a Prometheus instant query and returns the scalar value.
+func (p *PrometheusClient) instantQuery(ctx context.Context, query string) (float64, error) {
+	u, err := url.Parse(p.BaseURL)
+	if err != nil {
+		return 0, err
+	}
+	u.Path = "/api/v1/query"
+	q := u.Query()
+	q.Set("query", query)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("prometheus query failed: %s", resp.Status)
+	}
+
+	var pr prometheusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return 0, err
+	}
+
+	if pr.Status != "success" || len(pr.Data.Result) == 0 {
+		return math.NaN(), nil
+	}
+
+	valStr, ok := pr.Data.Result[0].Value[1].(string)
+	if !ok {
+		return math.NaN(), nil
+	}
+	return strconv.ParseFloat(valStr, 64)
+}
+
+// NewPrometheusClient creates a Prometheus query client.
+func NewPrometheusClient(baseURL string) *PrometheusClient {
+	return &PrometheusClient{
+		BaseURL:    baseURL,
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}


### PR DESCRIPTION
## Summary

Closes #18

- Deploy Grafana Beyla as eBPF DaemonSet for zero-code HTTP metrics collection
- Add Prometheus recording rules for pre-computed RED metrics (Rate, Errors, Duration)
- Enhance Grafana dashboard with RED stat panels, latency percentiles, heatmap
- Add Performance tab to admin UI with live RED metric cards from Prometheus
- Add pod observability annotations to all MicroFoundry-deployed applications
- Add Beyla-based alert rules (high error rate, high latency, no traffic)

## Changes (16 files: 5 new + 11 modified)

| File | Type | Description |
|------|------|-------------|
| `deploy/monitoring/beyla-config.yaml` | NEW | Beyla DaemonSet + RBAC + ServiceMonitor |
| `deploy/monitoring/prometheus-recording-rules.yaml` | NEW | Pre-computed RED recording rules |
| `pkg/monitoring/prometheus.go` | NEW | Prometheus instant query client |
| `pkg/admin/performance_handlers.go` | NEW | Performance tab + RED API handlers |
| `pkg/admin/static/templates/tabs/tab_performance.html` | NEW | Performance tab template |
| `deploy/monitoring/install.sh` | MOD | Added Beyla deploy step [4/6] |
| `deploy/monitoring/alerts/microfoundry-alerts.yaml` | MOD | Beyla-based alert rules |
| `deploy/monitoring/dashboards/mf-app-detail.yaml` | MOD | RED panels + dynamic app variable |
| `pkg/config/config.go` | MOD | PrometheusURL, BeylaEnabled config |
| `configs/mf.example.yaml` | MOD | New monitoring config fields |
| `pkg/k8s/app.go` | MOD | Pod observability annotations |
| `pkg/admin/server.go` | MOD | PrometheusClient + API routes |
| `pkg/admin/handlers.go` | MOD | Performance tab in validTabs |
| `pkg/admin/templates.go` | MOD | Template funcs (mul, fmtFloat, fmtMs) |
| `pkg/admin/static/templates/app_detail.html` | MOD | Performance tab navigation |
| `cmd/mf/push.go` | MOD | Observability output after deploy |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Beyla DaemonSet running (1/1 READY)
- [x] Recording rules deployed to Prometheus
- [x] Alert rules deployed (MFAppHighErrorRate, MFAppHighLatency, MFAppNoTraffic)
- [x] Enhanced Grafana dashboard with RED panels applied
- [ ] Deploy sample app and verify RED metrics appear
- [ ] Verify Performance tab renders with live data
- [ ] Verify `/api/apps/{name}/red-metrics` returns JSON
- [ ] Verify `/api/apps/{name}/health` returns health summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)