### PR TITLE
feat(cluster): HTTP/3 gateway guidance in cluster settings

### DIFF
--- a/pkg/admin/cluster_handlers.go
+++ b/pkg/admin/cluster_handlers.go
@@ -89,13 +89,14 @@ func (s *Server) AddClusterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := config.ClusterConfig{
-		Name:      id,
-		Provider:  provider,
-		Context:   r.FormValue("context"),
-		Namespace: r.FormValue("namespace"),
-		Domain:    r.FormValue("domain"),
-		Region:    r.FormValue("region"),
-		Enabled:   true,
+		Name:         id,
+		Provider:     provider,
+		Context:      r.FormValue("context"),
+		Namespace:    r.FormValue("namespace"),
+		Domain:       r.FormValue("domain"),
+		Region:       r.FormValue("region"),
+		IngressClass: r.FormValue("ingress_class"),
+		Enabled:      true,
 	}
 
 	if err := s.clientManager.AddCluster(id, cfg); err != nil {

--- a/pkg/admin/static/templates/cluster_detail.html
+++ b/pkg/admin/static/templates/cluster_detail.html
@@ -79,6 +79,24 @@
                         <dd class="mt-1 text-sm text-gray-900">{{$d.Region}}</dd>
                     </div>
                     {{end}}
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">Gateway</dt>
+                        <dd class="mt-1 text-sm">
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{if eq $d.IngressClass "traefik"}}bg-green-100 text-green-800{{else if eq $d.IngressClass "kong"}}bg-blue-100 text-blue-800{{else}}bg-gray-100 text-gray-800{{end}}">
+                                {{$d.IngressClass}}
+                            </span>
+                        </dd>
+                    </div>
+                    <div class="col-span-2">
+                        <dt class="text-sm font-medium text-gray-500">Protocols</dt>
+                        <dd class="mt-1 flex flex-wrap gap-1">
+                            {{range $d.Capabilities}}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{if eq . "HTTP/3"}}bg-green-100 text-green-700 ring-1 ring-green-500{{else}}bg-gray-100 text-gray-700{{end}}">
+                                {{.}}
+                            </span>
+                            {{end}}
+                        </dd>
+                    </div>
                 </dl>
             </div>
         </div>
@@ -130,6 +148,36 @@
             </div>
         </div>
     </div>
+
+    {{if eq $d.IngressClass "nginx"}}
+    <!-- Nginx Retirement Warning -->
+    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4">
+        <div class="flex items-start">
+            <svg class="w-5 h-5 mr-3 mt-0.5 text-amber-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+            </svg>
+            <div class="text-sm text-amber-800">
+                <p class="font-medium">Community ingress-nginx is being retired (March 2026)</p>
+                <p class="mt-1">No new features, bug fixes, or security patches after the retirement date. Consider migrating to <strong>Traefik</strong> (with HTTP/3 support) or <strong>F5 NGINX Ingress Controller</strong> for continued support.</p>
+            </div>
+        </div>
+    </div>
+    {{end}}
+
+    {{if eq $d.IngressClass "traefik"}}
+    <!-- HTTP/3 Available Banner -->
+    <div class="bg-green-50 border border-green-200 rounded-lg p-4">
+        <div class="flex items-start">
+            <svg class="w-5 h-5 mr-3 mt-0.5 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+            </svg>
+            <div class="text-sm text-green-800">
+                <p class="font-medium">HTTP/3 (QUIC) available with Traefik v3+</p>
+                <p class="mt-1">Enable HTTP/3 on the <code class="bg-green-100 px-1 rounded">websecure</code> entrypoint with <code class="bg-green-100 px-1 rounded">http3: {}</code>. Requires TLS enabled and UDP port 443 exposed on the Traefik Service. All apps on this cluster will benefit automatically.</p>
+            </div>
+        </div>
+    </div>
+    {{end}}
 
     <!-- Nodes Table -->
     <div class="bg-white rounded-lg shadow">

--- a/pkg/admin/static/templates/clusters.html
+++ b/pkg/admin/static/templates/clusters.html
@@ -65,6 +65,21 @@
                            placeholder="us-east-1"
                            class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                 </div>
+                <div>
+                    <label for="cluster-ingress" class="block text-sm font-medium text-gray-700 mb-1">Ingress Class</label>
+                    <select id="cluster-ingress" name="ingress_class"
+                            onchange="updateGatewayInfo(this.value)"
+                            class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                            data-tooltip="API gateway / ingress controller type" data-tooltip-pos="top">
+                        <option value="">nginx (default)</option>
+                        <option value="kong">Kong</option>
+                        <option value="traefik">Traefik</option>
+                    </select>
+                </div>
+            </div>
+
+            <!-- Gateway Protocol Capability Banner -->
+            <div id="gateway-info" class="hidden mt-2 rounded-md p-4 text-sm">
             </div>
             <div class="flex items-center space-x-3 pt-2">
                 <button type="submit"
@@ -93,6 +108,7 @@
                     <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nodes</th>
                     <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Apps</th>
                     <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Namespace</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gateway</th>
                     <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                 </tr>
             </thead>
@@ -140,6 +156,16 @@
                     <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                         {{.Namespace}}
                     </td>
+                    <td class="px-4 py-4 whitespace-nowrap text-sm">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{if eq .IngressClass "traefik"}}bg-green-100 text-green-800{{else if eq .IngressClass "kong"}}bg-blue-100 text-blue-800{{else}}bg-gray-100 text-gray-800{{end}}">
+                            {{.IngressClass}}
+                        </span>
+                        {{if eq .IngressClass "nginx"}}
+                        <span class="ml-1 text-amber-500" title="community ingress-nginx retiring March 2026">
+                            <svg class="w-4 h-4 inline" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                        </span>
+                        {{end}}
+                    </td>
                     <td class="px-4 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                         {{if not .IsActive}}
                         <button hx-post="/clusters/{{.ID}}/activate"
@@ -163,7 +189,7 @@
                 </tr>
                 {{else}}
                 <tr>
-                    <td colspan="7" class="px-6 py-12 text-center text-gray-500">
+                    <td colspan="8" class="px-6 py-12 text-center text-gray-500">
                         <svg class="w-12 h-12 mx-auto mb-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2"/>
                         </svg>
@@ -176,4 +202,49 @@
         </table>
     </div>
 </div>
+
+<script>
+function updateGatewayInfo(value) {
+    var el = document.getElementById('gateway-info');
+    var info = {
+        '': {
+            cls: 'bg-amber-50 border border-amber-200 text-amber-800',
+            html: '<div class="flex items-start"><svg class="w-5 h-5 mr-2 mt-0.5 text-amber-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>' +
+                '<div><p class="font-medium">NGINX Ingress Controller</p>' +
+                '<p class="mt-1">Protocols: HTTP/1.1, HTTP/2, WebSocket, gRPC</p>' +
+                '<p class="mt-1 text-amber-600">Community ingress-nginx is being retired (March 2026). Consider migrating to Traefik or F5 NGINX Ingress Controller for long-term support.</p></div></div>'
+        },
+        'kong': {
+            cls: 'bg-blue-50 border border-blue-200 text-blue-800',
+            html: '<div class="flex items-start"><svg class="w-5 h-5 mr-2 mt-0.5 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg>' +
+                '<div><p class="font-medium">Kong Gateway</p>' +
+                '<p class="mt-1">Protocols: HTTP/1.1, HTTP/2, WebSocket, gRPC</p>' +
+                '<p class="mt-1 text-blue-600">HTTP/3 (QUIC) is not available with Kong.</p></div></div>'
+        },
+        'traefik': {
+            cls: 'bg-green-50 border border-green-200 text-green-800',
+            html: '<div class="flex items-start"><svg class="w-5 h-5 mr-2 mt-0.5 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>' +
+                '<div><p class="font-medium">Traefik Proxy</p>' +
+                '<p class="mt-1">Protocols: HTTP/1.1, HTTP/2, WebSocket, gRPC, <span class="font-semibold text-green-700">HTTP/3</span></p>' +
+                '<details class="mt-2"><summary class="cursor-pointer font-medium text-green-700 hover:text-green-900">HTTP/3 Enablement Guide</summary>' +
+                '<div class="mt-2 pl-4 border-l-2 border-green-300 text-green-700 space-y-2">' +
+                '<p><strong>1.</strong> Enable HTTP/3 on the websecure entrypoint:</p>' +
+                '<pre class="bg-green-100 rounded px-3 py-2 text-xs font-mono">entryPoints:\n  websecure:\n    address: ":443"\n    http3: {}</pre>' +
+                '<p><strong>2.</strong> Expose UDP port 443 on the Traefik Service:</p>' +
+                '<pre class="bg-green-100 rounded px-3 py-2 text-xs font-mono">ports:\n  - name: websecure-udp\n    port: 443\n    targetPort: 443\n    protocol: UDP</pre>' +
+                '<p><strong>3.</strong> Ensure TLS is enabled (HTTP/3 requires TLS 1.3)</p>' +
+                '<p class="text-xs">Clients auto-negotiate HTTP/3 via the Alt-Svc response header.</p>' +
+                '</div></details></div></div>'
+        }
+    };
+    var data = info[value];
+    if (data) {
+        el.className = 'mt-2 rounded-md p-4 text-sm ' + data.cls;
+        el.innerHTML = data.html;
+        el.classList.remove('hidden');
+    } else {
+        el.classList.add('hidden');
+    }
+}
+</script>
 {{end}}

--- a/pkg/k8s/gateway.go
+++ b/pkg/k8s/gateway.go
@@ -18,6 +18,9 @@ type GatewayProvider interface {
 	// protocol is one of the models.Protocol* constants ("websocket", "grpc", "tcp").
 	// Returns nil for standard HTTP traffic.
 	ProtocolAnnotations(protocol string) map[string]string
+
+	// Capabilities returns the list of supported protocols for this gateway.
+	Capabilities() []string
 }
 
 // NewGatewayProvider creates the appropriate provider for the given ingress class.
@@ -53,6 +56,10 @@ func (p *nginxProvider) SystemAnnotations(serviceName string) map[string]string 
 		ann["nginx.ingress.kubernetes.io/proxy-buffer-size"] = "128k"
 	}
 	return ann
+}
+
+func (p *nginxProvider) Capabilities() []string {
+	return []string{"HTTP/1.1", "HTTP/2", "WebSocket", "gRPC"}
 }
 
 func (p *nginxProvider) ProtocolAnnotations(protocol string) map[string]string {
@@ -95,6 +102,10 @@ func (p *kongProvider) SystemAnnotations(serviceName string) map[string]string {
 	return ann
 }
 
+func (p *kongProvider) Capabilities() []string {
+	return []string{"HTTP/1.1", "HTTP/2", "WebSocket", "gRPC"}
+}
+
 func (p *kongProvider) ProtocolAnnotations(protocol string) map[string]string {
 	switch protocol {
 	case "websocket":
@@ -130,6 +141,10 @@ func (p *traefikProvider) SystemAnnotations(serviceName string) map[string]strin
 		"traefik.ingress.kubernetes.io/router.entrypoints": "websecure,web",
 	}
 	return ann
+}
+
+func (p *traefikProvider) Capabilities() []string {
+	return []string{"HTTP/1.1", "HTTP/2", "WebSocket", "gRPC", "HTTP/3"}
 }
 
 func (p *traefikProvider) ProtocolAnnotations(protocol string) map[string]string {

--- a/pkg/k8s/manager.go
+++ b/pkg/k8s/manager.go
@@ -49,7 +49,8 @@ func (cm *ClientManager) GetClient(clusterID string) (*Client, error) {
 		return nil, fmt.Errorf("cluster %q not found", clusterID)
 	}
 
-	client, err := NewClient(cfg.Context, cfg.Namespace, cfg.Domain)
+	client, err := NewClient(cfg.Context, cfg.Namespace, cfg.Domain,
+		WithIngressClass(cfg.IngressClass))
 	if err != nil {
 		return nil, fmt.Errorf("connecting to cluster %q: %w", clusterID, err)
 	}
@@ -97,17 +98,20 @@ func (cm *ClientManager) ListClusters(ctx context.Context) []models.ClusterInfo 
 
 	var infos []models.ClusterInfo
 	for id, cfg := range configs {
+		gw := NewGatewayProvider(cfg.IngressClass)
 		info := models.ClusterInfo{
-			ID:        id,
-			Name:      cfg.Name,
-			Provider:  cfg.Provider,
-			Region:    cfg.Region,
-			Context:   cfg.Context,
-			Namespace: cfg.Namespace,
-			Domain:    cfg.Domain,
-			Enabled:   cfg.Enabled,
-			IsActive:  id == active,
-			Status:    "disconnected",
+			ID:           id,
+			Name:         cfg.Name,
+			Provider:     cfg.Provider,
+			Region:       cfg.Region,
+			Context:      cfg.Context,
+			Namespace:    cfg.Namespace,
+			Domain:       cfg.Domain,
+			Enabled:      cfg.Enabled,
+			IsActive:     id == active,
+			Status:       "disconnected",
+			IngressClass: gw.IngressClass(),
+			Capabilities: gw.Capabilities(),
 		}
 
 		// GetClient has its own proper locking for lazy initialization
@@ -148,18 +152,21 @@ func (cm *ClientManager) GetClusterDetail(ctx context.Context, clusterID string)
 		return nil, err
 	}
 
+	gw := NewGatewayProvider(cfg.IngressClass)
 	detail := &models.ClusterDetail{
 		ClusterInfo: models.ClusterInfo{
-			ID:        clusterID,
-			Name:      cfg.Name,
-			Provider:  cfg.Provider,
-			Region:    cfg.Region,
-			Context:   cfg.Context,
-			Namespace: cfg.Namespace,
-			Domain:    cfg.Domain,
-			Enabled:   cfg.Enabled,
-			IsActive:  isActive,
-			Status:    "connected",
+			ID:           clusterID,
+			Name:         cfg.Name,
+			Provider:     cfg.Provider,
+			Region:       cfg.Region,
+			Context:      cfg.Context,
+			Namespace:    cfg.Namespace,
+			Domain:       cfg.Domain,
+			Enabled:      cfg.Enabled,
+			IsActive:     isActive,
+			Status:       "connected",
+			IngressClass: gw.IngressClass(),
+			Capabilities: gw.Capabilities(),
 		},
 	}
 

--- a/pkg/models/cluster.go
+++ b/pkg/models/cluster.go
@@ -10,20 +10,22 @@ const (
 
 // ClusterInfo is the runtime view of a registered cluster.
 type ClusterInfo struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Provider  string `json:"provider"`
-	Region    string `json:"region,omitempty"`
-	Context   string `json:"context"`
-	Namespace string `json:"namespace"`
-	Domain    string `json:"domain"`
-	Status    string `json:"status"` // connected, disconnected, error
-	Enabled   bool   `json:"enabled"`
-	IsActive  bool   `json:"is_active"`
-	NodeCount int    `json:"node_count"`
-	AppCount  int    `json:"app_count"`
-	Version   string `json:"version,omitempty"`
-	StatusMsg string `json:"status_message,omitempty"`
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Provider     string   `json:"provider"`
+	Region       string   `json:"region,omitempty"`
+	Context      string   `json:"context"`
+	Namespace    string   `json:"namespace"`
+	Domain       string   `json:"domain"`
+	Status       string   `json:"status"` // connected, disconnected, error
+	Enabled      bool     `json:"enabled"`
+	IsActive     bool     `json:"is_active"`
+	NodeCount    int      `json:"node_count"`
+	AppCount     int      `json:"app_count"`
+	Version      string   `json:"version,omitempty"`
+	StatusMsg    string   `json:"status_message,omitempty"`
+	IngressClass string   `json:"ingress_class,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // ClusterDetail extends ClusterInfo with node and resource data.


### PR DESCRIPTION
## Summary

- **Ingress Class selector** in Add Cluster form — dropdown for nginx (default), Kong, Traefik
- **Reactive protocol capability banners** — JavaScript-driven info panels show supported protocols per gateway:
  - **nginx**: HTTP/1.1, HTTP/2, WebSocket, gRPC + amber retirement warning (March 2026)
  - **Kong**: HTTP/1.1, HTTP/2, WebSocket, gRPC + note that HTTP/3 is unavailable
  - **Traefik**: HTTP/1.1, HTTP/2, WebSocket, gRPC, HTTP/3 + collapsible enablement guide
- **`GatewayProvider.Capabilities()`** — new interface method returning `[]string` of supported protocols per provider
- **ClientManager fix** — now passes `WithIngressClass(cfg.IngressClass)` when creating K8s clients (was missing — only `push.go` did this)
- **Cluster list table** — new "Gateway" column showing ingress class badge + nginx retirement warning icon
- **Cluster detail page** — shows Gateway + Protocols in info card, with contextual banners:
  - Nginx clusters: amber retirement warning banner
  - Traefik clusters: green HTTP/3 availability banner with enablement steps
- **ClusterInfo model** — added `IngressClass` and `Capabilities` fields

## Test plan

- [ ] Verify `go build ./...` and `go vet ./...` pass clean
- [ ] Open Add Cluster form → verify Ingress Class dropdown present
- [ ] Select each gateway → verify correct protocol banner appears
- [ ] Select Traefik → verify HTTP/3 enablement guide is collapsible and accurate
- [ ] Select nginx → verify retirement warning appears
- [ ] Register a cluster with `ingress_class=traefik` → verify saved and displayed
- [ ] View cluster detail → verify Gateway badge and Protocol badges visible
- [ ] View nginx cluster detail → verify retirement warning banner shown
- [ ] View traefik cluster detail → verify HTTP/3 available banner shown
- [ ] Verify existing clusters default to nginx when IngressClass is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
