### PR TITLE
feat(gateway): pluggable API gateway with nginx/kong/traefik support

### DIFF
--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -62,7 +62,8 @@ func newK8sClient() (*k8s.Client, error) {
 	if !ok {
 		return nil, fmt.Errorf("no active cluster configured")
 	}
-	return k8s.NewClient(cluster.Context, cluster.Namespace, cluster.Domain)
+	return k8s.NewClient(cluster.Context, cluster.Namespace, cluster.Domain,
+		k8s.WithIngressClass(cluster.IngressClass))
 }
 
 func versionCmd() *cobra.Command {

--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -96,7 +96,8 @@ func pushCmd() *cobra.Command {
 			}
 
 			// Connect to K8s early so we can read registry settings
-			k8sClient, err := k8s.NewClient(cluster.Context, cluster.Namespace, domain)
+			k8sClient, err := k8s.NewClient(cluster.Context, cluster.Namespace, domain,
+				k8s.WithIngressClass(cluster.IngressClass))
 			if err != nil {
 				return fmt.Errorf("connecting to kubernetes: %w", err)
 			}

--- a/cmd/mf/setup.go
+++ b/cmd/mf/setup.go
@@ -46,7 +46,8 @@ func setupKeycloakCmd() *cobra.Command {
 				return fmt.Errorf("no active cluster configured")
 			}
 
-			client, err := k8s.NewClient(clusterCfg.Context, clusterCfg.Namespace, clusterCfg.Domain)
+			client, err := k8s.NewClient(clusterCfg.Context, clusterCfg.Namespace, clusterCfg.Domain,
+				k8s.WithIngressClass(clusterCfg.IngressClass))
 			if err != nil {
 				return fmt.Errorf("connecting to cluster: %w", err)
 			}
@@ -224,7 +225,8 @@ Requires mkcert to be installed: https://github.com/FiloSottile/mkcert`,
 				return fmt.Errorf("no active cluster configured")
 			}
 
-			client, err := k8s.NewClient(clusterCfg.Context, clusterCfg.Namespace, clusterCfg.Domain)
+			client, err := k8s.NewClient(clusterCfg.Context, clusterCfg.Namespace, clusterCfg.Domain,
+				k8s.WithIngressClass(clusterCfg.IngressClass))
 			if err != nil {
 				return fmt.Errorf("connecting to cluster: %w", err)
 			}

--- a/configs/mf.example.yaml
+++ b/configs/mf.example.yaml
@@ -12,8 +12,9 @@ kubernetes:
       domain: "cf-local.dev"
       provider: "docker-desktop"
       enabled: true
-      tls: false  # Set to true after running `mf setup tls`
-    # Example: Add an EKS cluster
+      tls: false          # Set to true after running `mf setup tls`
+      ingress_class: ""   # API gateway: "nginx" (default), "kong", or "traefik"
+    # Example: Add an EKS cluster with Kong gateway
     # my-eks-cluster:
     #   name: "Production EKS"
     #   context: "arn:aws:eks:us-east-1:123456789:cluster/my-cluster"
@@ -22,6 +23,7 @@ kubernetes:
     #   provider: "eks"
     #   region: "us-east-1"
     #   enabled: true
+    #   ingress_class: "kong"  # Uses Kong-specific annotations
 
   # Legacy single-cluster format (auto-migrated):
   # context: "docker-desktop"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,14 +75,15 @@ type GitHubConfig struct {
 
 // ClusterConfig represents a registered Kubernetes cluster.
 type ClusterConfig struct {
-	Name      string `mapstructure:"name"      json:"name"`
-	Context   string `mapstructure:"context"   json:"context"`
-	Namespace string `mapstructure:"namespace" json:"namespace"`
-	Domain    string `mapstructure:"domain"    json:"domain"`
-	Provider  string `mapstructure:"provider"  json:"provider"`
-	Region    string `mapstructure:"region"    json:"region,omitempty"`
-	Enabled   bool   `mapstructure:"enabled"   json:"enabled"`
-	TLS       bool   `mapstructure:"tls"       json:"tls"`
+	Name         string `mapstructure:"name"          json:"name"`
+	Context      string `mapstructure:"context"       json:"context"`
+	Namespace    string `mapstructure:"namespace"     json:"namespace"`
+	Domain       string `mapstructure:"domain"        json:"domain"`
+	Provider     string `mapstructure:"provider"      json:"provider"`
+	Region       string `mapstructure:"region"        json:"region,omitempty"`
+	Enabled      bool   `mapstructure:"enabled"       json:"enabled"`
+	TLS          bool   `mapstructure:"tls"           json:"tls"`
+	IngressClass string `mapstructure:"ingress_class" json:"ingress_class,omitempty"`
 }
 
 type KubernetesConfig struct {

--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -527,6 +527,9 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 		return nil
 	}
 
+	// Determine protocol from TLS configuration on the Ingress
+	hasTLS := len(ingress.Spec.TLS) > 0
+
 	var routes []models.RouteDetail
 	for _, rule := range ingress.Spec.Rules {
 		host := rule.Host
@@ -538,6 +541,11 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 			domainPart = host[idx+1:]
 		}
 
+		protocol := "http"
+		if hasTLS {
+			protocol = "https"
+		}
+
 		if rule.HTTP != nil {
 			for _, path := range rule.HTTP.Paths {
 				routes = append(routes, models.RouteDetail{
@@ -545,7 +553,7 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 					Domain:   domainPart,
 					Path:     path.Path,
 					URL:      host + path.Path,
-					Protocol: "http",
+					Protocol: protocol,
 				})
 			}
 		}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -17,10 +17,21 @@ type Client struct {
 	Clientset kubernetes.Interface
 	Namespace string
 	Domain    string
+	Gateway   GatewayProvider
+}
+
+// ClientOption configures optional Client parameters.
+type ClientOption func(*Client)
+
+// WithIngressClass sets the gateway provider by ingress class name.
+func WithIngressClass(ingressClass string) ClientOption {
+	return func(c *Client) {
+		c.Gateway = NewGatewayProvider(ingressClass)
+	}
 }
 
 // NewClient creates a K8s client from kubeconfig.
-func NewClient(kubeContext, namespace, domain string) (*Client, error) {
+func NewClient(kubeContext, namespace, domain string, opts ...ClientOption) (*Client, error) {
 	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
 
 	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
@@ -47,11 +58,16 @@ func NewClient(kubeContext, namespace, domain string) (*Client, error) {
 		domain = "cf-local.dev"
 	}
 
-	return &Client{
+	c := &Client{
 		Clientset: clientset,
 		Namespace: namespace,
 		Domain:    domain,
-	}, nil
+		Gateway:   NewGatewayProvider("nginx"), // default
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c, nil
 }
 
 // EnsureNamespace creates the MicroFoundry namespace if it does not exist.

--- a/pkg/k8s/gateway.go
+++ b/pkg/k8s/gateway.go
@@ -1,0 +1,94 @@
+package k8s
+
+// GatewayProvider encapsulates ingress-controller-specific configuration.
+// Each provider returns the correct IngressClass name and annotation set
+// for its gateway type (nginx, kong, traefik, etc.).
+type GatewayProvider interface {
+	// IngressClass returns the Kubernetes IngressClass name (e.g., "nginx", "kong").
+	IngressClass() string
+
+	// AppAnnotations returns annotations for application ingresses.
+	AppAnnotations() map[string]string
+
+	// SystemAnnotations returns annotations for system-service ingresses (Keycloak, Grafana, etc.).
+	// serviceName identifies the service so providers can add service-specific annotations.
+	SystemAnnotations(serviceName string) map[string]string
+}
+
+// NewGatewayProvider creates the appropriate provider for the given ingress class.
+// Unrecognised values default to nginx for backward compatibility.
+func NewGatewayProvider(ingressClass string) GatewayProvider {
+	switch ingressClass {
+	case "kong":
+		return &kongProvider{}
+	case "traefik":
+		return &traefikProvider{}
+	default:
+		return &nginxProvider{}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// nginx (default)
+// ---------------------------------------------------------------------------
+
+type nginxProvider struct{}
+
+func (p *nginxProvider) IngressClass() string { return "nginx" }
+
+func (p *nginxProvider) AppAnnotations() map[string]string {
+	return map[string]string{
+		"nginx.ingress.kubernetes.io/rewrite-target": "/",
+	}
+}
+
+func (p *nginxProvider) SystemAnnotations(serviceName string) map[string]string {
+	ann := map[string]string{}
+	if serviceName == keycloakName {
+		ann["nginx.ingress.kubernetes.io/proxy-buffer-size"] = "128k"
+	}
+	return ann
+}
+
+// ---------------------------------------------------------------------------
+// Kong
+// ---------------------------------------------------------------------------
+
+type kongProvider struct{}
+
+func (p *kongProvider) IngressClass() string { return "kong" }
+
+func (p *kongProvider) AppAnnotations() map[string]string {
+	return map[string]string{
+		"konghq.com/strip-path": "true",
+	}
+}
+
+func (p *kongProvider) SystemAnnotations(serviceName string) map[string]string {
+	ann := map[string]string{}
+	if serviceName == keycloakName {
+		ann["konghq.com/proxy-buffering"] = "on"
+	}
+	return ann
+}
+
+// ---------------------------------------------------------------------------
+// Traefik
+// ---------------------------------------------------------------------------
+
+type traefikProvider struct{}
+
+func (p *traefikProvider) IngressClass() string { return "traefik" }
+
+func (p *traefikProvider) AppAnnotations() map[string]string {
+	return map[string]string{
+		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure,web",
+	}
+}
+
+func (p *traefikProvider) SystemAnnotations(serviceName string) map[string]string {
+	ann := map[string]string{
+		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure,web",
+	}
+	return ann
+}

--- a/pkg/k8s/ingress.go
+++ b/pkg/k8s/ingress.go
@@ -20,7 +20,7 @@ func (c *Client) CreateIngress(ctx context.Context, appName string, routes []mod
 	}
 
 	pathType := networkingv1.PathTypePrefix
-	ingressClassName := "nginx"
+	ingressClassName := c.Gateway.IngressClass()
 	var rules []networkingv1.IngressRule
 	var tlsHosts []string
 
@@ -54,12 +54,10 @@ func (c *Client) CreateIngress(ctx context.Context, appName string, routes []mod
 
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appName,
-			Namespace: c.Namespace,
-			Labels:    appLabels(appName),
-			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/rewrite-target": "/",
-			},
+			Name:        appName,
+			Namespace:   c.Namespace,
+			Labels:      appLabels(appName),
+			Annotations: c.Gateway.AppAnnotations(),
 		},
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: &ingressClassName,
@@ -94,14 +92,8 @@ func (c *Client) CreateIngress(ctx context.Context, appName string, routes []mod
 // The service is expected to exist in the client's namespace.
 func (c *Client) CreateSystemIngress(ctx context.Context, name, domain string, servicePort int32) error {
 	pathType := networkingv1.PathTypePrefix
-	ingressClassName := "nginx"
+	ingressClassName := c.Gateway.IngressClass()
 	host := fmt.Sprintf("%s.%s", name, domain)
-
-	annotations := map[string]string{}
-	// Keycloak needs larger buffer for JWT headers
-	if name == keycloakName {
-		annotations["nginx.ingress.kubernetes.io/proxy-buffer-size"] = "128k"
-	}
 
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -112,7 +104,7 @@ func (c *Client) CreateSystemIngress(ctx context.Context, name, domain string, s
 				"app.kubernetes.io/managed-by": labelManagedBy,
 				"microfoundry.io/system":       "true",
 			},
-			Annotations: annotations,
+			Annotations: c.Gateway.SystemAnnotations(name),
 		},
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: &ingressClassName,


### PR DESCRIPTION
## Summary

- Introduces `GatewayProvider` abstraction (`pkg/k8s/gateway.go`) with nginx, Kong, and Traefik implementations
- Makes ingress class configurable per-cluster via `ingress_class` in `ClusterConfig`
- Replaces all hardcoded `"nginx"` ingress class and annotation references with provider-driven values
- Fixes route protocol detection — `getAppRoutes` now checks TLS on the actual Ingress spec instead of hardcoding `"http"`

## Changes (1 new + 7 modified = 8 files)

| File | Change |
|------|--------|
| `pkg/k8s/gateway.go` | **NEW** — GatewayProvider interface + nginx/kong/traefik providers |
| `pkg/config/config.go` | Add `IngressClass` to `ClusterConfig` |
| `pkg/k8s/client.go` | Add `Gateway` field, `ClientOption` pattern, `WithIngressClass()` |
| `pkg/k8s/ingress.go` | Use `c.Gateway` for class + annotations in both CreateIngress and CreateSystemIngress |
| `pkg/k8s/app.go` | Route protocol detection from Ingress TLS spec |
| `cmd/mf/main.go` | Pass `WithIngressClass` to `newK8sClient()` |
| `cmd/mf/push.go` | Pass `WithIngressClass` to K8s client |
| `cmd/mf/setup.go` | Pass `WithIngressClass` to K8s client (2 call sites) |
| `configs/mf.example.yaml` | Document `ingress_class` with examples |

## Design

```
mf.yaml: ingress_class: "kong"
  → NewGatewayProvider("kong")
    → kongProvider.AppAnnotations() → {"konghq.com/strip-path": "true"}
    → kongProvider.IngressClass()   → "kong"
```

Backward compatible: empty/missing `ingress_class` defaults to nginx.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Default (no ingress_class set): creates nginx ingress with rewrite-target annotation
- [ ] `ingress_class: "kong"`: creates kong ingress with strip-path annotation
- [ ] `ingress_class: "traefik"`: creates traefik ingress with entrypoints annotation
- [ ] System ingress (keycloak): gets gateway-specific buffer/proxy annotations
- [ ] Route protocol shows "https" when TLS secret exists on ingress

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)