### PR TITLE
docs: Documentation Sync #3 — IAM, SCIM v2, OPA & Audit

### DIFF
--- a/docs/admin-guide.md
+++ b/docs/admin-guide.md
@@ -16,8 +16,9 @@ Complete guide to the MicroFoundry web-based admin dashboard.
 8. [Cluster Management](#cluster-management)
 9. [Service Catalog](#service-catalog)
 10. [Platform Settings](#platform-settings)
-11. [Users & Organizations](#users--organizations)
-12. [API Reference](#api-reference)
+11. [Users & IAM](#users--iam)
+12. [SCIM v2 API](#scim-v2-api)
+13. [API Reference](#api-reference)
 
 ---
 
@@ -390,18 +391,20 @@ Configure SMTP for email notifications:
 
 ---
 
-## Users & Organizations
-
-### Organization Management
+## Users & IAM
 
 **URL**: `/users`
 
-When authentication is enabled:
+The Users & IAM page provides complete identity and access management through a 4-tab interface. Tabs load dynamically via HTMX (`hx-get="/users/tab/{tab}"`, `hx-target="#tab-content"`, `hx-push-url="/users?tab={tab}"`).
 
-- Create organizations
-- Invite members by email
-- Set member roles (admin, member, viewer)
-- Switch active organization
+### Orgs Tab
+
+**URL**: `/users?tab=orgs`
+
+Organization management with a two-column layout:
+
+- **Left panel** — list of user's organizations, create org form
+- **Right panel** — selected org detail, members table, invite form
 
 | Action | Method | URL |
 |--------|--------|-----|
@@ -411,6 +414,151 @@ When authentication is enabled:
 | Remove member | DELETE | `/users/orgs/{id}/members/{email}` |
 | Set role | POST | `/users/orgs/{id}/members/{email}/role` |
 | Switch active | POST | `/users/orgs/{id}/activate` |
+
+Roles: **admin** (full org access), **member** (apps/services/secrets), **viewer** (read-only).
+
+### Users Tab
+
+**URL**: `/users?tab=users`
+
+Keycloak user management (requires Keycloak admin credentials in config):
+
+- User table: Username, Email, Name, Roles (as badges), Enabled/Disabled status
+- Search bar with real-time filtering by username or email
+- Create user form: username, email, first/last name, password
+- Per-user actions: toggle enable/disable, assign realm roles, delete
+
+| Action | Method | URL |
+|--------|--------|-----|
+| Create user | POST | `/users/keycloak` |
+| Toggle enable/disable | POST | `/users/keycloak/{id}/toggle` |
+| Assign role | POST | `/users/keycloak/{id}/roles` |
+| Delete user | DELETE | `/users/keycloak/{id}` |
+
+Realm roles: **platform-admin** (full platform access), **org-admin**, **org-member**, **viewer**.
+
+### Policies Tab
+
+**URL**: `/users?tab=policies`
+
+View and manage OPA authorization policies:
+
+- Read-only display of the embedded default policy (`authz.rego`)
+- Custom policy editor with name and Rego source fields
+- Save button validates Rego syntax before applying (copy-on-write — invalid Rego never corrupts live policies)
+- Error messages displayed for syntax errors
+
+| Action | Method | URL |
+|--------|--------|-----|
+| Save policy | POST | `/users/policies` |
+
+### Audit Tab
+
+**URL**: `/users?tab=audit`
+
+Authorization decision log (in-memory ring buffer, last 1000 entries):
+
+- Table columns: Timestamp, User Email, Action, Resource, Path, Method, Allowed/Denied
+- Filter dropdowns: by user, by resource, by action
+- Allow (green) / Deny (red) status badges
+- Entry count indicator showing total logged decisions
+
+---
+
+## SCIM v2 API
+
+MicroFoundry implements SCIM v2 (RFC 7643/7644) endpoints for standard identity provisioning. All SCIM endpoints require the `platform-admin` role and use `Content-Type: application/scim+json`.
+
+### Endpoints
+
+| Method | Endpoint | Description | Status Codes |
+|--------|----------|-------------|-------------|
+| GET | `/scim/v2/Users` | List users with pagination & filtering | 200, 400, 503 |
+| POST | `/scim/v2/Users` | Create user | 201, 400, 409, 503 |
+| GET | `/scim/v2/Users/{id}` | Get user by ID | 200, 400, 404, 503 |
+| PUT | `/scim/v2/Users/{id}` | Replace user (full update) | 200, 400, 404, 503 |
+| PATCH | `/scim/v2/Users/{id}` | Partial update (PatchOp) | 200, 400, 404, 503 |
+| DELETE | `/scim/v2/Users/{id}` | Delete user | 204, 400, 503 |
+| GET | `/scim/v2/ServiceProviderConfig` | Provider capabilities | 200 |
+| GET | `/scim/v2/ResourceTypes` | Supported resource types | 200 |
+| GET | `/scim/v2/Schemas` | Schema definitions | 200 |
+
+### Query Parameters (List Users)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `startIndex` | 1 | SCIM 1-based pagination start |
+| `count` | 20 | Results per page (max: 100) |
+| `filter` | — | SCIM filter expression |
+
+Supported filter operators: `eq`, `co`, `sw`. Supported attributes: `userName`, `emails.value`. Compound filters (`and`/`or`) are not supported.
+
+Example: `GET /scim/v2/Users?filter=userName eq "admin"&count=10`
+
+### Request/Response Examples
+
+**List Users:**
+
+```bash
+curl -H "Authorization: Bearer TOKEN" \
+  "http://localhost:8080/scim/v2/Users?startIndex=1&count=20"
+```
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+  "totalResults": 3,
+  "itemsPerPage": 20,
+  "startIndex": 1,
+  "Resources": [
+    {
+      "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "userName": "admin",
+      "name": { "givenName": "Admin", "familyName": "User" },
+      "emails": [{ "value": "admin@example.com", "type": "work", "primary": true }],
+      "active": true,
+      "meta": {
+        "resourceType": "User",
+        "created": "2025-01-15T10:00:00Z",
+        "location": "http://localhost:8080/scim/v2/Users/550e8400-e29b-41d4-a716-446655440000"
+      }
+    }
+  ]
+}
+```
+
+**Create User:**
+
+```bash
+curl -X POST -H "Content-Type: application/scim+json" \
+  -H "Authorization: Bearer TOKEN" \
+  -d '{"schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],"userName":"newuser","name":{"givenName":"New","familyName":"User"},"emails":[{"value":"new@example.com","primary":true}],"active":true}' \
+  "http://localhost:8080/scim/v2/Users"
+```
+
+Returns `201 Created` with `Location` header pointing to the new user resource.
+
+**Patch User (disable):**
+
+```bash
+curl -X PATCH -H "Content-Type: application/scim+json" \
+  -H "Authorization: Bearer TOKEN" \
+  -d '{"schemas":["urn:ietf:params:scim:api:messages:2.0:PatchOp"],"Operations":[{"op":"replace","path":"active","value":false}]}' \
+  "http://localhost:8080/scim/v2/Users/550e8400-e29b-41d4-a716-446655440000"
+```
+
+### Validation
+
+All `{id}` path parameters are validated as UUIDs. Non-UUID values return a `400` SCIM error:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "detail": "invalid user ID format",
+  "status": "400"
+}
+```
 
 ---
 
@@ -488,6 +636,15 @@ All API endpoints return JSON and are available at `/api/...`.
 | GET | `/api/orgs/{id}` | Get organization detail |
 | POST | `/api/orgs` | Create organization |
 | GET | `/api/orgs/{id}/members` | List members |
+
+### IAM APIs
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/users` | List Keycloak users (with `?search=` filter) |
+| GET | `/api/policies` | Get all OPA policies (name → Rego source) |
+| PUT | `/api/policies` | Update an OPA policy (JSON: `name`, `source`) |
+| GET | `/api/audit` | Query audit log (`?user=`, `?resource=`, `?action=`) |
 
 ### Config API
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -415,15 +415,95 @@ Organizations are stored as K8s ConfigMaps (`mf-org-*`) with:
 - Member list with roles (admin, member, viewer)
 - Created/updated timestamps
 
-### Middleware
+### Middleware Chain
 
-The `auth.InjectUser` middleware runs on every request:
+The auth middleware chain wraps every request in this order (outermost → innermost):
+
+```
+Request
+  → InstrumentHandler (Prometheus metrics — outermost)
+    → InjectUser (session cookie → user context)
+      → OPAMiddleware (policy evaluation → allow/deny)
+        → Handler (business logic)
+```
+
+**InjectUser** runs OUTSIDE OPA so it executes first, populating the user context that OPA needs for policy evaluation.
+
 1. Reads session cookie
 2. Extracts `UserSession` from session store
-3. Injects user into request context
-4. Handlers access user via `auth.UserFromContext(r.Context())`
+3. Injects user into request context via `auth.UserFromContext(r.Context())`
+4. If no valid session, user is `nil` (unauthenticated)
 
-When auth is disabled, all features work without authentication.
+### OPA Authorization Engine
+
+MicroFoundry embeds an [Open Policy Agent](https://www.openpolicyagent.org/) engine for fine-grained authorization using Rego policies.
+
+```
+OPAMiddleware(request)
+  → Skip if public path (/static/, /login, /auth/*, /health, /metrics)
+  → buildAuthzInput: classify route (method+path → action+resource)
+  → Resolve org membership role (orgStore.ListMembers)
+  → opa.Evaluate(input) → {allow: bool, reason: string}
+  → Record audit entry (timestamp, user, action, resource, allowed)
+  → If denied: redirect to /login (unauthenticated) or 403 (insufficient role)
+```
+
+**Route classification** maps HTTP method + path to action + resource:
+- `GET /apps` → action=`read`, resource=`apps`
+- `POST /services/create` → action=`write`, resource=`services`
+- `DELETE /secrets/mykey` → action=`delete`, resource=`secrets`
+- `GET /scim/v2/Users` → action=`read`, resource=`scim`
+
+**Default policy** (`pkg/auth/policies/authz.rego`):
+- Platform admins → full access
+- Authenticated users → read any resource
+- Org admins → write/delete within their org
+- Org members → write apps, services, secrets only
+- SCIM, settings, clusters → platform-admin only
+- Unauthenticated (null user) → public resources only (not SCIM/settings/clusters/users)
+
+**Policy hot-reload**: The `UpdatePolicy` endpoint uses copy-on-write — compiles new modules in a temporary copy first, only swaps on success. Invalid Rego never corrupts the live policy set.
+
+### SCIM v2 Integration
+
+MicroFoundry exposes SCIM v2 (RFC 7643/7644) endpoints that proxy to the Keycloak Admin REST API:
+
+```
+SCIM Client → /scim/v2/Users → SCIMHandler
+                                    │
+                              Convert SCIM ↔ Keycloak
+                                    │
+                              Keycloak Admin REST API
+                              (client_credentials grant)
+                                    │
+                              /admin/realms/{realm}/users
+```
+
+**Keycloak Admin Client** (`pkg/auth/keycloak_admin.go`):
+- Uses `client_credentials` grant (not password grant)
+- Token caching with automatic refresh before expiry
+- User CRUD: List, Get, Create, Update, Delete
+- Role management: GetUserRoles, AssignUserRole, RemoveUserRole, GetRealmRoles
+- Password reset: ResetPassword (temporary or permanent)
+
+### Audit Subsystem
+
+An in-memory ring buffer records every OPA authorization decision:
+
+```go
+type AuditLog struct {
+    entries []AuditEntry  // Fixed-size circular buffer
+    size    int           // Max entries (default: 1000)
+    head    int           // Write position
+    count   int           // Current entry count
+}
+```
+
+Each entry records: timestamp, user email/ID, action, resource, path, method, org ID, allowed/denied, reason, IP address.
+
+At ~100 requests/minute, the default 1000-entry buffer provides ~10 minutes of history. The buffer is queryable by user, resource, and action via the admin UI (Audit tab) and API (`GET /api/audit`).
+
+When auth is disabled, all features work without authentication — OPA middleware is skipped entirely.
 
 ---
 

--- a/docs/cloudfoundry-architecture.md
+++ b/docs/cloudfoundry-architecture.md
@@ -966,7 +966,7 @@ How CloudFoundry components map to MicroFoundry's Kubernetes-based architecture:
 | **TCP Router** | Custom TCP proxy | **K8s Service (LoadBalancer/NodePort)** |
 | **NATS** | Message bus | **K8s Events / Controller watches** |
 | **Cloud Controller** | Ruby/Go API | **MicroFoundry API Server** (Go) |
-| **UAA** | Java OAuth2 server | **Dex / Keycloak / K8s RBAC** |
+| **UAA** | Java OAuth2 server | **Keycloak OIDC + OPA (Rego) + SCIM v2** |
 | **MySQL** | PXC Galera | **AWS RDS / Cloud SQL / CockroachDB** |
 | **Blobstore** | WebDAV | **S3 / GCS / MinIO** |
 | **Buildpacks** | CF Buildpacks | **Cloud Native Buildpacks (CNB) / Paketo** |

--- a/docs/observability-capacity.md
+++ b/docs/observability-capacity.md
@@ -158,6 +158,31 @@ The following alerts provide observability-of-observability:
 - **MFAppHighLatency**: p99 latency >2s per app (warning)
 - **MFAppNoTraffic**: Running app with zero HTTP traffic for 15m (info)
 
+## Authorization Audit Buffer
+
+The OPA authorization middleware records every allow/deny decision in an in-memory ring buffer (`pkg/auth/audit.go`). This is separate from the Prometheus/Loki observability stack — it provides an IAM-specific audit trail visible in the admin UI.
+
+### Capacity
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| Buffer size | 1000 entries | Circular — oldest entries evicted on overflow |
+| Entry size | ~300 bytes | Timestamp, user, action, resource, path, method, org, IP, reason |
+| Memory footprint | ~300 KB | Fixed allocation, does not grow |
+
+At 100 requests/minute, the buffer holds ~10 minutes of history. For production deployments requiring persistent audit trails, export entries to an external log sink (Loki, SIEM) via the `GET /api/audit` endpoint.
+
+### Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `user` | Filter by user email |
+| `resource` | Filter by resource type (apps, services, scim, etc.) |
+| `action` | Filter by action (read, write, delete) |
+| `limit` | Max entries to return (default: 100) |
+
+---
+
 ## Recording Rule Staleness
 
 When an app is deleted, its recording rule series become stale after the Prometheus

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -12,7 +12,7 @@ A complete guide to deploying and managing applications on MicroFoundry — a mi
 4. [Backing Services](#backing-services)
 5. [Secret Management](#secret-management)
 6. [Monitoring & Observability](#monitoring--observability)
-7. [Authentication & Organizations](#authentication--organizations)
+7. [Authentication & IAM](#authentication--iam)
 8. [Multi-Cluster Management](#multi-cluster-management)
 9. [Container Registry](#container-registry)
 10. [CLI Reference](#cli-reference)
@@ -142,7 +142,7 @@ monitoring:
 #   from_addr: "noreply@microfoundry.local"
 #   tls: true
 
-# Authentication (optional — Keycloak OIDC)
+# Authentication (optional — Keycloak OIDC + OPA + SCIM)
 # auth:
 #   enabled: true
 #   issuer_url: "http://localhost:8180/realms/microfoundry"
@@ -150,6 +150,10 @@ monitoring:
 #   client_secret: "your-secret"
 #   redirect_url: "http://localhost:8080/auth/callback"
 #   session_key: ""  # Auto-generated if empty
+#   admin_base_url: "http://localhost:8180"   # Keycloak Admin API
+#   admin_client_id: "admin-cli"              # Client for Admin REST API
+#   admin_client_secret: "your-admin-secret"  # Client credentials grant
+#   realm: "microfoundry"                     # Keycloak realm name
 ```
 
 ---
@@ -433,9 +437,9 @@ kubectl port-forward -n monitoring svc/kube-prometheus-kube-prome-alertmanager 9
 
 ---
 
-## Authentication & Organizations
+## Authentication & IAM
 
-MicroFoundry supports OIDC authentication via **Keycloak** with social login (Google, GitHub, Amazon).
+MicroFoundry provides a full IAM stack: OIDC authentication via **Keycloak**, fine-grained authorization via **OPA (Open Policy Agent)**, standard identity provisioning via **SCIM v2**, and an authorization **audit log**.
 
 ### Deploy Keycloak
 
@@ -466,15 +470,20 @@ auth:
   client_id: "mf-admin"
   client_secret: "<from mf setup keycloak-realm>"
   redirect_url: "http://localhost:8080/auth/callback"
+  # Keycloak Admin API (for user management & SCIM)
+  admin_base_url: "http://localhost:8180"
+  admin_client_id: "admin-cli"
+  admin_client_secret: "<from Keycloak admin-cli>"
+  realm: "microfoundry"
 ```
 
 ### Roles
 
 Keycloak is configured with these roles:
-- **platform-admin** — full platform access
-- **org-admin** — organization administrator
-- **org-member** — organization member
-- **viewer** — read-only access
+- **platform-admin** — full platform access (SCIM, settings, clusters, audit)
+- **org-admin** — organization administrator (write/delete within org)
+- **org-member** — organization member (write apps, services, secrets)
+- **viewer** — read-only access to all resources
 
 ### Organizations
 
@@ -484,6 +493,55 @@ When auth is enabled, users can create and manage organizations:
 - Invite members by email
 - Assign roles: admin, member, viewer
 - Switch active organization
+
+### OPA Authorization
+
+All API and UI routes are evaluated by the embedded **Open Policy Agent** using Rego policies. The middleware chain runs in order:
+
+```
+InstrumentHandler → InjectUser → OPAMiddleware → Handler
+```
+
+**Default authorization rules** (embedded in `pkg/auth/policies/authz.rego`):
+
+| Rule | Condition |
+|------|-----------|
+| Public resources | Auth disabled (user is null), excludes SCIM/settings/clusters/users |
+| Platform admin | Full access to all resources |
+| Authenticated read | Any authenticated user can read any resource |
+| Org admin write | Org admins can write within their organization |
+| Org member write | Members can write apps, services, and secrets only |
+| SCIM access | Requires platform-admin role |
+| Delete | Requires org admin role (apps, services, secrets) |
+
+**Custom policies**: Platform admins can add or replace Rego policies at runtime via the **Policies tab** in Users & IAM. Changes are compiled and swapped atomically.
+
+### SCIM v2 Provisioning
+
+MicroFoundry exposes 9 SCIM v2 endpoints (RFC 7643/7644) for standard identity provisioning. All SCIM endpoints require `platform-admin` role.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/scim/v2/Users` | GET | List users (pagination, filter) |
+| `/scim/v2/Users` | POST | Create user |
+| `/scim/v2/Users/{id}` | GET | Get user by ID |
+| `/scim/v2/Users/{id}` | PUT | Replace user |
+| `/scim/v2/Users/{id}` | PATCH | Partial update (PatchOp) |
+| `/scim/v2/Users/{id}` | DELETE | Delete user |
+| `/scim/v2/ServiceProviderConfig` | GET | Discovery |
+| `/scim/v2/ResourceTypes` | GET | Resource types |
+| `/scim/v2/Schemas` | GET | Schema discovery |
+
+SCIM requests use `Content-Type: application/scim+json`. Path IDs are validated as UUIDs. The `count` parameter is capped at 100.
+
+### Audit Log
+
+Every authorization decision is recorded in an in-memory ring buffer (1000 entries). Each entry captures:
+
+- Timestamp, user, action, resource, HTTP path/method
+- Organization ID, allow/deny decision, denial reason, client IP
+
+View the audit log from the **Audit tab** in Users & IAM, or query via `GET /api/audit`.
 
 ---
 
@@ -650,6 +708,6 @@ MicroFoundry maps CloudFoundry concepts to Kubernetes primitives:
 | Loggregator | Promtail + Loki |
 | Doppler/Metrics | Prometheus + Grafana + Beyla eBPF |
 | NATS (Alerts) | AlertManager |
-| UAA | Keycloak OIDC |
+| UAA | Keycloak OIDC + OPA + SCIM v2 |
 | VCAP_SERVICES | Same format — injected via K8s Secrets |
 | manifest.yml | Supported — same format |


### PR DESCRIPTION
## Summary

Document Expert sync #3 — comprehensive documentation update covering IAM capabilities from Epics #26–#37.

- **admin-guide.md** — Rewrote "Users & Organizations" → "Users & IAM" with 4-tab documentation (Orgs, Users, Policies, Audit), added full SCIM v2 API section (9 endpoints with curl examples and JSON responses), added IAM APIs to API Reference
- **architecture.md** — Rewrote Middleware section to full Middleware Chain with execution order diagram, added OPA Authorization Engine (route classification, default policy, hot-reload), SCIM v2 Integration (Keycloak Admin API flow), and Audit Subsystem (ring buffer architecture)
- **user-manual.md** — Expanded Authentication section to cover OPA authorization rules table, SCIM v2 endpoint reference, audit log overview, new auth config fields (`admin_base_url`, `admin_client_id`, `realm`)
- **cloudfoundry-architecture.md** — Updated UAA mapping from "Dex / Keycloak / K8s RBAC" to "Keycloak OIDC + OPA (Rego) + SCIM v2"
- **observability-capacity.md** — Added Authorization Audit Buffer section with capacity table and query parameters

**5 files changed, +345 −25 lines** (docs-only, no code changes)

Closes #39

## Test plan

- [ ] Verify all internal doc links resolve (TOC anchors)
- [ ] Confirm SCIM v2 curl examples match actual endpoint behavior
- [ ] Check OPA authorization rules table matches `authz.rego` policy
- [ ] Validate audit buffer capacity numbers against `audit.go` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)