### PR TITLE
feat(ui): contextual tooltips for all admin pages

### DIFF
--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -30,6 +30,10 @@ admin:
   port: 8080
   host: "0.0.0.0"
 
+# Admin UI feature toggles
+ui:
+  tooltips: true  # Show contextual help tooltips on hover (disable with false)
+
 monitoring:
   grafana_url: "http://localhost:3000"
   loki_url: "http://loki.monitoring.svc.cluster.local:3100"

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -11,22 +11,24 @@ import (
 
 // PageData is the base data passed to every full-page template.
 type PageData struct {
-	Title         string
-	Version       string
-	Active        string
-	ActiveCluster string
-	Content       any
-	User          *auth.UserSession // nil when auth is disabled or not logged in
-	AuthEnabled   bool
+	Title           string
+	Version         string
+	Active          string
+	ActiveCluster   string
+	Content         any
+	User            *auth.UserSession // nil when auth is disabled or not logged in
+	AuthEnabled     bool
+	TooltipsEnabled bool
 }
 
 func (s *Server) pageData(title, active string) PageData {
 	return PageData{
-		Title:         title,
-		Version:       s.version,
-		Active:        active,
-		ActiveCluster: s.clientManager.GetActive(),
-		AuthEnabled:   s.authEnabled(),
+		Title:           title,
+		Version:         s.version,
+		Active:          active,
+		ActiveCluster:   s.clientManager.GetActive(),
+		AuthEnabled:     s.authEnabled(),
+		TooltipsEnabled: s.config.UI.Tooltips,
 	}
 }
 

--- a/pkg/admin/static/templates/app_detail.html
+++ b/pkg/admin/static/templates/app_detail.html
@@ -32,6 +32,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/overview"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=overview"
+                   data-tooltip="App info, routes, resources, and build details"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "overview"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Overview
                 </a>
@@ -39,6 +40,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/instances"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=instances"
+                   data-tooltip="Running pod instances with status, restarts, and node info"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "instances"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Instances
                 </a>
@@ -46,6 +48,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/config"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=config"
+                   data-tooltip="Environment variables, resource limits, and labels"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "config"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Config
                 </a>
@@ -53,6 +56,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/services"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=services"
+                   data-tooltip="Bound backing services and associated secrets"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "services"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Services
                 </a>
@@ -60,6 +64,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/routes"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=routes"
+                   data-tooltip="HTTP routes mapped to this application"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "routes"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Routes
                 </a>
@@ -67,6 +72,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/logs"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=logs"
+                   data-tooltip="Live streaming and historical log viewer (Loki)"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "logs"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Logs
                 </a>
@@ -74,6 +80,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/metrics"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=metrics"
+                   data-tooltip="CPU, memory, network, and restart metrics (Grafana)"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "metrics"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Metrics
                 </a>
@@ -81,6 +88,7 @@
                    hx-get="/apps/{{$d.Name}}/tab/performance"
                    hx-target="#tab-content"
                    hx-push-url="/apps/{{$d.Name}}?tab=performance"
+                   data-tooltip="RED metrics: request rate, errors, and latency (Beyla eBPF)"
                    class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "performance"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
                     Performance
                 </a>

--- a/pkg/admin/static/templates/app_row.html
+++ b/pkg/admin/static/templates/app_row.html
@@ -37,6 +37,7 @@
     </td>
     <td class="px-4 py-4 whitespace-nowrap text-right text-sm space-x-2">
         <button onclick="document.getElementById('scale-dialog-{{.Name}}').classList.toggle('hidden')"
+                data-tooltip="Change the number of running instances" data-tooltip-pos="top"
                 class="px-2.5 py-1 bg-blue-50 text-blue-700 rounded hover:bg-blue-100 text-xs font-medium transition-colors">
             Scale
         </button>
@@ -44,6 +45,7 @@
                 hx-target="#app-row-{{.Name}}"
                 hx-swap="outerHTML"
                 hx-confirm="Are you sure you want to delete {{.Name}}?"
+                data-tooltip="Delete this application and all its resources" data-tooltip-pos="top"
                 class="px-2.5 py-1 bg-red-50 text-red-700 rounded hover:bg-red-100 text-xs font-medium transition-colors">
             Delete
         </button>
@@ -56,11 +58,13 @@
                 <input type="number" name="instances" value="{{.TotalCount}}" min="0" max="20"
                        class="w-16 px-2 py-1 border border-gray-300 rounded text-xs text-center">
                 <button type="submit"
+                        data-tooltip="Apply the new instance count" data-tooltip-pos="top"
                         class="px-2 py-1 bg-green-50 text-green-700 rounded hover:bg-green-100 text-xs font-medium">
                     Apply
                 </button>
                 <button type="button"
                         onclick="this.closest('[id^=scale-dialog]').classList.add('hidden')"
+                        data-tooltip="Cancel scaling operation" data-tooltip-pos="top"
                         class="px-2 py-1 bg-gray-50 text-gray-600 rounded hover:bg-gray-100 text-xs font-medium">
                     Cancel
                 </button>

--- a/pkg/admin/static/templates/apps.html
+++ b/pkg/admin/static/templates/apps.html
@@ -10,6 +10,7 @@
         <div class="flex items-center space-x-3">
             <select id="state-filter"
                     onchange="window.location.href='/apps?state='+this.value"
+                    data-tooltip="Filter applications by running state"
                     class="text-sm border border-gray-300 rounded-md px-3 py-1.5 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
                 <option value="all" {{if eq (index $c "Filter") "all"}}selected{{end}}>All States</option>
                 <option value="started" {{if eq (index $c "Filter") "started"}}selected{{end}}>Started</option>
@@ -19,6 +20,7 @@
                     hx-target="#app-table-body"
                     hx-select="#app-table-body"
                     hx-swap="outerHTML"
+                    data-tooltip="Reload application list. Auto-refreshes every 10s."
                     class="px-3 py-1.5 text-sm bg-gray-100 hover:bg-gray-200 rounded-md text-gray-700 transition-colors">
                 Refresh
             </button>

--- a/pkg/admin/static/templates/catalog.html
+++ b/pkg/admin/static/templates/catalog.html
@@ -22,7 +22,7 @@
         </span>
         {{end}}
         {{end}}
-        <a href="/topologies/upload" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+        <a href="/topologies/upload" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium" data-tooltip="Upload Terraform files for service provisioning">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/>
             </svg>
@@ -162,9 +162,11 @@
                 <div class="flex items-center space-x-1 ml-4">
                     <span class="text-xs text-gray-400">{{.VisibleCount}}/{{len .Plans}} visible</span>
                     <button hx-post="/catalog/{{.ServiceType.ID}}/visibility" hx-swap="none" hx-vals='{"visible":"true"}'
-                            class="px-2 py-1 text-xs text-green-700 bg-green-50 rounded hover:bg-green-100">Enable All</button>
+                            class="px-2 py-1 text-xs text-green-700 bg-green-50 rounded hover:bg-green-100"
+                            data-tooltip="Make all plans visible to users" data-tooltip-pos="top">Enable All</button>
                     <button hx-post="/catalog/{{.ServiceType.ID}}/visibility" hx-swap="none" hx-vals='{"visible":"false"}'
-                            class="px-2 py-1 text-xs text-gray-600 bg-gray-50 rounded hover:bg-gray-100">Disable All</button>
+                            class="px-2 py-1 text-xs text-gray-600 bg-gray-50 rounded hover:bg-gray-100"
+                            data-tooltip="Hide all plans from users" data-tooltip-pos="top">Disable All</button>
                 </div>
             </div>
         </div>

--- a/pkg/admin/static/templates/clusters.html
+++ b/pkg/admin/static/templates/clusters.html
@@ -9,7 +9,8 @@
         <h3 class="text-lg font-medium text-gray-900">Kubernetes Clusters</h3>
         <div class="flex items-center space-x-3">
             <button onclick="document.getElementById('add-cluster-form').classList.toggle('hidden')"
-                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                    data-tooltip="Register a new Kubernetes cluster">
                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
                 </svg>
@@ -67,12 +68,14 @@
             </div>
             <div class="flex items-center space-x-3 pt-2">
                 <button type="submit"
-                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                        data-tooltip="Save and register this cluster configuration" data-tooltip-pos="top">
                     Register Cluster
                 </button>
                 <button type="button"
                         onclick="document.getElementById('add-cluster-form').classList.add('hidden')"
-                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
+                        class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors"
+                        data-tooltip="Cancel cluster registration" data-tooltip-pos="top">
                     Cancel
                 </button>
             </div>
@@ -141,14 +144,16 @@
                         {{if not .IsActive}}
                         <button hx-post="/clusters/{{.ID}}/activate"
                                 hx-swap="none"
-                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors">
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors"
+                                data-tooltip="Make this the active cluster for deployments" data-tooltip-pos="top">
                             Set Active
                         </button>
                         <button hx-delete="/clusters/{{.ID}}"
                                 hx-confirm="Are you sure you want to remove cluster '{{.Name}}'?"
                                 hx-target="closest tr"
                                 hx-swap="outerHTML"
-                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 rounded-md transition-colors">
+                                class="inline-flex items-center px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 rounded-md transition-colors"
+                                data-tooltip="Unregister this cluster from MicroFoundry" data-tooltip-pos="top">
                             Remove
                         </button>
                         {{else}}

--- a/pkg/admin/static/templates/dashboard.html
+++ b/pkg/admin/static/templates/dashboard.html
@@ -6,7 +6,7 @@
 {{$c := .Content}}
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
     <!-- Applications Card -->
-    <a href="/apps" class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow">
+    <a href="/apps" class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow" data-tooltip="Total deployed applications. Click to view list.">
         <div class="flex items-center">
             <div class="p-3 rounded-full bg-blue-100 text-blue-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -21,7 +21,7 @@
     </a>
 
     <!-- Domain Card -->
-    <div class="bg-white rounded-lg shadow p-6">
+    <div class="bg-white rounded-lg shadow p-6" data-tooltip="Base domain used for routing traffic to applications">
         <div class="flex items-center">
             <div class="p-3 rounded-full bg-green-100 text-green-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -36,7 +36,7 @@
     </div>
 
     <!-- Namespace Card -->
-    <div class="bg-white rounded-lg shadow p-6">
+    <div class="bg-white rounded-lg shadow p-6" data-tooltip="Kubernetes namespace where resources are deployed">
         <div class="flex items-center">
             <div class="p-3 rounded-full bg-purple-100 text-purple-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -51,7 +51,7 @@
     </div>
 
     <!-- K8s Context Card -->
-    <div class="bg-white rounded-lg shadow p-6">
+    <div class="bg-white rounded-lg shadow p-6" data-tooltip="Active Kubernetes context from kubeconfig">
         <div class="flex items-center">
             <div class="p-3 rounded-full bg-orange-100 text-orange-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -72,19 +72,19 @@
         <h3 class="text-lg font-medium text-gray-900">Quick Links</h3>
     </div>
     <div class="p-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-        <a href="/apps" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+        <a href="/apps" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors" data-tooltip="Browse and manage all deployed apps">
             <span class="text-blue-600 font-medium">View Applications</span>
             <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
             </svg>
         </a>
-        <a href="/config" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+        <a href="/config" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors" data-tooltip="View and edit platform settings">
             <span class="text-blue-600 font-medium">Platform Configuration</span>
             <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
             </svg>
         </a>
-        <a href="/services" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors">
+        <a href="/services" class="flex items-center p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors" data-tooltip="View and manage provisioned backing services">
             <span class="text-blue-600 font-medium">Backing Services</span>
             <svg class="w-4 h-4 ml-auto text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>

--- a/pkg/admin/static/templates/layout.html
+++ b/pkg/admin/static/templates/layout.html
@@ -10,9 +10,54 @@
     <script src="https://unpkg.com/htmx-ext-sse@2.2.2/sse.js"></script>
     <style>
         [hx-swap-oob] { display: none; }
+        /* Tooltip system — pure CSS via data-tooltip attribute */
+        [data-tooltip] { position: relative; }
+        [data-tooltip]::after {
+            content: attr(data-tooltip);
+            position: absolute;
+            background: #111827;
+            color: #fff;
+            padding: 6px 10px;
+            border-radius: 6px;
+            font-size: 12px;
+            line-height: 1.4;
+            white-space: nowrap;
+            max-width: 320px;
+            z-index: 50;
+            pointer-events: none;
+            opacity: 0;
+            transition: opacity 0.15s ease;
+            box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+        }
+        [data-tooltip]:hover::after,
+        [data-tooltip]:focus-visible::after {
+            opacity: 1;
+        }
+        /* Default: bottom */
+        [data-tooltip]::after {
+            top: 100%; left: 50%; transform: translateX(-50%);
+            margin-top: 6px;
+        }
+        /* Right (sidebar nav) */
+        [data-tooltip-pos="right"]::after {
+            top: 50%; left: 100%; transform: translateY(-50%);
+            margin-top: 0; margin-left: 8px;
+        }
+        /* Top (row action buttons) */
+        [data-tooltip-pos="top"]::after {
+            top: auto; bottom: 100%; left: 50%; transform: translateX(-50%);
+            margin-top: 0; margin-bottom: 6px;
+        }
+        /* Left */
+        [data-tooltip-pos="left"]::after {
+            top: 50%; left: auto; right: 100%; transform: translateY(-50%);
+            margin-top: 0; margin-right: 8px;
+        }
+        /* Disable tooltips */
+        body.tooltips-off [data-tooltip]::after { display: none !important; }
     </style>
 </head>
-<body class="h-full">
+<body class="h-full {{if not .TooltipsEnabled}}tooltips-off{{end}}">
     <div class="flex h-full">
         {{template "nav" .}}
         <main class="flex-1 overflow-y-auto">

--- a/pkg/admin/static/templates/monitoring.html
+++ b/pkg/admin/static/templates/monitoring.html
@@ -12,7 +12,8 @@
             <p class="text-sm text-gray-500 mt-1">Application metrics, cluster resources, and alert management</p>
         </div>
         <a href="{{index $c "GrafanaBaseURL"}}" target="_blank"
-           class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-lg hover:bg-orange-700">
+           class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-lg hover:bg-orange-700"
+           data-tooltip="Open Grafana dashboard in a new tab">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
             </svg>
@@ -55,7 +56,8 @@
             <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
                 <h3 class="text-lg font-medium text-gray-900">MicroFoundry Overview</h3>
                 <a href="{{index $c "FullOverviewURL"}}" target="_blank"
-                   class="text-sm text-blue-600 hover:underline flex items-center">
+                   class="text-sm text-blue-600 hover:underline flex items-center"
+                   data-tooltip="View this dashboard in full Grafana">
                     Open in Grafana
                     <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
@@ -74,7 +76,8 @@
             <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
                 <h3 class="text-lg font-medium text-gray-900">Cluster Resources</h3>
                 <a href="{{index $c "FullClusterURL"}}" target="_blank"
-                   class="text-sm text-blue-600 hover:underline flex items-center">
+                   class="text-sm text-blue-600 hover:underline flex items-center"
+                   data-tooltip="View this dashboard in full Grafana">
                     Open in Grafana
                     <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>

--- a/pkg/admin/static/templates/partials/header.html
+++ b/pkg/admin/static/templates/partials/header.html
@@ -7,7 +7,7 @@
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
             </svg>
-            <a href="/clusters" class="font-medium text-gray-700 hover:text-blue-600">{{.ActiveCluster}}</a>
+            <a href="/clusters" class="font-medium text-gray-700 hover:text-blue-600" data-tooltip="Active cluster. Click to manage clusters.">{{.ActiveCluster}}</a>
         </div>
         {{end}}
         {{if .User}}
@@ -19,7 +19,7 @@
                 <div class="font-medium text-gray-700">{{.User.Name}}</div>
                 <div class="text-xs text-gray-400">{{.User.Email}}</div>
             </div>
-            <a href="/auth/logout" class="text-xs text-gray-500 hover:text-red-600 ml-2" title="Sign out">
+            <a href="/auth/logout" class="text-xs text-gray-500 hover:text-red-600 ml-2" data-tooltip="Sign out of MicroFoundry">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
                 </svg>

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -10,6 +10,7 @@
             <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Operations</span>
         </div>
         <a href="/"
+           data-tooltip="Platform overview: app count, cluster info, and quick links" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "dashboard"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
@@ -17,6 +18,7 @@
             Dashboard
         </a>
         <a href="/apps"
+           data-tooltip="View and manage all deployed applications" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "apps"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
@@ -24,6 +26,7 @@
             Applications
         </a>
         <a href="/services"
+           data-tooltip="Provisioned backing services: databases, caches, and queues" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "services"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"/>
@@ -31,6 +34,7 @@
             Services
         </a>
         <a href="/secrets"
+           data-tooltip="Manage application secrets and environment variables" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "secrets"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
@@ -38,6 +42,7 @@
             Secrets
         </a>
         <a href="/monitoring"
+           data-tooltip="Application metrics, cluster resources, and alert management" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "monitoring"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
@@ -50,6 +55,7 @@
             <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Settings</span>
         </div>
         <a href="/clusters"
+           data-tooltip="Register and manage Kubernetes clusters" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "clusters"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
@@ -57,6 +63,7 @@
             Clusters
         </a>
         <a href="/catalog"
+           data-tooltip="Browse service plans and configure provisioning topologies" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "catalog"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
@@ -64,6 +71,7 @@
             Service Catalog
         </a>
         <a href="/settings/registry"
+           data-tooltip="Configure container registry for image pushes" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-registry"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
@@ -72,6 +80,7 @@
             Registry
         </a>
         <a href="/settings/webhooks"
+           data-tooltip="Configure HTTP notifications for platform events" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-webhooks"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
@@ -79,6 +88,7 @@
             Webhooks
         </a>
         <a href="/settings/smtp"
+           data-tooltip="Set up email server for alerts and notifications" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "settings-smtp"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
@@ -86,6 +96,7 @@
             SMTP
         </a>
         <a href="/monitoring"
+           data-tooltip="Application metrics, cluster resources, and alert management" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "monitoring"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
@@ -93,6 +104,7 @@
             Metrics & Alerts
         </a>
         <a href="/users"
+           data-tooltip="Manage organizations, users, roles, and authorization policies" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
@@ -100,6 +112,7 @@
             Users & Orgs
         </a>
         <a href="/config"
+           data-tooltip="View platform-wide configuration and routing" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "config"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>

--- a/pkg/admin/static/templates/secret_create.html
+++ b/pkg/admin/static/templates/secret_create.html
@@ -56,7 +56,8 @@
                     </div>
                 </div>
                 <button type="button" onclick="addKVRow()"
-                        class="mt-2 inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium">
+                        class="mt-2 inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium"
+                        data-tooltip="Add another key-value pair to this secret">
                     <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
                     </svg>
@@ -66,10 +67,10 @@
 
             <!-- Footer -->
             <div class="flex justify-end space-x-3 pt-4 border-t border-gray-200">
-                <a href="/secrets" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium">
+                <a href="/secrets" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium" data-tooltip="Return to secrets list without creating" data-tooltip-pos="top">
                     Cancel
                 </a>
-                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium" data-tooltip="Create the secret in Kubernetes" data-tooltip-pos="top">
                     Create Secret
                 </button>
             </div>

--- a/pkg/admin/static/templates/secret_detail.html
+++ b/pkg/admin/static/templates/secret_detail.html
@@ -35,7 +35,8 @@
         {{if eq $detail.Type "user-defined"}}
         <button hx-delete="/secrets/{{$detail.Name}}"
                 hx-confirm="Delete secret '{{$detail.Name}}'? This cannot be undone."
-                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium"
+                data-tooltip="Permanently delete this secret" data-tooltip-pos="top">
             Delete
         </button>
         {{end}}

--- a/pkg/admin/static/templates/secrets.html
+++ b/pkg/admin/static/templates/secrets.html
@@ -8,7 +8,7 @@
         <h2 class="text-lg font-semibold text-gray-900">Secrets Manager</h2>
         <p class="text-sm text-gray-500">Manage application secrets and environment variables</p>
     </div>
-    <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+    <a href="/secrets/new" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium" data-tooltip="Create a new user-defined secret">
         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
@@ -82,7 +82,8 @@
                             hx-target="closest tr"
                             hx-swap="outerHTML swap:500ms"
                             hx-confirm="Delete secret '{{.Name}}'? This cannot be undone."
-                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                            class="text-red-600 hover:text-red-800 text-sm font-medium"
+                            data-tooltip="Permanently delete this secret" data-tooltip-pos="top">Delete</button>
                     {{end}}
                 </td>
             </tr>

--- a/pkg/admin/static/templates/service_detail.html
+++ b/pkg/admin/static/templates/service_detail.html
@@ -27,7 +27,8 @@
         {{if eq (len $inst.Bindings) 0}}
         <button hx-delete="/services/{{$inst.Name}}"
                 hx-confirm="Delete service '{{$inst.Name}}'? This will deprovision K8s resources."
-                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+                class="inline-flex items-center px-3 py-1.5 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium"
+                data-tooltip="Delete this service instance" data-tooltip-pos="top">
             Delete
         </button>
         {{end}}
@@ -95,7 +96,7 @@
         <div class="bg-white rounded-lg shadow">
             <div class="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
                 <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Connection Details</h3>
-                <a href="/secrets/{{$inst.Name}}" class="text-sm text-blue-600 hover:text-blue-800 font-medium">View in Secrets Manager &rarr;</a>
+                <a href="/secrets/{{$inst.Name}}" class="text-sm text-blue-600 hover:text-blue-800 font-medium" data-tooltip="View service credentials in the Secrets Manager">View in Secrets Manager &rarr;</a>
             </div>
             <div class="px-6 py-4">
                 <dl class="space-y-3">
@@ -181,7 +182,8 @@
                             <button hx-post="/services/{{$inst.Name}}/unbind"
                                     hx-include="closest form"
                                     hx-confirm="Unbind '{{.AppName}}' from '{{$inst.Name}}'?"
-                                    class="text-xs text-red-600 hover:text-red-800 font-medium">Unbind</button>
+                                    class="text-xs text-red-600 hover:text-red-800 font-medium"
+                                    data-tooltip="Remove this app's binding to the service" data-tooltip-pos="top">Unbind</button>
                         </form>
                     </li>
                     {{end}}

--- a/pkg/admin/static/templates/services.html
+++ b/pkg/admin/static/templates/services.html
@@ -8,7 +8,7 @@
         <h2 class="text-lg font-semibold text-gray-900">Provisioned Services</h2>
         <p class="text-sm text-gray-500">Backing services bound to your applications</p>
     </div>
-    <a href="/catalog" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+    <a href="/catalog" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium" data-tooltip="Provision a new backing service from the catalog">
         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
@@ -51,7 +51,8 @@
                             hx-target="#svc-row-{{.Name}}"
                             hx-swap="outerHTML swap:0.3s"
                             hx-confirm="Delete service '{{.Name}}'? This will deprovision the K8s resources."
-                            class="text-red-600 hover:text-red-800 text-sm font-medium">Delete</button>
+                            class="text-red-600 hover:text-red-800 text-sm font-medium"
+                            data-tooltip="Deprovision this service and remove K8s resources" data-tooltip-pos="top">Delete</button>
                 </td>
             </tr>
             {{end}}
@@ -68,7 +69,7 @@
         You haven't created any backing services yet. Browse the service catalog to provision databases, caches, message queues, and more.
     </p>
     <div class="mt-6">
-        <a href="/catalog" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+        <a href="/catalog" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium" data-tooltip="Open the service catalog to provision a new service">
             Browse Catalog
         </a>
     </div>

--- a/pkg/admin/static/templates/settings_registry.html
+++ b/pkg/admin/static/templates/settings_registry.html
@@ -60,13 +60,13 @@
                 <label class="flex items-center">
                     <input type="checkbox" name="insecure" value="true" {{if (index $c "Registry").Insecure}}checked{{end}}
                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-                    <span class="ml-2 text-sm text-gray-700">Skip TLS Verification</span>
+                    <span class="ml-2 text-sm text-gray-700" data-tooltip="Allow insecure connections to the registry">Skip TLS Verification</span>
                 </label>
 
                 <label class="flex items-center">
                     <input type="checkbox" name="enabled" value="true" {{if (index $c "Registry").Enabled}}checked{{end}}
                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-                    <span class="ml-2 text-sm text-gray-700">Enable Registry Push</span>
+                    <span class="ml-2 text-sm text-gray-700" data-tooltip="Enable image push to this registry on mf push">Enable Registry Push</span>
                 </label>
             </div>
 
@@ -78,6 +78,7 @@
                             hx-include="closest form"
                             hx-target="#test-result"
                             hx-swap="innerHTML"
+                            data-tooltip="Verify connectivity to the configured registry" data-tooltip-pos="top"
                             class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
@@ -99,10 +100,12 @@
             <!-- Actions -->
             <div class="flex items-center space-x-3 pt-2">
                 <button type="submit"
+                        data-tooltip="Save registry settings to Kubernetes" data-tooltip-pos="top"
                         class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
                     Save Registry Settings
                 </button>
                 <a href="/config"
+                   data-tooltip="Return without saving" data-tooltip-pos="top"
                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
                     Cancel
                 </a>

--- a/pkg/admin/static/templates/settings_smtp.html
+++ b/pkg/admin/static/templates/settings_smtp.html
@@ -66,13 +66,13 @@
                 <label class="flex items-center">
                     <input type="checkbox" name="tls" value="true" {{if (index $c "SMTP").TLS}}checked{{end}}
                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-                    <span class="ml-2 text-sm text-gray-700">Use TLS</span>
+                    <span class="ml-2 text-sm text-gray-700" data-tooltip="Encrypt SMTP connection with TLS">Use TLS</span>
                 </label>
 
                 <label class="flex items-center">
                     <input type="checkbox" name="enabled" value="true" {{if (index $c "SMTP").Enabled}}checked{{end}}
                            class="rounded border-gray-300 text-blue-600 shadow-sm focus:ring-blue-500">
-                    <span class="ml-2 text-sm text-gray-700">Enable SMTP</span>
+                    <span class="ml-2 text-sm text-gray-700" data-tooltip="Enable email notifications for alerts">Enable SMTP</span>
                 </label>
             </div>
 
@@ -84,6 +84,7 @@
                             hx-include="closest form"
                             hx-target="#test-result"
                             hx-swap="innerHTML"
+                            data-tooltip="Send a test email using current configuration" data-tooltip-pos="top"
                             class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
@@ -97,10 +98,12 @@
             <!-- Actions -->
             <div class="flex items-center space-x-3 pt-2">
                 <button type="submit"
+                        data-tooltip="Save SMTP configuration to Kubernetes" data-tooltip-pos="top"
                         class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
                     Save SMTP Settings
                 </button>
                 <a href="/config"
+                   data-tooltip="Return without saving" data-tooltip-pos="top"
                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
                     Cancel
                 </a>

--- a/pkg/admin/static/templates/settings_webhooks.html
+++ b/pkg/admin/static/templates/settings_webhooks.html
@@ -11,6 +11,7 @@
             <p class="mt-1 text-sm text-gray-500">Send HTTP POST notifications when platform events occur.</p>
         </div>
         <button onclick="document.getElementById('add-webhook-form').classList.toggle('hidden')"
+                data-tooltip="Create a new webhook endpoint"
                 class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
@@ -56,11 +57,13 @@
             </label>
             <div class="flex items-center space-x-3 pt-2">
                 <button type="submit"
+                        data-tooltip="Register the webhook and start sending events" data-tooltip-pos="top"
                         class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
                     Create Webhook
                 </button>
                 <button type="button"
                         onclick="document.getElementById('add-webhook-form').classList.add('hidden')"
+                        data-tooltip="Cancel webhook creation" data-tooltip-pos="top"
                         class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 rounded-md transition-colors">
                     Cancel
                 </button>
@@ -86,7 +89,7 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                         {{.Name}}
                     </td>
-                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 max-w-xs truncate" title="{{.URL}}">
+                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 max-w-xs truncate" data-tooltip="{{.URL}}">
                         {{.URL}}
                     </td>
                     <td class="px-4 py-4">
@@ -108,6 +111,7 @@
                     <td class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                         <button hx-post="/settings/webhooks/{{.ID}}/test"
                                 hx-swap="none"
+                                data-tooltip="Send a test payload to this webhook URL" data-tooltip-pos="top"
                                 class="inline-flex items-center px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-md transition-colors">
                             Test
                         </button>
@@ -115,6 +119,7 @@
                                 hx-confirm="Delete webhook '{{.Name}}'?"
                                 hx-target="closest tr"
                                 hx-swap="outerHTML"
+                                data-tooltip="Remove this webhook permanently" data-tooltip-pos="top"
                                 class="inline-flex items-center px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 border border-red-200 rounded-md transition-colors">
                             Delete
                         </button>

--- a/pkg/admin/static/templates/tabs/tab_config.html
+++ b/pkg/admin/static/templates/tabs/tab_config.html
@@ -20,7 +20,7 @@
                             {{if isSensitive $key}}
                             <span class="env-masked" data-value="{{$val}}">
                                 <span class="mask-text">&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;</span>
-                                <button onclick="toggleEnvValue(this)" class="ml-2 text-xs text-blue-600 hover:text-blue-800">Show</button>
+                                <button onclick="toggleEnvValue(this)" data-tooltip="Toggle visibility of sensitive value" data-tooltip-pos="left" class="ml-2 text-xs text-blue-600 hover:text-blue-800">Show</button>
                             </span>
                             {{else}}
                             {{$val}}

--- a/pkg/admin/static/templates/tabs/tab_iam_audit.html
+++ b/pkg/admin/static/templates/tabs/tab_iam_audit.html
@@ -41,7 +41,7 @@
                     <option value="delete" {{if eq .ActionFilter "delete"}}selected{{end}}>Delete</option>
                 </select>
             </div>
-            <button type="submit" class="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded-md hover:bg-gray-200 border">Filter</button>
+            <button type="submit" data-tooltip="Apply filters to the audit log" class="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded-md hover:bg-gray-200 border">Filter</button>
         </form>
     </div>
 

--- a/pkg/admin/static/templates/tabs/tab_iam_orgs.html
+++ b/pkg/admin/static/templates/tabs/tab_iam_orgs.html
@@ -13,6 +13,7 @@
                 <div class="p-4 border-b border-gray-200 flex items-center justify-between">
                     <h3 class="text-lg font-semibold text-gray-900">Organizations</h3>
                     <button onclick="document.getElementById('create-org-form').classList.toggle('hidden')"
+                            data-tooltip="Create a new organization"
                             class="text-sm px-3 py-1.5 bg-gray-900 text-white rounded-md hover:bg-gray-800">
                         + New
                     </button>
@@ -28,7 +29,7 @@
                                    placeholder="my-team">
                         </div>
                         <div class="flex space-x-2">
-                            <button type="submit" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Create</button>
+                            <button type="submit" data-tooltip="Create the organization and its namespace" data-tooltip-pos="top" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Create</button>
                             <button type="button" onclick="document.getElementById('create-org-form').classList.add('hidden')"
                                     class="px-3 py-1.5 bg-white text-gray-700 text-sm rounded-md border hover:bg-gray-50">Cancel</button>
                         </div>
@@ -74,7 +75,7 @@
                         <div class="flex items-center space-x-2">
                             {{if ne (index $ "ActiveOrg") $org.ID}}
                             <form method="POST" action="/users/orgs/{{$org.ID}}/activate">
-                                <button type="submit" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">
+                                <button type="submit" data-tooltip="Set this as the active organization" data-tooltip-pos="top" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">
                                     Set Active
                                 </button>
                             </form>
@@ -138,6 +139,7 @@
                                     <button hx-delete="/users/orgs/{{$org.ID}}/members/{{.Email}}"
                                             hx-confirm="Remove {{.Email}} from this organization?"
                                             hx-target="closest tr" hx-swap="outerHTML"
+                                            data-tooltip="Remove this user from the organization" data-tooltip-pos="top"
                                             class="text-red-600 hover:text-red-800 text-xs">Remove</button>
                                     {{else}}
                                     <span class="text-xs text-gray-400">Owner</span>
@@ -175,7 +177,7 @@
                                 <option value="viewer">Viewer</option>
                             </select>
                         </div>
-                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Invite</button>
+                        <button type="submit" data-tooltip="Add a user to this organization" data-tooltip-pos="top" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Invite</button>
                     </form>
                 </div>
                 {{end}}
@@ -187,6 +189,7 @@
                     <p class="text-xs text-red-700 mb-3">Deleting an organization removes all its resources.</p>
                     <button hx-delete="/users/orgs/{{$org.ID}}"
                             hx-confirm="Delete organization '{{$org.Name}}'? This will remove all resources in namespace '{{$org.Namespace}}'."
+                            data-tooltip="Delete this organization and all its resources" data-tooltip-pos="top"
                             class="px-3 py-1.5 bg-red-600 text-white text-sm rounded-md hover:bg-red-700">
                         Delete Organization
                     </button>

--- a/pkg/admin/static/templates/tabs/tab_iam_policies.html
+++ b/pkg/admin/static/templates/tabs/tab_iam_policies.html
@@ -58,7 +58,7 @@
                               placeholder="package microfoundry.authz.custom&#10;import rego.v1&#10;&#10;# Your custom rules here..."></textarea>
                 </div>
                 <div class="flex space-x-2">
-                    <button type="submit" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Save Policy</button>
+                    <button type="submit" data-tooltip="Compile and hot-reload this Rego policy" data-tooltip-pos="top" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Save Policy</button>
                     <span class="text-xs text-gray-500 self-center">Policy will be compiled and hot-reloaded immediately</span>
                 </div>
             </form>

--- a/pkg/admin/static/templates/tabs/tab_iam_users.html
+++ b/pkg/admin/static/templates/tabs/tab_iam_users.html
@@ -20,9 +20,10 @@
         <form hx-get="/users/tab/users" hx-target="#tab-content" class="flex items-center space-x-2">
             <input type="text" name="search" value="{{.Search}}" placeholder="Search users..."
                    class="rounded-md border-gray-300 shadow-sm text-sm p-2 border focus:ring-blue-500 focus:border-blue-500 w-64">
-            <button type="submit" class="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded-md hover:bg-gray-200 border">Search</button>
+            <button type="submit" data-tooltip="Search users by name or email" class="px-3 py-2 bg-gray-100 text-gray-700 text-sm rounded-md hover:bg-gray-200 border">Search</button>
         </form>
         <button onclick="document.getElementById('create-user-form').classList.toggle('hidden')"
+                data-tooltip="Create a new Keycloak user account"
                 class="px-3 py-1.5 bg-gray-900 text-white text-sm rounded-md hover:bg-gray-800">+ New User</button>
     </div>
 
@@ -57,7 +58,7 @@
                        placeholder="Leave empty to require user to set password">
             </div>
             <div class="col-span-2 flex space-x-2">
-                <button type="submit" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Create User</button>
+                <button type="submit" data-tooltip="Create the user in Keycloak" data-tooltip-pos="top" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Create User</button>
                 <button type="button" onclick="document.getElementById('create-user-form').classList.add('hidden')"
                         class="px-4 py-2 bg-white text-gray-700 text-sm rounded-md border hover:bg-gray-50">Cancel</button>
             </div>
@@ -116,11 +117,13 @@
                     <td class="px-4 py-3 text-right space-x-1">
                         <button hx-post="/users/keycloak/{{.ID}}/toggle"
                                 hx-confirm="{{if .Enabled}}Disable{{else}}Enable{{end}} user '{{.Username}}'?"
+                                data-tooltip="Toggle user account active status" data-tooltip-pos="top"
                                 class="text-xs {{if .Enabled}}text-yellow-600 hover:text-yellow-800{{else}}text-green-600 hover:text-green-800{{end}}">
                             {{if .Enabled}}Disable{{else}}Enable{{end}}
                         </button>
                         <button hx-delete="/users/keycloak/{{.ID}}"
                                 hx-confirm="Delete user '{{.Username}}'? This cannot be undone."
+                                data-tooltip="Permanently delete this user from Keycloak" data-tooltip-pos="top"
                                 class="text-xs text-red-600 hover:text-red-800">Delete</button>
                     </td>
                 </tr>

--- a/pkg/admin/static/templates/tabs/tab_instances.html
+++ b/pkg/admin/static/templates/tabs/tab_instances.html
@@ -42,8 +42,10 @@
               hx-target="#tab-content"
               class="flex items-center space-x-2">
             <input type="number" name="instances" value="{{.Instances}}" min="0" max="20"
+                   data-tooltip="Set desired instance count and apply"
                    class="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-center">
             <button type="submit"
+                    data-tooltip="Set desired instance count and apply"
                     class="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition-colors">
                 Scale
             </button>

--- a/pkg/admin/static/templates/tabs/tab_logs.html
+++ b/pkg/admin/static/templates/tabs/tab_logs.html
@@ -50,6 +50,7 @@
             <h4 class="text-sm font-medium text-gray-700">Historical Logs (Loki)</h4>
             <div class="flex items-center space-x-2">
                 <select id="log-duration"
+                        data-tooltip="Select time window for historical log query"
                         class="text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
                     <option value="15m">Last 15 minutes</option>
                     <option value="1h" selected>Last 1 hour</option>
@@ -61,6 +62,7 @@
                         hx-include="#log-duration"
                         hx-params="duration"
                         hx-indicator="#log-history-spinner"
+                        data-tooltip="Fetch historical logs from Loki for selected time range"
                         class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors">
                     Query
                 </button>
@@ -81,6 +83,7 @@
         <p class="text-sm text-gray-500">Live log stream from all instances</p>
         <button id="log-toggle"
                 onclick="toggleLogs('{{index . "Name"}}')"
+                data-tooltip="Toggle live log streaming via SSE"
                 class="px-3 py-1.5 text-sm bg-green-600 text-white rounded hover:bg-green-700 transition-colors">
             Start Streaming
         </button>

--- a/pkg/admin/static/templates/tabs/tab_metrics.html
+++ b/pkg/admin/static/templates/tabs/tab_metrics.html
@@ -3,6 +3,7 @@
     <div class="flex items-center justify-between">
         <p class="text-sm text-gray-500">Application metrics from Prometheus via Grafana</p>
         <a href="{{index . "GrafanaAppURL"}}" target="_blank"
+           data-tooltip="Open full metrics dashboard in Grafana"
            class="text-sm text-blue-600 hover:underline flex items-center">
             Open in Grafana
             <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pkg/admin/static/templates/tabs/tab_performance.html
+++ b/pkg/admin/static/templates/tabs/tab_performance.html
@@ -6,6 +6,7 @@
             <p class="text-xs text-gray-400 mt-1">Rate &middot; Errors &middot; Duration &mdash; Netflix Atlas / Spectator inspired</p>
         </div>
         <a href="{{index . "GrafanaAppURL"}}" target="_blank"
+           data-tooltip="Open full performance dashboard in Grafana"
            class="text-sm text-blue-600 hover:underline flex items-center">
             Open in Grafana
             <svg class="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pkg/admin/static/templates/topology_detail.html
+++ b/pkg/admin/static/templates/topology_detail.html
@@ -50,7 +50,8 @@
         <div class="flex justify-between items-center mb-3">
             <h3 class="text-sm font-semibold text-gray-900">Terraform Files</h3>
             <button type="button" onclick="addFileEditor()"
-                    class="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium">
+                    class="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 font-medium"
+                    data-tooltip="Add a new .tf file to this topology">
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
                 </svg>
@@ -118,7 +119,8 @@
                     hx-target="#preview-output"
                     hx-swap="innerHTML"
                     hx-include="closest form"
-                    class="inline-flex items-center px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium">
+                    class="inline-flex items-center px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm font-medium"
+                    data-tooltip="Execute terraform plan in dry-run mode">
                 <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
@@ -153,7 +155,8 @@
             <button type="button"
                     hx-delete="/topologies/{{.ServiceType}}/{{.PlanID}}"
                     hx-confirm="Remove this topology? Existing terraform-provisioned instances will need terraform state for cleanup."
-                    class="inline-flex items-center px-4 py-2 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium">
+                    class="inline-flex items-center px-4 py-2 border border-red-300 text-red-700 rounded-md hover:bg-red-50 text-sm font-medium"
+                    data-tooltip="Delete this topology" data-tooltip-pos="top">
                 Remove Topology
             </button>
             {{end}}
@@ -162,7 +165,7 @@
             <a href="/catalog" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium">
                 Cancel
             </a>
-            <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+            <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium" data-tooltip="Save all Terraform file changes" data-tooltip-pos="top">
                 Save Topology
             </button>
         </div>

--- a/pkg/admin/static/templates/topology_upload.html
+++ b/pkg/admin/static/templates/topology_upload.html
@@ -73,10 +73,10 @@
 
             <!-- Footer -->
             <div class="flex justify-end space-x-3 pt-4 border-t border-gray-200">
-                <a href="/catalog" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium">
+                <a href="/catalog" class="inline-flex items-center px-4 py-2 border border-gray-300 text-gray-700 rounded-md hover:bg-gray-50 text-sm font-medium" data-tooltip="Return to catalog without uploading" data-tooltip-pos="top">
                     Cancel
                 </a>
-                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium">
+                <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 text-sm font-medium" data-tooltip="Upload and save Terraform files" data-tooltip-pos="top">
                     Upload Topology
                 </button>
             </div>

--- a/pkg/admin/static/templates/users.html
+++ b/pkg/admin/static/templates/users.html
@@ -33,28 +33,32 @@
                    hx-get="/users/tab/orgs"
                    hx-target="#tab-content"
                    hx-push-url="/users?tab=orgs"
-                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "orgs"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "orgs"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}"
+                   data-tooltip="Manage organizations and team namespaces">
                     Organizations
                 </a>
                 <a href="/users?tab=users"
                    hx-get="/users/tab/users"
                    hx-target="#tab-content"
                    hx-push-url="/users?tab=users"
-                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "users"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "users"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}"
+                   data-tooltip="View and manage Keycloak user accounts">
                     Users
                 </a>
                 <a href="/users?tab=policies"
                    hx-get="/users/tab/policies"
                    hx-target="#tab-content"
                    hx-push-url="/users?tab=policies"
-                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "policies"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "policies"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}"
+                   data-tooltip="View and edit OPA Rego authorization policies">
                     Policies
                 </a>
                 <a href="/users?tab=audit"
                    hx-get="/users/tab/audit"
                    hx-target="#tab-content"
                    hx-push-url="/users?tab=audit"
-                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "audit"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}">
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "audit"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}"
+                   data-tooltip="Review authorization decision audit trail">
                     Audit Log
                 </a>
             </nav>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,12 @@ type Config struct {
 	Registry   RegistryConfig   `mapstructure:"registry"`
 	SMTP       SMTPConfig       `mapstructure:"smtp"`
 	Auth       AuthConfig       `mapstructure:"auth"`
+	UI         UIConfig         `mapstructure:"ui"`
+}
+
+// UIConfig holds admin UI feature toggles.
+type UIConfig struct {
+	Tooltips bool `mapstructure:"tooltips"`
 }
 
 // RegistryConfig provides file-based defaults for container registry settings.
@@ -168,6 +174,7 @@ func Load() (*Config, error) {
 	v.SetDefault("monitoring.alertmanager_url", "http://kube-prometheus-kube-prome-alertmanager.monitoring.svc.cluster.local:9093")
 	v.SetDefault("monitoring.prometheus_url", "http://kube-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090")
 	v.SetDefault("monitoring.beyla_enabled", true)
+	v.SetDefault("ui.tooltips", true)
 
 	// Read config file (optional — not an error if missing)
 	if err := v.ReadInConfig(); err != nil {


### PR DESCRIPTION
## Summary

Closes #43

- Add pure CSS tooltip system via `data-tooltip` attributes — zero JS dependencies
- ~120 tooltip elements across 33 templates: sidebar nav, buttons, tabs, forms, settings
- Configurable via `ui.tooltips` in `mf.yaml` (enabled by default, `body.tooltips-off` to disable)
- Directional positioning: `data-tooltip-pos="right|top|left"` for context-aware placement
- CSS `::after` pseudo-elements with 150ms fade transition and `shadow-lg`
- Keyboard accessible via `:focus-visible` selector
- Works automatically with HTMX content swaps (no JS initialization needed)

**33 files modified, +200 -68 lines**

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Sidebar items show tooltips on hover (positioned to the right)
- [ ] Dashboard cards, quick links show tooltips on hover
- [ ] App detail tabs show descriptive tooltips
- [ ] Action buttons (Scale, Delete, Create, Save) show tooltips
- [ ] Settings pages (Registry, SMTP, Webhooks) show tooltips
- [ ] IAM tabs and buttons show tooltips
- [ ] Setting `ui.tooltips: false` in mf.yaml disables all tooltips
- [ ] Tooltips appear on keyboard focus (Tab navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)