### PR TITLE
fix(monitoring): move metrics to Settings nav, add connectivity checks

### DIFF
--- a/pkg/admin/monitoring_handlers.go
+++ b/pkg/admin/monitoring_handlers.go
@@ -1,7 +1,9 @@
 package admin
 
 import (
+	"context"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -11,9 +13,20 @@ const (
 	dashboardClusterUID  = "mf-cluster"
 )
 
+// ComponentStatus represents the health of a monitoring component.
+type ComponentStatus struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	Connected bool   `json:"connected"`
+	Error     string `json:"error,omitempty"`
+}
+
 // MonitoringHandler renders the Metrics & Alerts page with embedded Grafana dashboards.
 func (s *Server) MonitoringHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	// Run health checks in parallel
+	components := s.checkMonitoringHealth(ctx)
 
 	// Build embeddable Grafana iframe URLs
 	overviewURL := s.grafana.DashboardURL(dashboardOverviewUID, nil)
@@ -31,6 +44,14 @@ func (s *Server) MonitoringHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	allConnected := true
+	for _, c := range components {
+		if !c.Connected {
+			allConnected = false
+			break
+		}
+	}
+
 	data := s.pageData("Metrics & Alerts", "monitoring")
 	data.Content = map[string]any{
 		"OverviewIframeURL": overviewURL,
@@ -40,8 +61,48 @@ func (s *Server) MonitoringHandler(w http.ResponseWriter, r *http.Request) {
 		"GrafanaBaseURL":    s.grafana.BaseURL,
 		"Alerts":            alerts,
 		"FiringCount":       firingCount,
+		"Components":        components,
+		"AllConnected":      allConnected,
 	}
 	s.templates.Render(w, "monitoring.html", data)
+}
+
+// checkMonitoringHealth runs health checks on all monitoring components in parallel.
+func (s *Server) checkMonitoringHealth(ctx context.Context) []ComponentStatus {
+	type result struct {
+		idx    int
+		status ComponentStatus
+	}
+
+	checks := []struct {
+		name string
+		url  string
+		fn   func(ctx context.Context) error
+	}{
+		{"Grafana", s.grafana.BaseURL, s.grafana.HealthCheck},
+		{"Prometheus", s.prometheus.BaseURL, s.prometheus.HealthCheck},
+		{"Alertmanager", s.alertmanager.BaseURL, s.alertmanager.HealthCheck},
+		{"Loki", s.loki.BaseURL, s.loki.HealthCheck},
+	}
+
+	results := make([]ComponentStatus, len(checks))
+	var wg sync.WaitGroup
+
+	for i, check := range checks {
+		wg.Add(1)
+		go func(idx int, name, url string, fn func(context.Context) error) {
+			defer wg.Done()
+			cs := ComponentStatus{Name: name, URL: url, Connected: true}
+			if err := fn(ctx); err != nil {
+				cs.Connected = false
+				cs.Error = err.Error()
+			}
+			results[idx] = cs
+		}(i, check.name, check.url, check.fn)
+	}
+
+	wg.Wait()
+	return results
 }
 
 // AlertsListHandler returns the alerts partial for HTMX polling.
@@ -86,6 +147,23 @@ func (s *Server) LogHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		"Entries":  entries,
 		"AppName":  name,
 		"Duration": duration,
+	})
+}
+
+// APIMonitoringHealthHandler returns the connectivity status of all monitoring components.
+func (s *Server) APIMonitoringHealthHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	components := s.checkMonitoringHealth(ctx)
+	allOK := true
+	for _, c := range components {
+		if !c.Connected {
+			allOK = false
+			break
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"healthy":    allOK,
+		"components": components,
 	})
 }
 

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -263,6 +263,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/topologies/{type}/{plan}", s.APITopologyDetailHandler)
 	s.mux.HandleFunc("PUT /api/topologies/{type}/{plan}", s.APISaveTopologyHandler)
 	s.mux.HandleFunc("GET /api/monitoring/alerts", s.APIAlertsHandler)
+	s.mux.HandleFunc("GET /api/monitoring/health", s.APIMonitoringHealthHandler)
 
 	// Beyla RED metrics API routes
 	s.mux.HandleFunc("GET /api/apps/{name}/red-metrics", s.APIAppREDMetricsHandler)

--- a/pkg/admin/static/templates/monitoring.html
+++ b/pkg/admin/static/templates/monitoring.html
@@ -9,7 +9,7 @@
     <div class="flex items-center justify-between">
         <div>
             <h2 class="text-2xl font-bold text-gray-900">Metrics & Alerts</h2>
-            <p class="text-sm text-gray-500 mt-1">Application metrics, cluster resources, and alert management</p>
+            <p class="text-sm text-gray-500 mt-1">Cluster monitoring, application metrics, and alert management</p>
         </div>
         <a href="{{index $c "GrafanaBaseURL"}}" target="_blank"
            class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-lg hover:bg-orange-700"
@@ -19,6 +19,60 @@
             </svg>
             Open Grafana
         </a>
+    </div>
+
+    <!-- Monitoring Stack Connectivity -->
+    <div class="bg-white rounded-lg shadow">
+        <div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+            <div class="flex items-center space-x-3">
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wider">Monitoring Stack</h3>
+                {{if index $c "AllConnected"}}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                    All connected
+                </span>
+                {{else}}
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                    Connectivity issues
+                </span>
+                {{end}}
+            </div>
+            <span class="text-xs text-gray-400">Checked on page load</span>
+        </div>
+        <div class="p-4">
+            <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                {{range index $c "Components"}}
+                <div class="flex items-center space-x-3 p-3 rounded-lg {{if .Connected}}bg-green-50 border border-green-200{{else}}bg-red-50 border border-red-200{{end}}">
+                    {{if .Connected}}
+                    <svg class="w-5 h-5 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                    </svg>
+                    {{else}}
+                    <svg class="w-5 h-5 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                    </svg>
+                    {{end}}
+                    <div class="min-w-0">
+                        <p class="text-sm font-medium {{if .Connected}}text-green-800{{else}}text-red-800{{end}}">{{.Name}}</p>
+                        <p class="text-xs {{if .Connected}}text-green-600{{else}}text-red-600{{end}} truncate" title="{{.URL}}">
+                            {{if .Connected}}Connected{{else}}{{.Error}}{{end}}
+                        </p>
+                    </div>
+                </div>
+                {{end}}
+            </div>
+
+            {{if not (index $c "AllConnected")}}
+            <div class="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p class="text-sm text-amber-800">
+                    <strong>Setup required:</strong> Deploy the monitoring stack with
+                    <code class="bg-amber-100 px-1 rounded">deploy/monitoring/install.sh</code>
+                    to enable metrics, dashboards, and alerts. See the
+                    <a href="/config" class="text-amber-900 underline font-medium">Platform Config</a>
+                    page for monitoring URLs.
+                </p>
+            </div>
+            {{end}}
+        </div>
     </div>
 
     <!-- Active Alerts -->

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -51,14 +51,6 @@
             </svg>
             Secrets
         </a>
-        <a href="/monitoring"
-           data-tooltip="Application metrics, cluster resources, and alert management" data-tooltip-pos="right"
-           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "monitoring"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
-            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-            </svg>
-            Metrics & Alerts
-        </a>
 
         <!-- Settings -->
         <div class="px-3 pt-5 pb-1">

--- a/pkg/monitoring/alertmanager.go
+++ b/pkg/monitoring/alertmanager.go
@@ -77,6 +77,30 @@ type amAlert struct {
 	} `json:"status"`
 }
 
+// HealthCheck verifies that Alertmanager is reachable.
+func (a *AlertmanagerClient) HealthCheck(ctx context.Context) error {
+	u, err := url.Parse(a.BaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid alertmanager URL: %w", err)
+	}
+	u.Path = "/-/healthy"
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("alertmanager unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("alertmanager returned %s", resp.Status)
+	}
+	return nil
+}
+
 func convertAlerts(amAlerts []amAlert) []Alert {
 	alerts := make([]Alert, 0, len(amAlerts))
 	for _, a := range amAlerts {

--- a/pkg/monitoring/grafana.go
+++ b/pkg/monitoring/grafana.go
@@ -1,13 +1,40 @@
 package monitoring
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"net/url"
+	"time"
 )
 
 // GrafanaConfig holds the connection info for embedded Grafana.
 type GrafanaConfig struct {
 	BaseURL string
+}
+
+// HealthCheck verifies that Grafana is reachable.
+func (g *GrafanaConfig) HealthCheck(ctx context.Context) error {
+	u, err := url.Parse(g.BaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid grafana URL: %w", err)
+	}
+	u.Path = "/api/health"
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("grafana unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("grafana returned %s", resp.Status)
+	}
+	return nil
 }
 
 // DashboardURL returns an embeddable Grafana solo dashboard URL.

--- a/pkg/monitoring/loki.go
+++ b/pkg/monitoring/loki.go
@@ -76,6 +76,30 @@ func (l *LokiClient) queryRange(ctx context.Context, query string, start, end ti
 	return parseLokiStreams(lokiResp), nil
 }
 
+// HealthCheck verifies that Loki is reachable.
+func (l *LokiClient) HealthCheck(ctx context.Context) error {
+	u, err := url.Parse(l.BaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid loki URL: %w", err)
+	}
+	u.Path = "/ready"
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("loki unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("loki returned %s", resp.Status)
+	}
+	return nil
+}
+
 type lokiQueryResponse struct {
 	Status string `json:"status"`
 	Data   struct {

--- a/pkg/monitoring/prometheus.go
+++ b/pkg/monitoring/prometheus.go
@@ -150,6 +150,30 @@ func (p *PrometheusClient) instantQuery(ctx context.Context, query string) (floa
 	return strconv.ParseFloat(valStr, 64)
 }
 
+// HealthCheck verifies that Prometheus is reachable.
+func (p *PrometheusClient) HealthCheck(ctx context.Context) error {
+	u, err := url.Parse(p.BaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid prometheus URL: %w", err)
+	}
+	u.Path = "/-/healthy"
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("prometheus unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("prometheus returned %s", resp.Status)
+	}
+	return nil
+}
+
 // NewPrometheusClient creates a Prometheus query client.
 func NewPrometheusClient(baseURL string) *PrometheusClient {
 	return &PrometheusClient{


### PR DESCRIPTION
## Summary
- Removed duplicate "Metrics & Alerts" from the Operations nav section (kept under Settings only)
- Added `HealthCheck()` methods to Grafana, Prometheus, Alertmanager, and Loki clients
- Added connectivity status banner to the monitoring page with per-component health indicators
- Added `GET /api/monitoring/health` JSON endpoint for programmatic health checks
- Added setup guidance when monitoring stack components are unreachable

## Problem
1. "Metrics & Alerts" appeared twice in the sidebar (Operations and Settings). Per user feedback, cluster-level monitoring should be an admin-only concern under Settings.
2. When the monitoring stack isn't deployed, the page showed blank Grafana iframes with no feedback — admins had no way to diagnose connectivity issues.

## Changes
| File | Change |
|------|--------|
| `pkg/admin/static/templates/partials/nav.html` | Remove duplicate Metrics & Alerts from Operations |
| `pkg/monitoring/grafana.go` | Add `HealthCheck()` → `GET /api/health` |
| `pkg/monitoring/prometheus.go` | Add `HealthCheck()` → `GET /-/healthy` |
| `pkg/monitoring/alertmanager.go` | Add `HealthCheck()` → `GET /-/healthy` |
| `pkg/monitoring/loki.go` | Add `HealthCheck()` → `GET /ready` |
| `pkg/admin/monitoring_handlers.go` | Parallel health checks, `ComponentStatus` struct, `APIMonitoringHealthHandler` |
| `pkg/admin/static/templates/monitoring.html` | Connectivity banner with green/red status cards |
| `pkg/admin/server.go` | Register `GET /api/monitoring/health` route |

## Test plan
- [ ] Verify "Metrics & Alerts" appears only under Settings nav section
- [ ] Open monitoring page with deployed stack → all 4 components show green "Connected"
- [ ] Open monitoring page without stack → components show red with error messages
- [ ] Verify setup guidance banner appears when components are unreachable
- [ ] Call `GET /api/monitoring/health` → returns JSON with component statuses
- [ ] App detail → Metrics and Performance tabs still work (unchanged)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)