### PR TITLE
fix(iam): harden IAM — authz bypass, error handling, SCIM compliance

### DIFF
--- a/pkg/admin/iam_handlers.go
+++ b/pkg/admin/iam_handlers.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/younjinjeong/microfoundry/pkg/auth"
@@ -44,7 +45,16 @@ func (s *Server) renderIAMOrgsTab(w http.ResponseWriter, r *http.Request) {
 
 	if user != nil {
 		store := s.orgStore()
-		orgs, _ := store.GetUserOrgs(r.Context(), user.Email)
+		if store == nil {
+			data["Error"] = "Organization store not available"
+			s.templates.RenderPartial(w, "tab_iam_orgs.html", data)
+			return
+		}
+		orgs, err := store.GetUserOrgs(r.Context(), user.Email)
+		if err != nil {
+			log.Printf("[IAM] failed to get user orgs for %s: %v", user.Email, err)
+			data["Error"] = "Failed to load organizations"
+		}
 
 		selectedOrg := r.URL.Query().Get("org")
 		if selectedOrg == "" && len(orgs) > 0 {
@@ -60,7 +70,10 @@ func (s *Server) renderIAMOrgsTab(w http.ResponseWriter, r *http.Request) {
 			orgDetail, err := store.Get(r.Context(), selectedOrg)
 			if err == nil {
 				data["OrgDetail"] = orgDetail
-				members, _ := store.ListMembers(r.Context(), selectedOrg)
+				members, err := store.ListMembers(r.Context(), selectedOrg)
+				if err != nil {
+					log.Printf("[IAM] failed to list members for org %s: %v", selectedOrg, err)
+				}
 				data["Members"] = members
 
 				userRole := "viewer"
@@ -90,7 +103,11 @@ func (s *Server) renderIAMUsersTab(w http.ResponseWriter, r *http.Request) {
 		} else {
 			// Fetch roles for each user
 			for i := range users {
-				roles, _ := s.keycloakAdmin.GetUserRoles(r.Context(), users[i].ID)
+				roles, err := s.keycloakAdmin.GetUserRoles(r.Context(), users[i].ID)
+				if err != nil {
+					log.Printf("[IAM] failed to get roles for user %s: %v", users[i].ID, err)
+					continue
+				}
 				roleNames := make([]string, 0, len(roles))
 				for _, role := range roles {
 					roleNames = append(roleNames, role.Name)
@@ -103,7 +120,10 @@ func (s *Server) renderIAMUsersTab(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Get available realm roles for assignment
-		realmRoles, _ := s.keycloakAdmin.GetRealmRoles(r.Context())
+		realmRoles, err := s.keycloakAdmin.GetRealmRoles(r.Context())
+		if err != nil {
+			log.Printf("[IAM] failed to get realm roles: %v", err)
+		}
 		data["RealmRoles"] = realmRoles
 	} else {
 		data["NotConfigured"] = true
@@ -181,7 +201,11 @@ func (s *Server) CreateKeycloakUserHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	if password != "" {
-		_ = s.keycloakAdmin.ResetPassword(r.Context(), userID, password, false)
+		if err := s.keycloakAdmin.ResetPassword(r.Context(), userID, password, false); err != nil {
+			log.Printf("[IAM] user %s created but password reset failed: %v", userID, err)
+			http.Error(w, "User created but password set failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	w.Header().Set("HX-Redirect", "/users?tab=users")

--- a/pkg/admin/org_handlers.go
+++ b/pkg/admin/org_handlers.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/younjinjeong/microfoundry/pkg/auth"
@@ -36,7 +37,15 @@ func (s *Server) OrgsPageHandler(w http.ResponseWriter, r *http.Request) {
 	case "orgs":
 		ctx := r.Context()
 		store := s.orgStore()
-		orgs, _ := store.GetUserOrgs(ctx, user.Email)
+		if store == nil {
+			content["Error"] = "Organization store not available"
+			break
+		}
+		orgs, err := store.GetUserOrgs(ctx, user.Email)
+		if err != nil {
+			log.Printf("[Orgs] failed to get user orgs for %s: %v", user.Email, err)
+			content["Error"] = "Failed to load organizations"
+		}
 
 		selectedOrg := r.URL.Query().Get("org")
 		if selectedOrg == "" && len(orgs) > 0 {
@@ -51,7 +60,10 @@ func (s *Server) OrgsPageHandler(w http.ResponseWriter, r *http.Request) {
 			orgDetail, err := store.Get(ctx, selectedOrg)
 			if err == nil {
 				content["OrgDetail"] = orgDetail
-				members, _ := store.ListMembers(ctx, selectedOrg)
+				members, err := store.ListMembers(ctx, selectedOrg)
+				if err != nil {
+					log.Printf("[Orgs] failed to list members for org %s: %v", selectedOrg, err)
+				}
 				content["Members"] = members
 
 				userRole := "viewer"
@@ -73,7 +85,11 @@ func (s *Server) OrgsPageHandler(w http.ResponseWriter, r *http.Request) {
 				content["Error"] = err.Error()
 			} else {
 				for i := range users {
-					roles, _ := s.keycloakAdmin.GetUserRoles(r.Context(), users[i].ID)
+					roles, err := s.keycloakAdmin.GetUserRoles(r.Context(), users[i].ID)
+					if err != nil {
+						log.Printf("[Orgs] failed to get roles for user %s: %v", users[i].ID, err)
+						continue
+					}
 					roleNames := make([]string, 0, len(roles))
 					for _, role := range roles {
 						roleNames = append(roleNames, role.Name)
@@ -84,7 +100,10 @@ func (s *Server) OrgsPageHandler(w http.ResponseWriter, r *http.Request) {
 				content["TotalUsers"] = total
 				content["Search"] = search
 			}
-			realmRoles, _ := s.keycloakAdmin.GetRealmRoles(r.Context())
+			realmRoles, err := s.keycloakAdmin.GetRealmRoles(r.Context())
+			if err != nil {
+				log.Printf("[Orgs] failed to get realm roles: %v", err)
+			}
 			content["RealmRoles"] = realmRoles
 		} else {
 			content["NotConfigured"] = true
@@ -292,7 +311,10 @@ func (s *Server) APIGetOrgHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members, _ := store.ListMembers(r.Context(), orgID)
+	members, err := store.ListMembers(r.Context(), orgID)
+	if err != nil {
+		log.Printf("[Orgs] failed to list members for org %s: %v", orgID, err)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"org":     org,

--- a/pkg/admin/scim_handlers.go
+++ b/pkg/admin/scim_handlers.go
@@ -3,17 +3,28 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/younjinjeong/microfoundry/pkg/auth"
 )
 
+// uuidRegex validates UUID format for SCIM path parameters.
+var uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+func isValidUUID(s string) bool {
+	return uuidRegex.MatchString(s)
+}
+
 // writeSCIMJSON writes a SCIM JSON response with the correct content type.
 func writeSCIMJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/scim+json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("[SCIM] failed to encode JSON response: %v", err)
+	}
 }
 
 // writeSCIMError sends a SCIM error response.
@@ -46,6 +57,9 @@ func (s *Server) SCIMListUsersHandler(w http.ResponseWriter, r *http.Request) {
 	count, _ := strconv.Atoi(r.URL.Query().Get("count"))
 	if count <= 0 {
 		count = 20
+	}
+	if count > 100 {
+		count = 100
 	}
 
 	filter := r.URL.Query().Get("filter")
@@ -128,6 +142,10 @@ func (s *Server) SCIMGetUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := r.PathValue("id")
+	if !isValidUUID(userID) {
+		writeSCIMError(w, http.StatusBadRequest, "invalid user ID format")
+		return
+	}
 	user, err := s.keycloakAdmin.GetUser(r.Context(), userID)
 	if err != nil {
 		writeSCIMError(w, http.StatusNotFound, err.Error())
@@ -146,6 +164,10 @@ func (s *Server) SCIMUpdateUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := r.PathValue("id")
+	if !isValidUUID(userID) {
+		writeSCIMError(w, http.StatusBadRequest, "invalid user ID format")
+		return
+	}
 
 	var scimUser auth.SCIMUser
 	if err := json.NewDecoder(r.Body).Decode(&scimUser); err != nil {
@@ -179,6 +201,10 @@ func (s *Server) SCIMPatchUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := r.PathValue("id")
+	if !isValidUUID(userID) {
+		writeSCIMError(w, http.StatusBadRequest, "invalid user ID format")
+		return
+	}
 
 	var patch auth.SCIMPatchOp
 	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
@@ -233,6 +259,10 @@ func (s *Server) SCIMDeleteUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := r.PathValue("id")
+	if !isValidUUID(userID) {
+		writeSCIMError(w, http.StatusBadRequest, "invalid user ID format")
+		return
+	}
 	if err := s.keycloakAdmin.DeleteUser(r.Context(), userID); err != nil {
 		writeSCIMError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -255,7 +285,7 @@ func (s *Server) SCIMServiceProviderConfigHandler(w http.ResponseWriter, r *http
 		},
 		"filter": map[string]any{
 			"supported":  true,
-			"maxResults": 200,
+			"maxResults": 100,
 		},
 		"changePassword": map[string]any{
 			"supported": true,

--- a/pkg/auth/opa.go
+++ b/pkg/auth/opa.go
@@ -129,12 +129,29 @@ func (e *OPAEngine) Evaluate(ctx context.Context, input AuthzInput) (AuthzResult
 }
 
 // UpdatePolicy adds or replaces a custom policy module and recompiles.
+// Uses copy-on-write to avoid corrupting modules map if compilation fails.
 func (e *OPAEngine) UpdatePolicy(name, regoText string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	e.modules[name] = regoText
-	return e.compile()
+	// Copy modules to avoid mutation before successful compile
+	updated := make(map[string]string, len(e.modules)+1)
+	for k, v := range e.modules {
+		updated[k] = v
+	}
+	updated[name] = regoText
+
+	compiler, err := ast.CompileModulesWithOpt(updated, ast.CompileOpts{
+		EnablePrintStatements: false,
+	})
+	if err != nil {
+		return fmt.Errorf("compiling rego policies: %w", err)
+	}
+
+	// Swap atomically only after successful compile
+	e.modules = updated
+	e.compiler = compiler
+	return nil
 }
 
 // GetPolicies returns the currently loaded policy names and their source.

--- a/pkg/auth/opa_middleware.go
+++ b/pkg/auth/opa_middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -100,7 +101,10 @@ func buildAuthzInput(r *http.Request, orgStore *OrgStore) AuthzInput {
 	if user != nil {
 		orgRole := ""
 		if orgStore != nil && input.OrgID != "" {
-			members, _ := orgStore.ListMembers(r.Context(), input.OrgID)
+			members, err := orgStore.ListMembers(r.Context(), input.OrgID)
+			if err != nil {
+				log.Printf("[OPA] failed to list org members for org %s: %v", input.OrgID, err)
+			}
 			for _, m := range members {
 				if m.Email == user.Email {
 					orgRole = m.Role

--- a/pkg/auth/policies/authz.rego
+++ b/pkg/auth/policies/authz.rego
@@ -4,9 +4,11 @@ import rego.v1
 
 default allow := false
 
-# When auth is disabled, user is null — allow everything
+# When auth is disabled, user is null — allow public resources only
+# SCIM, settings, clusters, and user management still require authentication
 allow if {
 	input.user == null
+	not input.resource in {"scim", "settings", "clusters", "users"}
 }
 
 # Platform admins have full access to all resources

--- a/pkg/auth/scim.go
+++ b/pkg/auth/scim.go
@@ -144,10 +144,17 @@ func SCIMUserToKeycloak(scim *SCIMUser) *KeycloakUser {
 }
 
 // ParseSCIMFilter parses a basic SCIM filter expression.
-// Supports: attrName op "value" (e.g., userName eq "john").
+// Supports: attrName op "value" (e.g., userName eq "john doe").
+// Compound filters (and/or) are not supported and will return an error.
 func ParseSCIMFilter(filter string) (attr, op, value string, err error) {
 	if filter == "" {
 		return "", "", "", nil
+	}
+
+	// Reject compound filters — we only support simple expressions
+	lowerFilter := strings.ToLower(filter)
+	if strings.Contains(lowerFilter, " and ") || strings.Contains(lowerFilter, " or ") {
+		return "", "", "", fmt.Errorf("compound filters (and/or) are not supported")
 	}
 
 	parts := strings.SplitN(filter, " ", 3)
@@ -157,7 +164,14 @@ func ParseSCIMFilter(filter string) (attr, op, value string, err error) {
 
 	attr = parts[0]
 	op = strings.ToLower(parts[1])
-	value = strings.Trim(parts[2], "\"")
+
+	// Handle quoted values (may contain spaces)
+	raw := parts[2]
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") && len(raw) >= 2 {
+		value = raw[1 : len(raw)-1]
+	} else {
+		value = strings.Trim(raw, "\"")
+	}
 
 	switch op {
 	case "eq", "co", "sw":


### PR DESCRIPTION
## Summary

- **Security**: Close null-user bypass in `authz.rego` — unauthenticated requests no longer reach SCIM, settings, clusters, or user management endpoints
- **Reliability**: Fix 10+ silent error swallowing locations across `iam_handlers.go`, `org_handlers.go`, and `opa_middleware.go` — all errors now logged with `[IAM]`/`[Orgs]`/`[OPA]` prefixes
- **SCIM Compliance**: Add UUID validation for all SCIM `{id}` path parameters, cap `count` at 100 (matching `ServiceProviderConfig.maxResults`), improve filter parsing for quoted values with spaces, reject compound `and`/`or` filters
- **OPA Atomicity**: `UpdatePolicy` now uses copy-on-write — invalid Rego never corrupts the live policy set
- **Nil Safety**: Add `orgStore == nil` guard in `OrgsPageHandler` and `renderIAMOrgsTab` to prevent nil pointer dereference
- **Password Reset**: `CreateKeycloakUserHandler` now surfaces password reset failures instead of silently discarding them

## Files Changed (7)

| File | Changes |
|------|---------|
| `pkg/auth/policies/authz.rego` | Restrict null-user bypass to exclude admin resources |
| `pkg/auth/opa_middleware.go` | Log `ListMembers` errors instead of discarding |
| `pkg/auth/opa.go` | Copy-on-write `UpdatePolicy` for atomic policy updates |
| `pkg/auth/scim.go` | Compound filter rejection, quoted value handling |
| `pkg/admin/scim_handlers.go` | UUID validation, count cap (100), JSON encode error logging |
| `pkg/admin/iam_handlers.go` | Log errors for orgs/roles/members, handle password reset failure |
| `pkg/admin/org_handlers.go` | Nil guard for orgStore, log all discarded errors |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Verify unauthenticated requests to `/scim/v2/Users` are denied (403)
- [ ] Verify `PATCH /scim/v2/Users/not-a-uuid` returns 400 with SCIM error
- [ ] Verify `GET /scim/v2/Users?count=999` caps at 100 results
- [ ] Verify SCIM filter `userName eq "john doe"` parses correctly
- [ ] Verify invalid Rego policy upload does not corrupt existing policies
- [ ] Verify `CreateKeycloakUserHandler` returns error when password reset fails
- [ ] Verify org tab renders gracefully when orgStore is nil

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)