### PR TITLE
feat: platform configuration — registry, webhooks, SMTP & menu restructure

### DIFF
--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -16,6 +16,7 @@ import (
 	"github.com/younjinjeong/microfoundry/pkg/k8s"
 	"github.com/younjinjeong/microfoundry/pkg/manifest"
 	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/settings"
 )
 
 func pushCmd() *cobra.Command {
@@ -94,12 +95,30 @@ func pushCmd() *cobra.Command {
 				app.Env["MICROFOUNDRY_OWNER"] = u.Username
 			}
 
+			// Connect to K8s early so we can read registry settings
+			k8sClient, err := k8s.NewClient(cluster.Context, cluster.Namespace, domain)
+			if err != nil {
+				return fmt.Errorf("connecting to kubernetes: %w", err)
+			}
+
+			// Determine image prefix from registry settings (if configured)
+			imagePrefix := "microfoundry/"
+			var registryCfg *models.RegistryConfig
+			var registryPassword string
+			store := settings.NewStore(k8sClient)
+			if ps, err := store.Get(ctx); err == nil && ps.Registry.Enabled && ps.Registry.URL != "" {
+				registryCfg = &ps.Registry
+				imagePrefix = registryCfg.ImagePrefix()
+				registryPassword, _ = store.GetCredential(ctx, "registry-password")
+				fmt.Printf("Registry: %s (project: %s)\n", registryCfg.URL, registryCfg.Project)
+			}
+
 			// Phase 1: Build
 			fmt.Printf("Building %s...\n", app.Name)
 			strategy := build.DetectBuildStrategy(srcDir)
 			fmt.Printf("  Strategy: %s\n", strategy)
 
-			builder := build.NewBuilder("microfoundry/")
+			builder := build.NewBuilder(imagePrefix)
 			result, err := builder.Build(app.Name, srcDir)
 			if err != nil {
 				fmt.Printf("  Build: FAILED\n")
@@ -109,12 +128,29 @@ func pushCmd() *cobra.Command {
 			app.State = models.AppStateDeploying
 			fmt.Printf("  Build: OK (%s)\n", result.ImageRef)
 
+			// Phase 1.5: Push to registry (if configured)
+			if registryCfg != nil && registryPassword != "" {
+				fmt.Printf("Pushing to registry %s...\n", registryCfg.URL)
+				if err := builder.Login(registryCfg.URL, registryCfg.Username, registryPassword); err != nil {
+					return fmt.Errorf("registry login failed: %w", err)
+				}
+				fmt.Printf("  Login: OK\n")
+
+				if err := builder.Push(result.ImageRef); err != nil {
+					return fmt.Errorf("registry push failed: %w", err)
+				}
+				fmt.Printf("  Push: OK (%s)\n", result.ImageRef)
+
+				// Ensure imagePullSecret exists in namespace
+				if err := k8sClient.EnsureImagePullSecret(ctx, registryCfg.URL, registryCfg.Username, registryPassword); err != nil {
+					fmt.Printf("  ImagePullSecret: WARN (%v)\n", err)
+				} else {
+					fmt.Printf("  ImagePullSecret: OK\n")
+				}
+			}
+
 			// Phase 2: Deploy to K8s
 			fmt.Printf("Deploying %s to cluster %s...\n", app.Name, cfg.Kubernetes.Active)
-			k8sClient, err := k8s.NewClient(cluster.Context, cluster.Namespace, domain)
-			if err != nil {
-				return fmt.Errorf("connecting to kubernetes: %w", err)
-			}
 
 			if err := k8sClient.EnsureNamespace(ctx); err != nil {
 				return fmt.Errorf("namespace setup: %w", err)

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -36,3 +36,18 @@ monitoring:
   alertmanager_url: "http://kube-prometheus-kube-prome-alertmanager.monitoring.svc.cluster.local:9093"
   prometheus_url: "http://kube-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090"
   beyla_enabled: true
+
+# Container registry (file-based defaults; admin UI settings stored in K8s take precedence)
+# registry:
+#   url: "harbor.local:30003"
+#   project: "microfoundry"
+#   username: "admin"
+#   insecure: false
+
+# SMTP server (file-based defaults; admin UI settings stored in K8s take precedence)
+# smtp:
+#   host: "smtp.gmail.com"
+#   port: 587
+#   username: "user@example.com"
+#   from_addr: "noreply@microfoundry.local"
+#   tls: true

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -100,6 +100,20 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /monitoring", s.MonitoringHandler)
 	s.mux.HandleFunc("GET /monitoring/alerts", s.AlertsListHandler)
 
+	// Settings routes — Registry
+	s.mux.HandleFunc("GET /settings/registry", s.RegistrySettingsHandler)
+	s.mux.HandleFunc("POST /settings/registry", s.SaveRegistryHandler)
+	s.mux.HandleFunc("POST /settings/registry/test", s.TestRegistryHandler)
+	// Settings routes — Webhooks
+	s.mux.HandleFunc("GET /settings/webhooks", s.WebhooksSettingsHandler)
+	s.mux.HandleFunc("POST /settings/webhooks", s.CreateWebhookHandler)
+	s.mux.HandleFunc("DELETE /settings/webhooks/{id}", s.DeleteWebhookHandler)
+	s.mux.HandleFunc("POST /settings/webhooks/{id}/test", s.TestWebhookHandler)
+	// Settings routes — SMTP
+	s.mux.HandleFunc("GET /settings/smtp", s.SMTPSettingsHandler)
+	s.mux.HandleFunc("POST /settings/smtp", s.SaveSMTPHandler)
+	s.mux.HandleFunc("POST /settings/smtp/test", s.TestSMTPHandler)
+
 	// Catalog visibility routes
 	s.mux.HandleFunc("POST /catalog/{type}/{plan}/visibility", s.TogglePlanVisibilityHandler)
 	s.mux.HandleFunc("POST /catalog/{type}/visibility", s.ToggleServiceVisibilityHandler)
@@ -151,6 +165,14 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/apps/{name}/red-metrics", s.APIAppREDMetricsHandler)
 	s.mux.HandleFunc("GET /api/apps/{name}/health", s.APIAppHealthHandler)
 	s.mux.HandleFunc("GET /api/apps/{name}/observability", s.APIAppObservabilityHandler)
+
+	// Settings API routes
+	s.mux.HandleFunc("GET /api/settings", s.APIGetSettingsHandler)
+	s.mux.HandleFunc("PUT /api/settings/registry", s.APISaveRegistryHandler)
+	s.mux.HandleFunc("GET /api/settings/webhooks", s.APIGetWebhooksHandler)
+	s.mux.HandleFunc("POST /api/settings/webhooks", s.APICreateWebhookHandler)
+	s.mux.HandleFunc("DELETE /api/settings/webhooks/{id}", s.APIDeleteWebhookHandler)
+	s.mux.HandleFunc("PUT /api/settings/smtp", s.APISaveSMTPHandler)
 }
 
 func (s *Server) ListenAndServe(addr string) error {

--- a/pkg/admin/settings_handlers.go
+++ b/pkg/admin/settings_handlers.go
@@ -1,0 +1,458 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	"github.com/younjinjeong/microfoundry/pkg/settings"
+)
+
+// settingsStore creates a settings store for the current request's active cluster.
+func (s *Server) settingsStore(r *http.Request) (*settings.Store, error) {
+	client, err := s.getClient(r)
+	if err != nil {
+		return nil, err
+	}
+	return settings.NewStore(client), nil
+}
+
+// --- Registry ---
+
+// RegistrySettingsHandler renders the container registry configuration page.
+func (s *Server) RegistrySettingsHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	ps, _ := store.Get(ctx)
+	hasPwd, _ := store.GetCredential(ctx, "registry-password")
+
+	data := s.pageData("Registry", "settings-registry")
+	data.Content = map[string]any{
+		"Registry":    ps.Registry,
+		"HasPassword": hasPwd != "",
+		"Saved":       r.URL.Query().Get("saved") == "true",
+	}
+	s.templates.Render(w, "settings_registry.html", data)
+}
+
+// SaveRegistryHandler persists registry settings to K8s ConfigMap + Secret.
+func (s *Server) SaveRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	cfg := models.RegistryConfig{
+		URL:      r.FormValue("url"),
+		Project:  r.FormValue("project"),
+		Username: r.FormValue("username"),
+		Insecure: r.FormValue("insecure") == "true",
+		Enabled:  r.FormValue("enabled") == "true",
+	}
+	password := r.FormValue("password")
+
+	if err := store.SaveRegistry(r.Context(), cfg, password); err != nil {
+		http.Error(w, "Failed to save: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// If registry is enabled and credentials are available, ensure the imagePullSecret exists
+	if cfg.Enabled && cfg.URL != "" && cfg.Username != "" {
+		if password == "" {
+			password, _ = store.GetCredential(r.Context(), "registry-password")
+		}
+		if password != "" {
+			client, _ := s.getClient(r)
+			if client != nil {
+				_ = client.EnsureImagePullSecret(r.Context(), cfg.URL, cfg.Username, password)
+			}
+		}
+	}
+
+	http.Redirect(w, r, "/settings/registry?saved=true", http.StatusSeeOther)
+}
+
+// TestRegistryHandler tests the registry connection by attempting docker login.
+func (s *Server) TestRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	url := r.FormValue("url")
+	username := r.FormValue("username")
+	password := r.FormValue("password")
+
+	if url == "" || username == "" {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<span class="text-red-600">URL and username are required.</span>`)
+		return
+	}
+
+	// If no password in form, try stored credential
+	if password == "" {
+		store, err := s.settingsStore(r)
+		if err == nil {
+			password, _ = store.GetCredential(r.Context(), "registry-password")
+		}
+	}
+
+	if password == "" {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<span class="text-red-600">Password is required for connection test.</span>`)
+		return
+	}
+
+	// Test by trying an HTTP request to /v2/ (OCI registry API)
+	testURL := fmt.Sprintf("https://%s/v2/", url)
+	if r.FormValue("insecure") == "true" {
+		testURL = fmt.Sprintf("http://%s/v2/", url)
+	}
+
+	req, _ := http.NewRequestWithContext(r.Context(), "GET", testURL, nil)
+	req.SetBasicAuth(username, password)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+
+	w.Header().Set("Content-Type", "text/html")
+	if err != nil {
+		fmt.Fprintf(w, `<span class="text-red-600">Connection failed: %s</span>`, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized {
+		// 200 = authenticated, 401 = registry reachable but bad creds
+		if resp.StatusCode == http.StatusOK {
+			fmt.Fprint(w, `<span class="text-green-600">Connected and authenticated successfully.</span>`)
+		} else {
+			fmt.Fprint(w, `<span class="text-yellow-600">Registry reachable but authentication failed. Check credentials.</span>`)
+		}
+	} else {
+		fmt.Fprintf(w, `<span class="text-yellow-600">Registry returned status %d.</span>`, resp.StatusCode)
+	}
+}
+
+// --- Webhooks ---
+
+// WebhooksSettingsHandler renders the webhooks list page.
+func (s *Server) WebhooksSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	ps, _ := store.Get(r.Context())
+
+	data := s.pageData("Webhooks", "settings-webhooks")
+	data.Content = map[string]any{
+		"Webhooks":   ps.Webhooks,
+		"EventTypes": models.WebhookEventTypes,
+	}
+	s.templates.Render(w, "settings_webhooks.html", data)
+}
+
+// CreateWebhookHandler adds a new webhook.
+func (s *Server) CreateWebhookHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	r.ParseForm()
+	wh := models.WebhookConfig{
+		ID:        uuid.New().String()[:8],
+		Name:      r.FormValue("name"),
+		URL:       r.FormValue("url"),
+		Events:    r.Form["events"],
+		Enabled:   r.FormValue("enabled") == "true",
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+
+	if err := store.AddWebhook(r.Context(), wh); err != nil {
+		http.Error(w, "Failed to create webhook: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/settings/webhooks")
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeleteWebhookHandler removes a webhook by ID.
+func (s *Server) DeleteWebhookHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := store.DeleteWebhook(r.Context(), id); err != nil {
+		http.Error(w, "Failed to delete webhook: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// TestWebhookHandler sends a test payload to a webhook.
+func (s *Server) TestWebhookHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	id := r.PathValue("id")
+	ps, _ := store.Get(r.Context())
+
+	var wh *models.WebhookConfig
+	for i := range ps.Webhooks {
+		if ps.Webhooks[i].ID == id {
+			wh = &ps.Webhooks[i]
+			break
+		}
+	}
+
+	if wh == nil {
+		http.Error(w, "Webhook not found", http.StatusNotFound)
+		return
+	}
+
+	payload := map[string]any{
+		"event":     "test.ping",
+		"timestamp": time.Now().Format(time.RFC3339),
+		"source":    "microfoundry",
+		"data": map[string]string{
+			"message": "Test webhook from MicroFoundry",
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequestWithContext(r.Context(), "POST", wh.URL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-MicroFoundry-Event", "test.ping")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "error", "message": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":      "sent",
+		"status_code": resp.StatusCode,
+	})
+}
+
+// --- SMTP ---
+
+// SMTPSettingsHandler renders the SMTP configuration page.
+func (s *Server) SMTPSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := r.Context()
+	ps, _ := store.Get(ctx)
+	hasPwd, _ := store.GetCredential(ctx, "smtp-password")
+
+	data := s.pageData("SMTP", "settings-smtp")
+	data.Content = map[string]any{
+		"SMTP":        ps.SMTP,
+		"HasPassword": hasPwd != "",
+		"Saved":       r.URL.Query().Get("saved") == "true",
+	}
+	s.templates.Render(w, "settings_smtp.html", data)
+}
+
+// SaveSMTPHandler persists SMTP settings to K8s ConfigMap + Secret.
+func (s *Server) SaveSMTPHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	port, _ := strconv.Atoi(r.FormValue("port"))
+	if port == 0 {
+		port = 587
+	}
+
+	cfg := models.SMTPConfig{
+		Host:     r.FormValue("host"),
+		Port:     port,
+		Username: r.FormValue("username"),
+		FromAddr: r.FormValue("from_addr"),
+		TLS:      r.FormValue("tls") == "true",
+		Enabled:  r.FormValue("enabled") == "true",
+	}
+	password := r.FormValue("password")
+
+	if err := store.SaveSMTP(r.Context(), cfg, password); err != nil {
+		http.Error(w, "Failed to save: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/settings/smtp?saved=true", http.StatusSeeOther)
+}
+
+// TestSMTPHandler tests the SMTP connection by dialing the server.
+func (s *Server) TestSMTPHandler(w http.ResponseWriter, r *http.Request) {
+	host := r.FormValue("host")
+	port := r.FormValue("port")
+	if host == "" || port == "" {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<span class="text-red-600">Host and port are required.</span>`)
+		return
+	}
+
+	addr := host + ":" + port
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+
+	w.Header().Set("Content-Type", "text/html")
+	if err != nil {
+		fmt.Fprintf(w, `<span class="text-red-600">Connection failed: %s</span>`, err.Error())
+		return
+	}
+	conn.Close()
+	fmt.Fprint(w, `<span class="text-green-600">TCP connection to SMTP server successful.</span>`)
+}
+
+// --- API Endpoints ---
+
+// APIGetSettingsHandler returns all platform settings as JSON.
+func (s *Server) APIGetSettingsHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ps, err := store.Get(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Redact sensitive fields
+	ps.Registry.Username = ""
+	writeJSON(w, http.StatusOK, ps)
+}
+
+// APISaveRegistryHandler saves registry settings from JSON body.
+func (s *Server) APISaveRegistryHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var body struct {
+		models.RegistryConfig
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if err := store.SaveRegistry(r.Context(), body.RegistryConfig, body.Password); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
+}
+
+// APIGetWebhooksHandler returns all webhooks as JSON.
+func (s *Server) APIGetWebhooksHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ps, _ := store.Get(r.Context())
+	writeJSON(w, http.StatusOK, ps.Webhooks)
+}
+
+// APICreateWebhookHandler creates a webhook from JSON body.
+func (s *Server) APICreateWebhookHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var wh models.WebhookConfig
+	if err := json.NewDecoder(r.Body).Decode(&wh); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	wh.ID = uuid.New().String()[:8]
+	wh.CreatedAt = time.Now().Format(time.RFC3339)
+
+	if err := store.AddWebhook(r.Context(), wh); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, wh)
+}
+
+// APIDeleteWebhookHandler deletes a webhook by ID.
+func (s *Server) APIDeleteWebhookHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := store.DeleteWebhook(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// APISaveSMTPHandler saves SMTP settings from JSON body.
+func (s *Server) APISaveSMTPHandler(w http.ResponseWriter, r *http.Request) {
+	store, err := s.settingsStore(r)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+
+	var body struct {
+		models.SMTPConfig
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	if err := store.SaveSMTP(r.Context(), body.SMTPConfig, body.Password); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "saved"})
+}

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -44,13 +44,6 @@
             </svg>
             Metrics & Alerts
         </a>
-        <a href="/users"
-           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
-            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
-            </svg>
-            Users & Orgs
-        </a>
 
         <!-- Settings -->
         <div class="px-3 pt-5 pb-1">
@@ -91,6 +84,13 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
             </svg>
             SMTP
+        </a>
+        <a href="/users"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            Users & Orgs
         </a>
         <a href="/config"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "config"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -5,19 +5,16 @@
         <span class="text-xs text-gray-500">{{.Version}}</span>
     </div>
     <nav class="flex-1 p-3 space-y-1">
+        <!-- Operations -->
+        <div class="px-3 pt-3 pb-1">
+            <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Operations</span>
+        </div>
         <a href="/"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "dashboard"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
             </svg>
             Dashboard
-        </a>
-        <a href="/clusters"
-           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "clusters"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
-            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
-            </svg>
-            Kubernetes Clusters
         </a>
         <a href="/apps"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "apps"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
@@ -32,13 +29,6 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
             </svg>
             Services
-        </a>
-        <a href="/catalog"
-           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "catalog"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
-            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
-            </svg>
-            Service Catalog
         </a>
         <a href="/secrets"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "secrets"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
@@ -61,13 +51,54 @@
             </svg>
             Users & Orgs
         </a>
+
+        <!-- Settings -->
+        <div class="px-3 pt-5 pb-1">
+            <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Settings</span>
+        </div>
+        <a href="/clusters"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "clusters"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
+            </svg>
+            Clusters
+        </a>
+        <a href="/catalog"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "catalog"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
+            </svg>
+            Service Catalog
+        </a>
+        <a href="/settings/registry"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-registry"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11v4m0 0l-2-2m2 2l2-2"/>
+            </svg>
+            Registry
+        </a>
+        <a href="/settings/webhooks"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-webhooks"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+            </svg>
+            Webhooks
+        </a>
+        <a href="/settings/smtp"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-smtp"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+            </svg>
+            SMTP
+        </a>
         <a href="/config"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "config"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
             </svg>
-            Configuration
+            Platform
         </a>
     </nav>
 </aside>

--- a/pkg/admin/static/templates/settings_registry.html
+++ b/pkg/admin/static/templates/settings_registry.html
@@ -1,0 +1,113 @@
+{{define "settings_registry.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="max-w-2xl mx-auto">
+    {{if index $c "Saved"}}
+    <div class="mb-6 rounded-md bg-green-50 p-4 border border-green-200">
+        <div class="flex">
+            <svg class="h-5 w-5 text-green-400 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+            <p class="text-sm font-medium text-green-800">Registry settings saved successfully.</p>
+        </div>
+    </div>
+    {{end}}
+
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">Container Registry</h3>
+            <p class="mt-1 text-sm text-gray-500">Configure a Docker/OCI registry for pushing application images. When enabled, <code class="text-xs bg-gray-100 px-1 py-0.5 rounded">mf push</code> will push images to this registry instead of keeping them local.</p>
+        </div>
+
+        <form action="/settings/registry" method="POST" class="p-6 space-y-5">
+            <div>
+                <label for="reg-url" class="block text-sm font-medium text-gray-700 mb-1">Registry URL</label>
+                <input type="text" id="reg-url" name="url" value="{{(index $c "Registry").URL}}"
+                       placeholder="harbor.local:30003"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                <p class="mt-1 text-xs text-gray-500">Hostname and optional port (no protocol). Example: <code>harbor.local:30003</code></p>
+            </div>
+
+            <div>
+                <label for="reg-project" class="block text-sm font-medium text-gray-700 mb-1">Project / Namespace</label>
+                <input type="text" id="reg-project" name="project" value="{{(index $c "Registry").Project}}"
+                       placeholder="microfoundry"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                <p class="mt-1 text-xs text-gray-500">The project or namespace in the registry. Images will be tagged as <code>url/project/app:latest</code>.</p>
+            </div>
+
+            <div>
+                <label for="reg-username" class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+                <input type="text" id="reg-username" name="username" value="{{(index $c "Registry").Username}}"
+                       placeholder="admin"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            </div>
+
+            <div>
+                <label for="reg-password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+                <input type="password" id="reg-password" name="password"
+                       placeholder="{{if index $c "HasPassword"}}(leave blank to keep existing){{else}}Enter password{{end}}"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                {{if index $c "HasPassword"}}
+                <p class="mt-1 text-xs text-gray-500">A password is currently set. Leave blank to keep it unchanged.</p>
+                {{end}}
+            </div>
+
+            <div class="flex items-center space-x-6">
+                <label class="flex items-center">
+                    <input type="checkbox" name="insecure" value="true" {{if (index $c "Registry").Insecure}}checked{{end}}
+                           class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                    <span class="ml-2 text-sm text-gray-700">Skip TLS Verification</span>
+                </label>
+
+                <label class="flex items-center">
+                    <input type="checkbox" name="enabled" value="true" {{if (index $c "Registry").Enabled}}checked{{end}}
+                           class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                    <span class="ml-2 text-sm text-gray-700">Enable Registry Push</span>
+                </label>
+            </div>
+
+            <!-- Test Connection -->
+            <div class="border-t border-gray-200 pt-5">
+                <div class="flex items-center space-x-3">
+                    <button type="button"
+                            hx-post="/settings/registry/test"
+                            hx-include="closest form"
+                            hx-target="#test-result"
+                            hx-swap="innerHTML"
+                            class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                        </svg>
+                        Test Connection
+                    </button>
+                    <div id="test-result" class="text-sm"></div>
+                </div>
+            </div>
+
+            <!-- Preview -->
+            {{if (index $c "Registry").Enabled}}
+            <div class="bg-gray-50 border border-gray-200 rounded-md p-4">
+                <p class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Image Tag Preview</p>
+                <code class="text-sm text-gray-800">{{(index $c "Registry").ImagePrefix}}my-app:latest</code>
+            </div>
+            {{end}}
+
+            <!-- Actions -->
+            <div class="flex items-center space-x-3 pt-2">
+                <button type="submit"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                    Save Registry Settings
+                </button>
+                <a href="/config"
+                   class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/settings_smtp.html
+++ b/pkg/admin/static/templates/settings_smtp.html
@@ -1,0 +1,111 @@
+{{define "settings_smtp.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="max-w-2xl mx-auto">
+    {{if index $c "Saved"}}
+    <div class="mb-6 rounded-md bg-green-50 p-4 border border-green-200">
+        <div class="flex">
+            <svg class="h-5 w-5 text-green-400 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+            <p class="text-sm font-medium text-green-800">SMTP settings saved successfully.</p>
+        </div>
+    </div>
+    {{end}}
+
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200">
+            <h3 class="text-lg font-medium text-gray-900">SMTP Configuration</h3>
+            <p class="mt-1 text-sm text-gray-500">Configure an SMTP server for sending email notifications (alerts, deployment reports).</p>
+        </div>
+
+        <form action="/settings/smtp" method="POST" class="p-6 space-y-5">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label for="smtp-host" class="block text-sm font-medium text-gray-700 mb-1">SMTP Host</label>
+                    <input type="text" id="smtp-host" name="host" value="{{(index $c "SMTP").Host}}"
+                           placeholder="smtp.gmail.com"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="smtp-port" class="block text-sm font-medium text-gray-700 mb-1">Port</label>
+                    <input type="number" id="smtp-port" name="port" value="{{if (index $c "SMTP").Port}}{{(index $c "SMTP").Port}}{{else}}587{{end}}"
+                           placeholder="587"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+            </div>
+
+            <div>
+                <label for="smtp-username" class="block text-sm font-medium text-gray-700 mb-1">Username</label>
+                <input type="text" id="smtp-username" name="username" value="{{(index $c "SMTP").Username}}"
+                       placeholder="user@example.com"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            </div>
+
+            <div>
+                <label for="smtp-password" class="block text-sm font-medium text-gray-700 mb-1">Password</label>
+                <input type="password" id="smtp-password" name="password"
+                       placeholder="{{if index $c "HasPassword"}}(leave blank to keep existing){{else}}Enter password{{end}}"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                {{if index $c "HasPassword"}}
+                <p class="mt-1 text-xs text-gray-500">A password is currently set. Leave blank to keep it unchanged.</p>
+                {{end}}
+            </div>
+
+            <div>
+                <label for="smtp-from" class="block text-sm font-medium text-gray-700 mb-1">From Address</label>
+                <input type="email" id="smtp-from" name="from_addr" value="{{(index $c "SMTP").FromAddr}}"
+                       placeholder="noreply@microfoundry.local"
+                       class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            </div>
+
+            <div class="flex items-center space-x-6">
+                <label class="flex items-center">
+                    <input type="checkbox" name="tls" value="true" {{if (index $c "SMTP").TLS}}checked{{end}}
+                           class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                    <span class="ml-2 text-sm text-gray-700">Use TLS</span>
+                </label>
+
+                <label class="flex items-center">
+                    <input type="checkbox" name="enabled" value="true" {{if (index $c "SMTP").Enabled}}checked{{end}}
+                           class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                    <span class="ml-2 text-sm text-gray-700">Enable SMTP</span>
+                </label>
+            </div>
+
+            <!-- Test Connection -->
+            <div class="border-t border-gray-200 pt-5">
+                <div class="flex items-center space-x-3">
+                    <button type="button"
+                            hx-post="/settings/smtp/test"
+                            hx-include="closest form"
+                            hx-target="#test-result"
+                            hx-swap="innerHTML"
+                            class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                        </svg>
+                        Test Connection
+                    </button>
+                    <div id="test-result" class="text-sm"></div>
+                </div>
+            </div>
+
+            <!-- Actions -->
+            <div class="flex items-center space-x-3 pt-2">
+                <button type="submit"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                    Save SMTP Settings
+                </button>
+                <a href="/config"
+                   class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/static/templates/settings_webhooks.html
+++ b/pkg/admin/static/templates/settings_webhooks.html
@@ -1,0 +1,138 @@
+{{define "settings_webhooks.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+<div class="bg-white rounded-lg shadow">
+    <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <div>
+            <h3 class="text-lg font-medium text-gray-900">Webhooks</h3>
+            <p class="mt-1 text-sm text-gray-500">Send HTTP POST notifications when platform events occur.</p>
+        </div>
+        <button onclick="document.getElementById('add-webhook-form').classList.toggle('hidden')"
+                class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            Add Webhook
+        </button>
+    </div>
+
+    <!-- Add Webhook Inline Form -->
+    <div id="add-webhook-form" class="hidden border-b border-gray-200 bg-gray-50 p-6">
+        <form hx-post="/settings/webhooks" hx-swap="none" class="space-y-4">
+            <h4 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">New Webhook</h4>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label for="wh-name" class="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                    <input type="text" id="wh-name" name="name" required
+                           placeholder="Slack Notifications"
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+                <div>
+                    <label for="wh-url" class="block text-sm font-medium text-gray-700 mb-1">URL</label>
+                    <input type="url" id="wh-url" name="url" required
+                           placeholder="https://hooks.slack.com/services/..."
+                           class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                </div>
+            </div>
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2">Events</label>
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+                    {{range index $c "EventTypes"}}
+                    <label class="flex items-center">
+                        <input type="checkbox" name="events" value="{{.}}"
+                               class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                        <span class="ml-2 text-xs text-gray-700">{{.}}</span>
+                    </label>
+                    {{end}}
+                </div>
+            </div>
+            <label class="flex items-center">
+                <input type="checkbox" name="enabled" value="true" checked
+                       class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
+                <span class="ml-2 text-sm text-gray-700">Enabled</span>
+            </label>
+            <div class="flex items-center space-x-3 pt-2">
+                <button type="submit"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                    Create Webhook
+                </button>
+                <button type="button"
+                        onclick="document.getElementById('add-webhook-form').classList.add('hidden')"
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Webhooks Table -->
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">URL</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Events</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                    <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                {{range index $c "Webhooks"}}
+                <tr class="hover:bg-gray-50">
+                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                        {{.Name}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 max-w-xs truncate" title="{{.URL}}">
+                        {{.URL}}
+                    </td>
+                    <td class="px-4 py-4">
+                        <div class="flex flex-wrap gap-1">
+                            {{range .Events}}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                {{.}}
+                            </span>
+                            {{end}}
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap">
+                        {{if .Enabled}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">active</span>
+                        {{else}}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">disabled</span>
+                        {{end}}
+                    </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                        <button hx-post="/settings/webhooks/{{.ID}}/test"
+                                hx-swap="none"
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors">
+                            Test
+                        </button>
+                        <button hx-delete="/settings/webhooks/{{.ID}}"
+                                hx-confirm="Delete webhook '{{.Name}}'?"
+                                hx-target="closest tr"
+                                hx-swap="outerHTML"
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 rounded-md transition-colors">
+                            Delete
+                        </button>
+                    </td>
+                </tr>
+                {{else}}
+                <tr>
+                    <td colspan="5" class="px-6 py-12 text-center text-gray-500">
+                        <svg class="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
+                        </svg>
+                        <p class="text-lg font-medium">No webhooks configured</p>
+                        <p class="text-sm mt-1">Click <strong>"Add Webhook"</strong> to create your first webhook.</p>
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -171,6 +171,9 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"topology_detail.html",
 		"topology_upload.html",
 		"monitoring.html",
+		"settings_registry.html",
+		"settings_webhooks.html",
+		"settings_smtp.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/build/builder.go
+++ b/pkg/build/builder.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // Builder handles source-to-image builds.
@@ -98,6 +99,31 @@ func DetectBuildStrategy(srcDir string) string {
 		return "cnb"
 	}
 	return "none"
+}
+
+// Login authenticates with a Docker registry via stdin to avoid leaking
+// credentials in the process list.
+func (b *Builder) Login(registry, username, password string) error {
+	cmd := exec.Command("docker", "login", registry,
+		"--username", username,
+		"--password-stdin")
+	cmd.Stdin = strings.NewReader(password)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker login failed: %s\n%s", err, string(output))
+	}
+	return nil
+}
+
+// Push pushes a built image to the remote registry.
+func (b *Builder) Push(imageRef string) error {
+	cmd := exec.Command("docker", "push", imageRef)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker push failed: %s\n%s", err, string(output))
+	}
+	return nil
 }
 
 // ImageExists checks if a Docker image exists locally.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,26 @@ type Config struct {
 	GitHub     GitHubConfig     `mapstructure:"github"`
 	Kubernetes KubernetesConfig `mapstructure:"kubernetes"`
 	Monitoring MonitoringConfig `mapstructure:"monitoring"`
+	Registry   RegistryConfig   `mapstructure:"registry"`
+	SMTP       SMTPConfig       `mapstructure:"smtp"`
+}
+
+// RegistryConfig provides file-based defaults for container registry settings.
+// Runtime settings from the admin UI (stored in K8s ConfigMap) take precedence.
+type RegistryConfig struct {
+	URL      string `mapstructure:"url"`
+	Project  string `mapstructure:"project"`
+	Username string `mapstructure:"username"`
+	Insecure bool   `mapstructure:"insecure"`
+}
+
+// SMTPConfig provides file-based defaults for SMTP settings.
+type SMTPConfig struct {
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	Username string `mapstructure:"username"`
+	FromAddr string `mapstructure:"from_addr"`
+	TLS      bool   `mapstructure:"tls"`
 }
 
 // MonitoringConfig holds endpoints for the monitoring stack.

--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -74,6 +74,16 @@ func (c *Client) DeployApp(ctx context.Context, app models.App, routes []models.
 		command = []string{"/bin/sh", "-c", app.Command}
 	}
 
+	// Use PullAlways when image references a remote registry (contains a '/' with a dot/colon prefix)
+	pullPolicy := corev1.PullIfNotPresent
+	if strings.Contains(app.ImageRef, ".") || strings.Contains(app.ImageRef, ":") {
+		// If imageRef looks like "harbor.local:30003/project/app:latest", use PullAlways
+		parts := strings.SplitN(app.ImageRef, "/", 2)
+		if len(parts) > 1 && (strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":")) {
+			pullPolicy = corev1.PullAlways
+		}
+	}
+
 	container := corev1.Container{
 		Name:            "app",
 		Image:           app.ImageRef,
@@ -81,7 +91,7 @@ func (c *Client) DeployApp(ctx context.Context, app models.App, routes []models.
 		Env:             envVars,
 		Command:         command,
 		ReadinessProbe:  readinessProbe,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: pullPolicy,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dMi", app.MemoryMB/2)),
@@ -130,7 +140,10 @@ func (c *Client) DeployApp(ctx context.Context, app models.App, routes []models.
 						"prometheus.io/path":         "/metrics",
 					},
 				},
-				Spec:       corev1.PodSpec{Containers: []corev1.Container{container}},
+				Spec: corev1.PodSpec{
+					Containers:       []corev1.Container{container},
+					ImagePullSecrets: c.imagePullSecrets(ctx),
+				},
 			},
 		},
 	}

--- a/pkg/k8s/registry.go
+++ b/pkg/k8s/registry.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const imagePullSecretName = "mf-registry-pull"
+
+// EnsureImagePullSecret creates or updates the Docker registry pull secret
+// in the current namespace. This is required for K8s to pull images from
+// private registries like Harbor.
+func (c *Client) EnsureImagePullSecret(ctx context.Context, registry, username, password string) error {
+	// Build .dockerconfigjson payload
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	dockerConfig := map[string]any{
+		"auths": map[string]any{
+			registry: map[string]string{
+				"username": username,
+				"password": password,
+				"auth":     auth,
+			},
+		},
+	}
+
+	configJSON, err := json.Marshal(dockerConfig)
+	if err != nil {
+		return fmt.Errorf("encoding docker config: %w", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imagePullSecretName,
+			Namespace: c.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "microfoundry",
+				"microfoundry.io/component":    "registry-pull-secret",
+			},
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			corev1.DockerConfigJsonKey: configJSON,
+		},
+	}
+
+	secAPI := c.Clientset.CoreV1().Secrets(c.Namespace)
+	existing, err := secAPI.Get(ctx, imagePullSecretName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = secAPI.Create(ctx, secret, metav1.CreateOptions{})
+		return err
+	} else if err != nil {
+		return err
+	}
+
+	secret.ResourceVersion = existing.ResourceVersion
+	_, err = secAPI.Update(ctx, secret, metav1.UpdateOptions{})
+	return err
+}
+
+// HasImagePullSecret checks if the registry pull secret exists in the namespace.
+func (c *Client) HasImagePullSecret(ctx context.Context) bool {
+	_, err := c.Clientset.CoreV1().Secrets(c.Namespace).Get(ctx, imagePullSecretName, metav1.GetOptions{})
+	return err == nil
+}
+
+// ImagePullSecretName returns the name of the registry pull secret.
+func ImagePullSecretName() string {
+	return imagePullSecretName
+}
+
+// imagePullSecrets returns the imagePullSecrets list for PodSpec if the
+// registry pull secret exists in the namespace. Returns nil otherwise.
+func (c *Client) imagePullSecrets(ctx context.Context) []corev1.LocalObjectReference {
+	if c.HasImagePullSecret(ctx) {
+		return []corev1.LocalObjectReference{{Name: imagePullSecretName}}
+	}
+	return nil
+}

--- a/pkg/models/settings.go
+++ b/pkg/models/settings.go
@@ -1,0 +1,74 @@
+package models
+
+import "strings"
+
+const (
+	PlatformSettingsConfigMapName = "mf-platform-settings"
+	PlatformCredentialsSecretName = "mf-platform-credentials"
+)
+
+// RegistryConfig holds Docker/OCI container registry settings.
+type RegistryConfig struct {
+	URL      string `json:"url"      mapstructure:"url"`
+	Project  string `json:"project"  mapstructure:"project"`
+	Username string `json:"username" mapstructure:"username"`
+	Insecure bool   `json:"insecure" mapstructure:"insecure"`
+	Enabled  bool   `json:"enabled"  mapstructure:"enabled"`
+}
+
+// ImagePrefix returns the prefix for image tags (e.g., "harbor.local:30003/microfoundry/").
+// Falls back to "microfoundry/" when registry is not configured.
+func (r *RegistryConfig) ImagePrefix() string {
+	if !r.Enabled || r.URL == "" {
+		return "microfoundry/"
+	}
+	// Strip protocol scheme if present
+	u := r.URL
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	u = strings.TrimRight(u, "/")
+
+	if r.Project != "" {
+		return u + "/" + r.Project + "/"
+	}
+	return u + "/"
+}
+
+// WebhookConfig holds a single webhook endpoint configuration.
+type WebhookConfig struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	URL       string   `json:"url"`
+	Events    []string `json:"events"`
+	Enabled   bool     `json:"enabled"`
+	CreatedAt string   `json:"created_at"`
+}
+
+// SMTPConfig holds SMTP server settings for email notifications.
+type SMTPConfig struct {
+	Host     string `json:"host"      mapstructure:"host"`
+	Port     int    `json:"port"      mapstructure:"port"`
+	Username string `json:"username"  mapstructure:"username"`
+	FromAddr string `json:"from_addr" mapstructure:"from_addr"`
+	TLS      bool   `json:"tls"       mapstructure:"tls"`
+	Enabled  bool   `json:"enabled"   mapstructure:"enabled"`
+}
+
+// PlatformSettings is the aggregate of all platform settings stored in ConfigMap.
+type PlatformSettings struct {
+	Registry RegistryConfig  `json:"registry"`
+	Webhooks []WebhookConfig `json:"webhooks"`
+	SMTP     SMTPConfig      `json:"smtp"`
+}
+
+// WebhookEventTypes lists all supported event types for webhook subscriptions.
+var WebhookEventTypes = []string{
+	"app.deployed",
+	"app.crashed",
+	"app.scaled",
+	"app.deleted",
+	"alert.fired",
+	"alert.resolved",
+	"service.created",
+	"service.deleted",
+}

--- a/pkg/settings/store.go
+++ b/pkg/settings/store.go
@@ -1,0 +1,185 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/younjinjeong/microfoundry/pkg/k8s"
+	"github.com/younjinjeong/microfoundry/pkg/models"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Store provides ConfigMap/Secret-backed persistence for platform settings.
+type Store struct {
+	k8sClient *k8s.Client
+}
+
+// NewStore creates a new settings store.
+func NewStore(client *k8s.Client) *Store {
+	return &Store{k8sClient: client}
+}
+
+// Get returns the current platform settings from the ConfigMap.
+func (s *Store) Get(ctx context.Context) (*models.PlatformSettings, error) {
+	cmAPI := s.k8sClient.Clientset.CoreV1().ConfigMaps(s.k8sClient.Namespace)
+	cm, err := cmAPI.Get(ctx, models.PlatformSettingsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &models.PlatformSettings{}, nil
+		}
+		return nil, err
+	}
+
+	settings := &models.PlatformSettings{}
+	if data, ok := cm.Data["settings"]; ok {
+		if err := json.Unmarshal([]byte(data), settings); err != nil {
+			return &models.PlatformSettings{}, nil
+		}
+	}
+	return settings, nil
+}
+
+// SaveRegistry saves registry configuration. Password goes to Secret, rest to ConfigMap.
+func (s *Store) SaveRegistry(ctx context.Context, cfg models.RegistryConfig, password string) error {
+	if err := s.update(ctx, func(settings *models.PlatformSettings) {
+		settings.Registry = cfg
+	}); err != nil {
+		return err
+	}
+
+	if password != "" {
+		return s.updateSecret(ctx, "registry-password", password)
+	}
+	return nil
+}
+
+// SaveSMTP saves SMTP configuration. Password goes to Secret, rest to ConfigMap.
+func (s *Store) SaveSMTP(ctx context.Context, cfg models.SMTPConfig, password string) error {
+	if err := s.update(ctx, func(settings *models.PlatformSettings) {
+		settings.SMTP = cfg
+	}); err != nil {
+		return err
+	}
+
+	if password != "" {
+		return s.updateSecret(ctx, "smtp-password", password)
+	}
+	return nil
+}
+
+// AddWebhook adds a single webhook to the list.
+func (s *Store) AddWebhook(ctx context.Context, wh models.WebhookConfig) error {
+	return s.update(ctx, func(settings *models.PlatformSettings) {
+		settings.Webhooks = append(settings.Webhooks, wh)
+	})
+}
+
+// DeleteWebhook removes a webhook by ID.
+func (s *Store) DeleteWebhook(ctx context.Context, id string) error {
+	return s.update(ctx, func(settings *models.PlatformSettings) {
+		filtered := make([]models.WebhookConfig, 0, len(settings.Webhooks))
+		for _, wh := range settings.Webhooks {
+			if wh.ID != id {
+				filtered = append(filtered, wh)
+			}
+		}
+		settings.Webhooks = filtered
+	})
+}
+
+// GetCredential retrieves a single credential from the platform Secret.
+func (s *Store) GetCredential(ctx context.Context, key string) (string, error) {
+	secAPI := s.k8sClient.Clientset.CoreV1().Secrets(s.k8sClient.Namespace)
+	sec, err := secAPI.Get(ctx, models.PlatformCredentialsSecretName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(sec.Data[key]), nil
+}
+
+// update applies a mutation function to the platform settings with optimistic concurrency.
+func (s *Store) update(ctx context.Context, mutate func(*models.PlatformSettings)) error {
+	cmAPI := s.k8sClient.Clientset.CoreV1().ConfigMaps(s.k8sClient.Namespace)
+
+	cm, err := cmAPI.Get(ctx, models.PlatformSettingsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		// Create new ConfigMap
+		settings := &models.PlatformSettings{}
+		mutate(settings)
+		data, _ := json.Marshal(settings)
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      models.PlatformSettingsConfigMapName,
+				Namespace: s.k8sClient.Namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "microfoundry",
+					"microfoundry.io/component":    "platform-settings",
+				},
+			},
+			Data: map[string]string{
+				"settings": string(data),
+			},
+		}
+		_, err = cmAPI.Create(ctx, cm, metav1.CreateOptions{})
+		return err
+	}
+
+	// Update existing ConfigMap
+	settings := &models.PlatformSettings{}
+	if raw, ok := cm.Data["settings"]; ok {
+		json.Unmarshal([]byte(raw), settings)
+	}
+	mutate(settings)
+	data, _ := json.Marshal(settings)
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["settings"] = string(data)
+	_, err = cmAPI.Update(ctx, cm, metav1.UpdateOptions{})
+	return err
+}
+
+// updateSecret creates or updates a key in the platform credentials Secret.
+func (s *Store) updateSecret(ctx context.Context, key, value string) error {
+	secAPI := s.k8sClient.Clientset.CoreV1().Secrets(s.k8sClient.Namespace)
+
+	sec, err := secAPI.Get(ctx, models.PlatformCredentialsSecretName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		// Create new Secret
+		sec = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      models.PlatformCredentialsSecretName,
+				Namespace: s.k8sClient.Namespace,
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "microfoundry",
+					"microfoundry.io/component":    "platform-credentials",
+				},
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				key: []byte(value),
+			},
+		}
+		_, err = secAPI.Create(ctx, sec, metav1.CreateOptions{})
+		return err
+	}
+
+	// Update existing Secret
+	if sec.Data == nil {
+		sec.Data = make(map[string][]byte)
+	}
+	sec.Data[key] = []byte(value)
+	_, err = secAPI.Update(ctx, sec, metav1.UpdateOptions{})
+	return err
+}


### PR DESCRIPTION
## Summary

Implements Epic #23 — Platform Configuration. Restructures the admin sidebar and adds three new settings pages.

- **Menu Restructure**: Split flat 9-item nav into Operations (6 items) and Settings (6 items) groups
- **Container Registry**: Configure Docker/OCI registry (Harbor) for image push, with `mf push` integration that auto-detects registry settings from K8s ConfigMap, pushes images, and creates imagePullSecrets
- **Webhooks**: CRUD for webhook endpoints that receive HTTP POST notifications on platform events (app.deployed, alert.fired, etc.)
- **SMTP**: Configure SMTP server for email notifications with TLS support and connection testing
- **Data Layer**: ConfigMap/Secret-backed persistence following existing `PlanVisibilityStore` pattern
- **API Endpoints**: Full REST API for all settings (GET/PUT/POST/DELETE)
- **Backward Compatible**: `mf push` works unchanged when no registry is configured

### Files Changed (15 total: 8 new + 7 modified)

| File | Action | Purpose |
|------|--------|---------|
| `pkg/admin/static/templates/partials/nav.html` | Modified | Operations/Settings groups |
| `pkg/models/settings.go` | New | RegistryConfig, WebhookConfig, SMTPConfig models |
| `pkg/settings/store.go` | New | ConfigMap/Secret persistence |
| `pkg/admin/settings_handlers.go` | New | 15 HTTP handlers (UI + API) |
| `pkg/admin/static/templates/settings_registry.html` | New | Registry config form |
| `pkg/admin/static/templates/settings_webhooks.html` | New | Webhooks table + add form |
| `pkg/admin/static/templates/settings_smtp.html` | New | SMTP config form |
| `pkg/k8s/registry.go` | New | imagePullSecret management |
| `pkg/build/builder.go` | Modified | Login() and Push() methods |
| `cmd/mf/push.go` | Modified | Registry-aware image prefix + push phase |
| `pkg/k8s/app.go` | Modified | imagePullSecrets + PullAlways |
| `pkg/admin/server.go` | Modified | 17 new route registrations |
| `pkg/admin/templates.go` | Modified | Register 3 new page templates |
| `pkg/config/config.go` | Modified | Registry, SMTP config fields |
| `configs/mf.example.yaml` | Modified | Commented registry/SMTP sections |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] All existing tests pass
- [ ] Admin sidebar shows Operations/Settings groups with 12 items
- [ ] `/settings/registry` renders form, save persists to ConfigMap
- [ ] `/settings/webhooks` add/delete webhooks with event selection
- [ ] `/settings/smtp` renders form, save persists to ConfigMap
- [ ] `mf push` with registry configured pushes to Harbor
- [ ] `mf push` without registry works unchanged (backward compatible)
- [ ] Settings API endpoints return JSON

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)