### PR TITLE
fix: add EnsureNamespace to create-service command

### DIFF
--- a/cmd/mf/create_service.go
+++ b/cmd/mf/create_service.go
@@ -41,6 +41,10 @@ func createServiceCmd() *cobra.Command {
 				return err
 			}
 
+			if err := k8sClient.EnsureNamespace(ctx); err != nil {
+				return fmt.Errorf("namespace setup: %w", err)
+			}
+
 			mgr := service.NewManager(k8sClient)
 
 			// Check if already exists


### PR DESCRIPTION
## Summary

- `mf create-service` was failing with "namespaces not found" when the microfoundry namespace didn't exist
- Added `EnsureNamespace` call before creating service resources, matching the behavior of `mf push`

```bash
./bin/mf create-service postgresql small my-db                                                                                                                                            
# Error: creating service: namespaces "microfoundry" not found                                                                                                                              
```


## Test plan

- [x] `go build ./...` passes
- [x] Verified fix by running `mf create-service postgresql small my-db` on a fresh kind cluster