### PR TITLE
feat(protocol): WebSocket and gRPC protocol support

### DIFF
--- a/cmd/mf/push.go
+++ b/cmd/mf/push.go
@@ -189,15 +189,16 @@ func pushCmd() *cobra.Command {
 
 			// Display result
 			status, _ := k8sClient.GetAppStatus(ctx, app.Name)
-			scheme := "http"
-			if k8sClient.HasTLSSecret(ctx) {
-				scheme = "https"
-			}
+			hasTLS := k8sClient.HasTLSSecret(ctx)
 			fmt.Println()
 			fmt.Printf("name:       %s\n", app.Name)
 			fmt.Printf("state:      STARTED\n")
 			if len(routes) > 0 {
+				scheme := routes[0].Scheme(hasTLS)
 				fmt.Printf("routes:     %s://%s\n", scheme, routes[0].URL())
+				if routes[0].Protocol != "" {
+					fmt.Printf("protocol:   %s\n", routes[0].Protocol)
+				}
 			}
 			if status != nil {
 				fmt.Printf("instances:  %d/%d\n", status.RunningCount, status.TotalCount)

--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -175,6 +175,16 @@ func (c *Client) DeployApp(ctx context.Context, app models.App, routes []models.
 		},
 	}
 
+	// Enable session affinity for WebSocket routes (sticky sessions)
+	if models.HasSpecialProtocol(routes) == "websocket" {
+		svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
+		svc.Spec.SessionAffinityConfig = &corev1.SessionAffinityConfig{
+			ClientIP: &corev1.ClientIPConfig{
+				TimeoutSeconds: int32Ptr(10800), // 3 hours
+			},
+		}
+	}
+
 	existingSvc, err := c.Clientset.CoreV1().Services(c.Namespace).Get(ctx, app.Name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		_, err = c.Clientset.CoreV1().Services(c.Namespace).Create(ctx, svc, metav1.CreateOptions{})
@@ -527,13 +537,14 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 		return nil
 	}
 
-	// Determine protocol from TLS configuration on the Ingress
 	hasTLS := len(ingress.Spec.TLS) > 0
+
+	// Detect special protocol from ingress annotations
+	routeProtocol := detectProtocolFromAnnotations(ingress.Annotations)
 
 	var routes []models.RouteDetail
 	for _, rule := range ingress.Spec.Rules {
 		host := rule.Host
-		// Split host into subdomain.domain
 		hostPart := host
 		domainPart := ""
 		if idx := strings.Index(host, "."); idx > 0 {
@@ -541,10 +552,9 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 			domainPart = host[idx+1:]
 		}
 
-		protocol := "http"
-		if hasTLS {
-			protocol = "https"
-		}
+		// Use Route.Scheme() for protocol-aware URL scheme
+		r := models.Route{Protocol: routeProtocol}
+		scheme := r.Scheme(hasTLS)
 
 		if rule.HTTP != nil {
 			for _, path := range rule.HTTP.Paths {
@@ -552,14 +562,43 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 					Host:     hostPart,
 					Domain:   domainPart,
 					Path:     path.Path,
-					URL:      host + path.Path,
-					Protocol: protocol,
+					URL:      scheme + "://" + host + path.Path,
+					Protocol: scheme,
 				})
 			}
 		}
 	}
 
 	return routes
+}
+
+// detectProtocolFromAnnotations infers the route protocol from ingress annotations.
+func detectProtocolFromAnnotations(ann map[string]string) string {
+	if ann == nil {
+		return ""
+	}
+	// nginx: backend-protocol=GRPC
+	if v, ok := ann["nginx.ingress.kubernetes.io/backend-protocol"]; ok && strings.EqualFold(v, "GRPC") {
+		return "grpc"
+	}
+	// nginx: connection-proxy-header=upgrade (WebSocket)
+	if _, ok := ann["nginx.ingress.kubernetes.io/connection-proxy-header"]; ok {
+		return "websocket"
+	}
+	// kong: protocols contain ws or grpc
+	if v, ok := ann["konghq.com/protocols"]; ok {
+		if strings.Contains(v, "ws") {
+			return "websocket"
+		}
+		if strings.Contains(v, "grpc") {
+			return "grpc"
+		}
+	}
+	// traefik: serversscheme=h2c (gRPC)
+	if v, ok := ann["traefik.ingress.kubernetes.io/service.serversscheme"]; ok && v == "h2c" {
+		return "grpc"
+	}
+	return ""
 }
 
 // listAppSecrets returns metadata about K8s Secrets associated with an app.
@@ -598,3 +637,5 @@ func (c *Client) WaitForRollout(ctx context.Context, name string, timeout time.D
 	}
 	return fmt.Errorf("timeout waiting for %s rollout", name)
 }
+
+func int32Ptr(i int32) *int32 { return &i }

--- a/pkg/k8s/gateway.go
+++ b/pkg/k8s/gateway.go
@@ -13,6 +13,11 @@ type GatewayProvider interface {
 	// SystemAnnotations returns annotations for system-service ingresses (Keycloak, Grafana, etc.).
 	// serviceName identifies the service so providers can add service-specific annotations.
 	SystemAnnotations(serviceName string) map[string]string
+
+	// ProtocolAnnotations returns annotations required for a specific protocol.
+	// protocol is one of the models.Protocol* constants ("websocket", "grpc", "tcp").
+	// Returns nil for standard HTTP traffic.
+	ProtocolAnnotations(protocol string) map[string]string
 }
 
 // NewGatewayProvider creates the appropriate provider for the given ingress class.
@@ -50,6 +55,24 @@ func (p *nginxProvider) SystemAnnotations(serviceName string) map[string]string 
 	return ann
 }
 
+func (p *nginxProvider) ProtocolAnnotations(protocol string) map[string]string {
+	switch protocol {
+	case "websocket":
+		return map[string]string{
+			"nginx.ingress.kubernetes.io/proxy-read-timeout":  "3600",
+			"nginx.ingress.kubernetes.io/proxy-send-timeout":  "3600",
+			"nginx.ingress.kubernetes.io/proxy-http-version":  "1.1",
+			"nginx.ingress.kubernetes.io/connection-proxy-header": "upgrade",
+		}
+	case "grpc":
+		return map[string]string{
+			"nginx.ingress.kubernetes.io/backend-protocol": "GRPC",
+		}
+	default:
+		return nil
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Kong
 // ---------------------------------------------------------------------------
@@ -72,6 +95,22 @@ func (p *kongProvider) SystemAnnotations(serviceName string) map[string]string {
 	return ann
 }
 
+func (p *kongProvider) ProtocolAnnotations(protocol string) map[string]string {
+	switch protocol {
+	case "websocket":
+		return map[string]string{
+			"konghq.com/protocols":    "ws,wss",
+			"konghq.com/read-timeout": "3600000",
+		}
+	case "grpc":
+		return map[string]string{
+			"konghq.com/protocols": "grpc,grpcs",
+		}
+	default:
+		return nil
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Traefik
 // ---------------------------------------------------------------------------
@@ -91,4 +130,21 @@ func (p *traefikProvider) SystemAnnotations(serviceName string) map[string]strin
 		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure,web",
 	}
 	return ann
+}
+
+func (p *traefikProvider) ProtocolAnnotations(protocol string) map[string]string {
+	switch protocol {
+	case "websocket":
+		// Traefik supports WebSocket natively; just ensure correct entrypoints.
+		return map[string]string{
+			"traefik.ingress.kubernetes.io/router.entrypoints": "websecure,web",
+		}
+	case "grpc":
+		return map[string]string{
+			"traefik.ingress.kubernetes.io/router.entrypoints": "websecure",
+			"traefik.ingress.kubernetes.io/service.serversscheme": "h2c",
+		}
+	default:
+		return nil
+	}
 }

--- a/pkg/k8s/ingress.go
+++ b/pkg/k8s/ingress.go
@@ -8,6 +8,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"maps"
 )
 
 const tlsSecretName = "mf-tls-wildcard"
@@ -52,12 +53,20 @@ func (c *Client) CreateIngress(ctx context.Context, appName string, routes []mod
 		})
 	}
 
+	// Build annotations: base app annotations + protocol-specific annotations
+	annotations := c.Gateway.AppAnnotations()
+	if proto := models.HasSpecialProtocol(routes); proto != "" {
+		if pa := c.Gateway.ProtocolAnnotations(proto); pa != nil {
+			maps.Copy(annotations, pa)
+		}
+	}
+
 	ingress := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        appName,
 			Namespace:   c.Namespace,
 			Labels:      appLabels(appName),
-			Annotations: c.Gateway.AppAnnotations(),
+			Annotations: annotations,
 		},
 		Spec: networkingv1.IngressSpec{
 			IngressClassName: &ingressClassName,

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -37,7 +37,8 @@ type ManifestApp struct {
 }
 
 type ManifestRoute struct {
-	Route string `yaml:"route"`
+	Route    string `yaml:"route"`
+	Protocol string `yaml:"protocol,omitempty"` // "websocket", "grpc", or "" (HTTP default)
 }
 
 type ManifestDocker struct {
@@ -115,6 +116,7 @@ func (ma ManifestApp) ParseRoutes(domain string) []models.Route {
 		var routes []models.Route
 		for _, mr := range ma.Routes {
 			r := parseRouteString(mr.Route)
+			r.Protocol = normalizeProtocol(mr.Protocol)
 			routes = append(routes, r)
 		}
 		return routes
@@ -143,6 +145,20 @@ func parseRouteString(s string) models.Route {
 		r.Domain = "cf-local.dev"
 	}
 	return r
+}
+
+// normalizeProtocol maps user-friendly protocol names to internal constants.
+func normalizeProtocol(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "websocket", "ws", "wss":
+		return "websocket"
+	case "grpc", "grpcs":
+		return "grpc"
+	case "tcp":
+		return "tcp"
+	default:
+		return "" // HTTP default
+	}
 }
 
 // ParseMemoryMB converts CF-style memory string to megabytes.

--- a/pkg/models/route.go
+++ b/pkg/models/route.go
@@ -2,13 +2,22 @@ package models
 
 import "fmt"
 
+// Route protocol constants.
+const (
+	ProtocolHTTP      = ""          // default — plain HTTP/HTTPS
+	ProtocolWebSocket = "websocket" // WebSocket (ws/wss)
+	ProtocolGRPC      = "grpc"      // gRPC (HTTP/2)
+	ProtocolTCP       = "tcp"       // raw TCP (future — Gateway API)
+)
+
 // Route maps a hostname + domain + optional path to an application.
 type Route struct {
-	GUID    string `json:"guid"`
-	AppGUID string `json:"app_guid"`
-	Host    string `json:"host"`
-	Domain  string `json:"domain"`
-	Path    string `json:"path,omitempty"`
+	GUID     string `json:"guid"`
+	AppGUID  string `json:"app_guid"`
+	Host     string `json:"host"`
+	Domain   string `json:"domain"`
+	Path     string `json:"path,omitempty"`
+	Protocol string `json:"protocol,omitempty"` // "", "websocket", "grpc", "tcp"
 }
 
 // URL returns the full route URL.
@@ -18,4 +27,42 @@ func (r Route) URL() string {
 		url += r.Path
 	}
 	return url
+}
+
+// Scheme returns the URL scheme for this route given a TLS context.
+func (r Route) Scheme(hasTLS bool) string {
+	switch r.Protocol {
+	case ProtocolWebSocket:
+		if hasTLS {
+			return "wss"
+		}
+		return "ws"
+	case ProtocolGRPC:
+		return "grpcs" // gRPC always over TLS in production
+	default:
+		if hasTLS {
+			return "https"
+		}
+		return "http"
+	}
+}
+
+// IsWebSocket returns true if this route uses the WebSocket protocol.
+func (r Route) IsWebSocket() bool {
+	return r.Protocol == ProtocolWebSocket
+}
+
+// IsGRPC returns true if this route uses the gRPC protocol.
+func (r Route) IsGRPC() bool {
+	return r.Protocol == ProtocolGRPC
+}
+
+// HasSpecialProtocol returns true if the route uses a non-HTTP protocol.
+func HasSpecialProtocol(routes []Route) string {
+	for _, r := range routes {
+		if r.Protocol != "" {
+			return r.Protocol
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

- **Route Protocol Model**: Added `Protocol` field to `Route` with constants for WebSocket (`ws/wss`), gRPC, and TCP. `Route.Scheme(hasTLS)` returns protocol-aware URL schemes (`wss://`, `grpcs://`, etc.)
- **Manifest Support**: `ManifestRoute` now accepts a `protocol` field (`websocket`, `grpc`, `ws`, `wss`, `grpcs`). `normalizeProtocol()` maps user-friendly names to internal constants
- **Gateway Provider Annotations**: Added `ProtocolAnnotations(protocol)` to the `GatewayProvider` interface with per-provider implementations:
  - **nginx**: `proxy-read-timeout=3600`, `proxy-send-timeout=3600`, `connection-proxy-header=upgrade` (WS); `backend-protocol=GRPC` (gRPC)
  - **kong**: `protocols=ws,wss`, `read-timeout=3600000` (WS); `protocols=grpc,grpcs` (gRPC)
  - **traefik**: native WS support with entrypoints; `serversscheme=h2c` (gRPC)
- **Session Affinity**: WebSocket routes automatically get `SessionAffinity: ClientIP` on the K8s Service for sticky sessions
- **Ingress Merging**: `CreateIngress` detects special protocols from routes and merges protocol-specific annotations into the ingress resource
- **Protocol Detection**: `getAppRoutes` reads ingress annotations to detect protocol for display in admin UI
- **Push Display**: `mf push` now shows protocol-aware URLs (e.g., `wss://chat.cf-local.dev`) and protocol type

## Manifest Example

```yaml
applications:
  - name: chat-app
    memory: 256M
    routes:
      - route: chat.cf-local.dev
        protocol: websocket
```

## Test plan

- [ ] Verify `go build ./...` and `go vet ./...` pass clean
- [ ] Push a standard HTTP app — verify no protocol annotations, scheme is `http`/`https`
- [ ] Push a WebSocket app with `protocol: websocket` in manifest — verify ingress has timeout annotations, service has SessionAffinity, output shows `wss://`
- [ ] Push a gRPC app with `protocol: grpc` — verify `backend-protocol: GRPC` annotation, output shows `grpcs://`
- [ ] Verify backward compatibility — apps without protocol field work identically to before
- [ ] Test with kong/traefik ingress class — verify provider-specific annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
