### PR TITLE
feat(admin): configurable domain name with auto-TLS (admin.cf-local.dev)

### DIFF
--- a/cmd/mf/admin.go
+++ b/cmd/mf/admin.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -91,9 +94,59 @@ func adminCmd() *cobra.Command {
 				opts = append(opts, admin.WithAuditLog(auditLog))
 			}
 
-			// TLS support
-			if tlsCert != "" && tlsKey != "" {
-				opts = append(opts, admin.WithTLS(tlsCert, tlsKey))
+			// Resolve TLS cert/key paths
+			// Priority: CLI flags → config file paths → auto-detect from ~/.mf/
+			certPath, keyPath := tlsCert, tlsKey
+			if certPath == "" && keyPath == "" && cfg.Admin.TLSCert != "" && cfg.Admin.TLSKey != "" {
+				certPath = cfg.Admin.TLSCert
+				keyPath = cfg.Admin.TLSKey
+			}
+			if certPath == "" && keyPath == "" && cfg.Admin.TLS {
+				// Auto-detect from ~/.mf/ directory
+				if home, err := os.UserHomeDir(); err == nil {
+					cp := filepath.Join(home, ".mf", "cert.pem")
+					kp := filepath.Join(home, ".mf", "key.pem")
+					if _, err := os.Stat(cp); err == nil {
+						if _, err := os.Stat(kp); err == nil {
+							certPath = cp
+							keyPath = kp
+						}
+					}
+				}
+			}
+
+			tlsEnabled := certPath != "" && keyPath != ""
+
+			if cfg.Admin.TLS && !tlsEnabled {
+				fmt.Println("Warning: admin.tls is true but certificates not found at ~/.mf/cert.pem")
+				fmt.Println("  Falling back to HTTP. Run 'mf setup tls' to generate certificates.")
+				fmt.Println()
+			}
+
+			if tlsEnabled {
+				opts = append(opts, admin.WithTLS(certPath, keyPath))
+			}
+
+			// Resolve listen port
+			// CLI flag overrides config; otherwise use tls_port for HTTPS, port for HTTP
+			listenPort := port
+			if !cmd.Flags().Changed("port") {
+				if tlsEnabled && cfg.Admin.TLSPort > 0 {
+					listenPort = cfg.Admin.TLSPort
+				} else if cfg.Admin.Port > 0 {
+					listenPort = cfg.Admin.Port
+				}
+			}
+
+			// Resolve listen host
+			listenHost := host
+			if !cmd.Flags().Changed("host") && cfg.Admin.Host != "" {
+				listenHost = cfg.Admin.Host
+			}
+
+			// Pass admin domain to server for template rendering
+			if cfg.Admin.Domain != "" {
+				opts = append(opts, admin.WithDomain(cfg.Admin.Domain, tlsEnabled))
 			}
 
 			srv := admin.NewServer(clientManager, cfg, version, opts...)
@@ -103,13 +156,52 @@ func adminCmd() *cobra.Command {
 			defer cancel()
 			go monitoring.StartCollector(ctx, srv.GetMetrics(), clientManager, 30*time.Second)
 
-			addr := fmt.Sprintf("%s:%d", host, port)
-			scheme := "http"
-			if tlsCert != "" && tlsKey != "" {
-				scheme = "https"
+			// Startup banner
+			fmt.Println()
+			fmt.Println("MicroFoundry Admin")
+			fmt.Println()
+			if tlsEnabled && cfg.Admin.Domain != "" {
+				adminURL := cfg.Admin.AdminURL()
+				fmt.Printf("  HTTPS  %s\n", adminURL)
+				fmt.Printf("  Cluster  %s\n", cfg.Kubernetes.Active)
+				fmt.Printf("  Domain   %s\n", cfg.Admin.Domain)
+				fmt.Printf("  TLS      %s (trusted by mkcert)\n", certPath)
+			} else if tlsEnabled {
+				fmt.Printf("  HTTPS  https://localhost:%d\n", listenPort)
+				fmt.Printf("  Cluster  %s\n", cfg.Kubernetes.Active)
+				fmt.Printf("  TLS      %s\n", certPath)
+			} else {
+				fmt.Printf("  HTTP   http://localhost:%d\n", listenPort)
+				fmt.Printf("  Cluster  %s\n", cfg.Kubernetes.Active)
+				if cfg.Admin.Domain == "" {
+					fmt.Println()
+					fmt.Println("  TIP: Run 'mf setup tls' to enable HTTPS with a custom domain")
+				}
 			}
-			fmt.Printf("MicroFoundry Admin starting at %s://localhost:%d\n", scheme, port)
-			fmt.Printf("Active cluster: %s\n", cfg.Kubernetes.Active)
+			fmt.Println()
+
+			// Start HTTP redirect server when TLS is enabled
+			if tlsEnabled {
+				httpPort := cfg.Admin.Port
+				if httpPort == 0 {
+					httpPort = 8080
+				}
+				redirectURL := cfg.Admin.AdminURL()
+				go func() {
+					redirectMux := http.NewServeMux()
+					redirectMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+						target := redirectURL + r.URL.Path
+						if r.URL.RawQuery != "" {
+							target += "?" + r.URL.RawQuery
+						}
+						http.Redirect(w, r, target, http.StatusMovedPermanently)
+					})
+					httpAddr := fmt.Sprintf("%s:%d", listenHost, httpPort)
+					_ = http.ListenAndServe(httpAddr, redirectMux)
+				}()
+			}
+
+			addr := fmt.Sprintf("%s:%d", listenHost, listenPort)
 			return srv.ListenAndServe(addr)
 		},
 	}

--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -204,7 +204,7 @@ func pushCmd() *cobra.Command {
 			fmt.Printf("memory:     %dM\n", app.MemoryMB)
 			fmt.Printf("disk:       %dM\n", app.DiskMB)
 			fmt.Printf("metrics:    auto-instrumented (Beyla eBPF)\n")
-			fmt.Printf("dashboard:  http://localhost:8080/apps/%s?tab=performance\n", app.Name)
+			fmt.Printf("dashboard:  %s/apps/%s?tab=performance\n", cfg.Admin.AdminURL(), app.Name)
 			fmt.Println()
 
 			return nil

--- a/cmd/mf/setup.go
+++ b/cmd/mf/setup.go
@@ -102,7 +102,7 @@ func setupKeycloakCmd() *cobra.Command {
 			fmt.Printf("    issuer_url: \"%s/realms/microfoundry\"\n", keycloakURL)
 			fmt.Println("    client_id: \"mf-admin\"")
 			fmt.Printf("    client_secret: \"%s\"\n", clientSecret)
-			fmt.Printf("    redirect_url: \"http://localhost:8080/auth/callback\"\n")
+			fmt.Printf("    redirect_url: \"https://admin.%s:8443/auth/callback\"\n", clusterCfg.Domain)
 
 			fmt.Printf("\nKeycloak Admin Console: %s/admin\n", keycloakURL)
 			fmt.Printf("Admin credentials: %s / %s\n", adminUser, adminPass)
@@ -158,7 +158,7 @@ func setupKeycloakRealmCmd() *cobra.Command {
 	cmd.Flags().StringVar(&adminUser, "admin-user", "admin", "Keycloak admin username")
 	cmd.Flags().StringVar(&adminPass, "admin-pass", "admin", "Keycloak admin password")
 	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth2 client secret (auto-generated if empty)")
-	cmd.Flags().StringVar(&redirectURI, "redirect-uri", "http://localhost:8080/auth/callback", "OAuth2 redirect URI")
+	cmd.Flags().StringVar(&redirectURI, "redirect-uri", "https://admin.cf-local.dev:8443/auth/callback", "OAuth2 redirect URI")
 
 	return cmd
 }
@@ -287,7 +287,9 @@ Requires mkcert to be installed: https://github.com/FiloSottile/mkcert`,
 
 			// Step 7: Add hosts entries
 			fmt.Println("[7/8] Updating hosts file...")
+			adminDomain := fmt.Sprintf("admin.%s", domain)
 			systemHosts := []string{
+				adminDomain,
 				fmt.Sprintf("keycloak.%s", domain),
 				fmt.Sprintf("grafana.%s", domain),
 			}
@@ -313,16 +315,21 @@ Requires mkcert to be installed: https://github.com/FiloSottile/mkcert`,
 			fmt.Println()
 			fmt.Println("=== TLS Setup Complete ===")
 			fmt.Println()
-			fmt.Printf("  Keycloak:  https://keycloak.%s\n", domain)
-			fmt.Printf("  Grafana:   https://grafana.%s\n", domain)
+			fmt.Println("  Service URLs:")
+			fmt.Printf("    Admin:     https://%s:8443\n", adminDomain)
+			fmt.Printf("    Keycloak:  https://keycloak.%s\n", domain)
+			fmt.Printf("    Grafana:   https://grafana.%s\n", domain)
 			fmt.Println()
 			fmt.Println("All apps pushed with `mf push` will automatically get HTTPS routes.")
+			fmt.Println("The admin server will auto-detect TLS certificates on next startup.")
 			fmt.Println()
-			fmt.Println("To enable TLS on the admin server, run:")
-			fmt.Printf("  mf admin --tls-cert %s --tls-key %s\n", certPath, keyPath)
+			fmt.Println("Add to your mf.yaml:")
+			fmt.Println("  admin:")
+			fmt.Printf("    domain: \"%s\"\n", adminDomain)
+			fmt.Println("    tls: true")
+			fmt.Println("    tls_port: 8443")
 			fmt.Println()
-			fmt.Println("Add to your mf.yaml cluster config:")
-			fmt.Println("  tls: true")
+			fmt.Printf("  Start the admin:  mf admin\n")
 
 			return nil
 		},

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -28,8 +28,11 @@ kubernetes:
   # namespace: "microfoundry"
 
 admin:
-  port: 8080
-  host: "0.0.0.0"
+  port: 8080       # HTTP port (used when TLS is disabled, or for HTTP→HTTPS redirect)
+  host: "0.0.0.0"  # Bind address for the admin server
+  # domain: "admin.cf-local.dev"  # Admin UI domain (set automatically by `mf setup tls`)
+  # tls: true                     # Auto-enable TLS using ~/.mf/cert.pem
+  # tls_port: 8443                # HTTPS port (default: 8443; use 443 for clean URLs)
 
 # Admin UI feature toggles
 ui:
@@ -64,7 +67,7 @@ monitoring:
 #   issuer_url: "http://localhost:8180/realms/microfoundry"
 #   client_id: "mf-admin"
 #   client_secret: "your-client-secret"
-#   redirect_url: "http://localhost:8080/auth/callback"
+#   redirect_url: "https://admin.cf-local.dev:8443/auth/callback"
 #   session_key: ""  # 64-char hex string; auto-generated if empty
 #   # Keycloak Admin API (for user CRUD, SCIM, and IAM management)
 #   admin_base_url: "http://localhost:8180"

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -19,6 +19,8 @@ type PageData struct {
 	User            *auth.UserSession // nil when auth is disabled or not logged in
 	AuthEnabled     bool
 	TooltipsEnabled bool
+	AdminDomain     string
+	TLSEnabled      bool
 }
 
 func (s *Server) pageData(title, active string) PageData {
@@ -29,6 +31,8 @@ func (s *Server) pageData(title, active string) PageData {
 		ActiveCluster:   s.clientManager.GetActive(),
 		AuthEnabled:     s.authEnabled(),
 		TooltipsEnabled: s.config.UI.Tooltips,
+		AdminDomain:     s.adminDomain,
+		TLSEnabled:      s.tlsEnabled,
 	}
 }
 

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -33,6 +33,9 @@ type Server struct {
 	// TLS (empty when TLS disabled)
 	tlsCertFile string
 	tlsKeyFile  string
+	// Admin domain (e.g., "admin.cf-local.dev")
+	adminDomain string
+	tlsEnabled  bool
 }
 
 // ServerOption configures optional Server features.
@@ -80,6 +83,14 @@ func WithTLS(certFile, keyFile string) ServerOption {
 	return func(s *Server) {
 		s.tlsCertFile = certFile
 		s.tlsKeyFile = keyFile
+	}
+}
+
+// WithDomain sets the admin domain name for display in the UI.
+func WithDomain(domain string, tlsEnabled bool) ServerOption {
+	return func(s *Server) {
+		s.adminDomain = domain
+		s.tlsEnabled = tlsEnabled
 	}
 }
 

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -3,6 +3,16 @@
     <div class="p-4 border-b border-gray-700">
         <h1 class="text-lg font-bold text-white">MicroFoundry</h1>
         <span class="text-xs text-gray-500">{{.Version}}</span>
+        {{if .AdminDomain}}
+        <div class="mt-1 flex items-center space-x-1">
+            {{if .TLSEnabled}}
+            <svg class="w-3 h-3 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clip-rule="evenodd"/>
+            </svg>
+            {{end}}
+            <span class="text-xs text-gray-500" data-tooltip="Admin UI domain name" data-tooltip-pos="right">{{.AdminDomain}}</span>
+        </div>
+        {{end}}
     </div>
     <nav class="flex-1 p-3 space-y-1">
         <!-- Operations -->

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,11 +13,23 @@ import (
 type Config struct {
 	GitHub     GitHubConfig     `mapstructure:"github"`
 	Kubernetes KubernetesConfig `mapstructure:"kubernetes"`
+	Admin      AdminConfig      `mapstructure:"admin"`
 	Monitoring MonitoringConfig `mapstructure:"monitoring"`
 	Registry   RegistryConfig   `mapstructure:"registry"`
 	SMTP       SMTPConfig       `mapstructure:"smtp"`
 	Auth       AuthConfig       `mapstructure:"auth"`
 	UI         UIConfig         `mapstructure:"ui"`
+}
+
+// AdminConfig holds admin UI server settings.
+type AdminConfig struct {
+	Port    int    `mapstructure:"port"`
+	Host    string `mapstructure:"host"`
+	Domain  string `mapstructure:"domain"`
+	TLS     bool   `mapstructure:"tls"`
+	TLSPort int    `mapstructure:"tls_port"`
+	TLSCert string `mapstructure:"tls_cert"`
+	TLSKey  string `mapstructure:"tls_key"`
 }
 
 // UIConfig holds admin UI feature toggles.
@@ -176,6 +188,11 @@ func Load() (*Config, error) {
 	v.SetDefault("monitoring.prometheus_url", "http://kube-prometheus-kube-prome-prometheus.monitoring.svc.cluster.local:9090")
 	v.SetDefault("monitoring.beyla_enabled", true)
 	v.SetDefault("ui.tooltips", true)
+	v.SetDefault("admin.port", 8080)
+	v.SetDefault("admin.host", "0.0.0.0")
+	v.SetDefault("admin.domain", "")
+	v.SetDefault("admin.tls", false)
+	v.SetDefault("admin.tls_port", 8443)
 
 	// Read config file (optional — not an error if missing)
 	if err := v.ReadInConfig(); err != nil {
@@ -193,6 +210,35 @@ func Load() (*Config, error) {
 	cfg.Kubernetes.Migrate()
 
 	return &cfg, nil
+}
+
+// AdminURL returns the base URL for the admin UI (e.g., "https://admin.cf-local.dev:8443").
+func (a *AdminConfig) AdminURL() string {
+	if a.TLS && a.Domain != "" {
+		port := a.TLSPort
+		if port == 0 {
+			port = 8443
+		}
+		if port == 443 {
+			return fmt.Sprintf("https://%s", a.Domain)
+		}
+		return fmt.Sprintf("https://%s:%d", a.Domain, port)
+	}
+	port := a.Port
+	if port == 0 {
+		port = 8080
+	}
+	if a.Domain != "" && !a.TLS {
+		// Domain set but no TLS — still show domain (HTTP)
+		if port == 80 {
+			return fmt.Sprintf("http://%s", a.Domain)
+		}
+		return fmt.Sprintf("http://%s:%d", a.Domain, port)
+	}
+	if port == 80 {
+		return "http://localhost"
+	}
+	return fmt.Sprintf("http://localhost:%d", port)
 }
 
 // ConfigDir returns the path to the user's mf config directory.


### PR DESCRIPTION
## Summary

Closes #45

- Add `AdminConfig` struct with `domain`, `tls`, `tls_port` fields and `AdminURL()` helper
- Auto-detect TLS certificates from `~/.mf/` when `admin.tls: true` — no more `--tls-cert/--tls-key` flags needed
- HTTP→HTTPS redirect server on port 8080 when TLS enabled
- Structured startup banner showing URL, cluster, domain, TLS status
- `mf setup tls` now registers `admin.cf-local.dev` in hosts file
- Sidebar shows domain name with green lock icon when TLS active
- `mf push` dashboard URL uses dynamic `cfg.Admin.AdminURL()` instead of hardcoded `localhost:8080`

## Files Changed (8)

| File | Change |
|------|--------|
| `pkg/config/config.go` | `AdminConfig` struct, viper defaults, `AdminURL()` |
| `cmd/mf/admin.go` | Auto-TLS, banner, HTTP redirect |
| `cmd/mf/setup.go` | Admin hosts entry, updated summary |
| `cmd/mf/push.go` | Dynamic dashboard URL |
| `pkg/admin/server.go` | `WithDomain` option |
| `pkg/admin/handlers.go` | `AdminDomain`/`TLSEnabled` in `PageData` |
| `partials/nav.html` | Domain + lock icon |
| `configs/mf.example.yaml` | Admin config docs |

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `mf setup tls` adds `admin.cf-local.dev` to hosts file
- [ ] `mf admin` with `admin.tls: true` auto-detects certs from `~/.mf/`
- [ ] Browser: `https://admin.cf-local.dev:8443` shows admin with valid cert
- [ ] Browser: `http://localhost:8080` redirects to HTTPS
- [ ] Sidebar shows domain name with green lock icon
- [ ] `mf push` shows `https://admin.cf-local.dev:8443/apps/...` as dashboard URL
- [ ] Without TLS config, falls back to `http://localhost:8080` (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)