### PR TITLE
feat(cli): add user and organization management commands

### DIFF
--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -43,6 +43,8 @@ func main() {
 		secretDetailCmd(),
 		createSecretCmd(),
 		deleteSecretCmd(),
+		usersCmd(),
+		orgsCmd(),
 		setupRoot,
 	)
 

--- a/cmd/mf/orgs.go
+++ b/cmd/mf/orgs.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/auth"
+)
+
+// newOrgStore creates an OrgStore from the active K8s cluster.
+func newOrgStore() (*auth.OrgStore, error) {
+	k8sClient, err := newK8sClient()
+	if err != nil {
+		return nil, err
+	}
+	return auth.NewOrgStore(k8sClient.Clientset, k8sClient.Namespace), nil
+}
+
+func orgsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "orgs",
+		Short: "Manage organizations",
+		Long:  "List, create, delete, and manage organizations and their members.",
+	}
+
+	cmd.AddCommand(
+		orgsListCmd(),
+		orgsCreateCmd(),
+		orgsDeleteCmd(),
+		orgsMembersCmd(),
+		orgsAddMemberCmd(),
+		orgsRemoveMemberCmd(),
+		orgsSetRoleCmd(),
+	)
+
+	return cmd
+}
+
+func orgsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all organizations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			orgs, err := store.List(ctx)
+			if err != nil {
+				return fmt.Errorf("listing organizations: %w", err)
+			}
+
+			if len(orgs) == 0 {
+				fmt.Println("No organizations found.")
+				fmt.Println("Use 'mf orgs create --name <name> --owner <email>' to create one.")
+				return nil
+			}
+
+			fmt.Printf("%-20s %-30s %-30s %-20s %-20s\n", "ID", "NAME", "OWNER", "NAMESPACE", "CREATED")
+			for _, o := range orgs {
+				created := o.CreatedAt
+				if len(created) > 16 {
+					created = created[:16]
+				}
+				fmt.Printf("%-20s %-30s %-30s %-20s %-20s\n",
+					o.ID, o.Name, o.OwnerEmail, o.Namespace, created)
+			}
+			return nil
+		},
+	}
+}
+
+func orgsCreateCmd() *cobra.Command {
+	var name, owner string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" || owner == "" {
+				return fmt.Errorf("--name and --owner are required")
+			}
+
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			org, err := store.Create(ctx, name, owner)
+			if err != nil {
+				return fmt.Errorf("creating organization: %w", err)
+			}
+
+			fmt.Printf("Organization created:\n")
+			fmt.Printf("  ID:        %s\n", org.ID)
+			fmt.Printf("  Name:      %s\n", org.Name)
+			fmt.Printf("  Owner:     %s\n", org.OwnerEmail)
+			fmt.Printf("  Namespace: %s\n", org.Namespace)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Organization name (required)")
+	cmd.Flags().StringVar(&owner, "owner", "", "Owner email address (required)")
+	return cmd
+}
+
+func orgsDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [org-id]",
+		Short: "Delete an organization",
+		Long:  "Delete an organization, its member list, and its Kubernetes namespace.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := store.Delete(ctx, args[0]); err != nil {
+				return fmt.Errorf("deleting organization: %w", err)
+			}
+
+			fmt.Printf("Organization %s deleted.\n", args[0])
+			return nil
+		},
+	}
+}
+
+func orgsMembersCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "members [org-id]",
+		Short: "List members of an organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			members, err := store.ListMembers(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("listing members: %w", err)
+			}
+
+			if len(members) == 0 {
+				fmt.Printf("Organization %s has no members.\n", args[0])
+				return nil
+			}
+
+			fmt.Printf("Members of organization %s:\n\n", args[0])
+			fmt.Printf("%-30s %-30s %-10s %-20s\n", "EMAIL", "NAME", "ROLE", "JOINED")
+			for _, m := range members {
+				joined := m.JoinedAt
+				if len(joined) > 16 {
+					joined = joined[:16]
+				}
+				fmt.Printf("%-30s %-30s %-10s %-20s\n",
+					m.Email, m.Name, m.Role, joined)
+			}
+			return nil
+		},
+	}
+}
+
+func orgsAddMemberCmd() *cobra.Command {
+	var email, name, role string
+
+	cmd := &cobra.Command{
+		Use:   "add-member [org-id]",
+		Short: "Add a member to an organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if email == "" {
+				return fmt.Errorf("--email is required")
+			}
+			if name == "" {
+				name = email
+			}
+			if role == "" {
+				role = "member"
+			}
+
+			validRoles := map[string]bool{"admin": true, "member": true, "viewer": true}
+			if !validRoles[role] {
+				return fmt.Errorf("invalid role %q (must be admin, member, or viewer)", role)
+			}
+
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := store.AddMember(ctx, args[0], email, name, role); err != nil {
+				return fmt.Errorf("adding member: %w", err)
+			}
+
+			fmt.Printf("Member %s added to organization %s with role %s.\n", email, args[0], role)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Member email address (required)")
+	cmd.Flags().StringVar(&name, "name", "", "Member display name (defaults to email)")
+	cmd.Flags().StringVar(&role, "role", "member", "Member role: admin, member, or viewer")
+	return cmd
+}
+
+func orgsRemoveMemberCmd() *cobra.Command {
+	var email string
+
+	cmd := &cobra.Command{
+		Use:   "remove-member [org-id]",
+		Short: "Remove a member from an organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if email == "" {
+				return fmt.Errorf("--email is required")
+			}
+
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := store.RemoveMember(ctx, args[0], email); err != nil {
+				return fmt.Errorf("removing member: %w", err)
+			}
+
+			fmt.Printf("Member %s removed from organization %s.\n", email, args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Member email address (required)")
+	return cmd
+}
+
+func orgsSetRoleCmd() *cobra.Command {
+	var email, role string
+
+	cmd := &cobra.Command{
+		Use:   "set-role [org-id]",
+		Short: "Change a member's role in an organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if email == "" || role == "" {
+				return fmt.Errorf("--email and --role are required")
+			}
+
+			validRoles := map[string]bool{"admin": true, "member": true, "viewer": true}
+			if !validRoles[role] {
+				return fmt.Errorf("invalid role %q (must be admin, member, or viewer)", role)
+			}
+
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := store.SetMemberRole(ctx, args[0], email, role); err != nil {
+				return fmt.Errorf("setting role: %w", err)
+			}
+
+			fmt.Printf("Member %s role set to %s in organization %s.\n", email, role, args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Member email address (required)")
+	cmd.Flags().StringVar(&role, "role", "", "New role: admin, member, or viewer (required)")
+	return cmd
+}

--- a/cmd/mf/users.go
+++ b/cmd/mf/users.go
@@ -1,0 +1,377 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/auth"
+	"github.com/younjinjeong/microfoundry/pkg/config"
+)
+
+// newKeycloakAdmin creates a KeycloakAdminClient from mf.yaml config.
+func newKeycloakAdmin() (*auth.KeycloakAdminClient, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+	if cfg.Auth.AdminBaseURL == "" {
+		return nil, fmt.Errorf("auth.admin_base_url is not configured in mf.yaml")
+	}
+	return auth.NewKeycloakAdminClient(
+		cfg.Auth.AdminBaseURL,
+		cfg.Auth.Realm,
+		cfg.Auth.AdminClientID,
+		cfg.Auth.AdminClientSecret,
+	), nil
+}
+
+func usersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Manage Keycloak users",
+		Long:  "List, create, delete, and manage users in the Keycloak identity provider.",
+	}
+
+	cmd.AddCommand(
+		usersListCmd(),
+		usersCreateCmd(),
+		usersDeleteCmd(),
+		usersToggleCmd(),
+		usersResetPasswordCmd(),
+		usersRolesCmd(),
+		usersAssignRoleCmd(),
+		usersRemoveRoleCmd(),
+		usersRealmRolesCmd(),
+	)
+
+	return cmd
+}
+
+func usersListCmd() *cobra.Command {
+	var search string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all users",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			users, total, err := kc.ListUsers(ctx, search, 0, 100)
+			if err != nil {
+				return fmt.Errorf("listing users: %w", err)
+			}
+
+			if len(users) == 0 {
+				fmt.Println("No users found.")
+				return nil
+			}
+
+			fmt.Printf("%-36s %-20s %-30s %-8s %-20s\n", "ID", "USERNAME", "EMAIL", "ENABLED", "CREATED")
+			for _, u := range users {
+				created := ""
+				if u.CreatedTimestamp > 0 {
+					created = time.Unix(u.CreatedTimestamp/1000, 0).Format("2006-01-02 15:04")
+				}
+				enabled := "yes"
+				if !u.Enabled {
+					enabled = "no"
+				}
+				fmt.Printf("%-36s %-20s %-30s %-8s %-20s\n",
+					u.ID, u.Username, u.Email, enabled, created)
+			}
+			fmt.Printf("\nTotal: %d users\n", total)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&search, "search", "", "Filter users by username or email")
+	return cmd
+}
+
+func usersCreateCmd() *cobra.Command {
+	var username, email, firstName, lastName, password string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new user",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if username == "" || email == "" {
+				return fmt.Errorf("--username and --email are required")
+			}
+
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			user := &auth.KeycloakUser{
+				Username:      username,
+				Email:         email,
+				FirstName:     firstName,
+				LastName:      lastName,
+				Enabled:       true,
+				EmailVerified: true,
+			}
+
+			userID, err := kc.CreateUser(ctx, user)
+			if err != nil {
+				return fmt.Errorf("creating user: %w", err)
+			}
+
+			if password != "" {
+				if err := kc.ResetPassword(ctx, userID, password, false); err != nil {
+					return fmt.Errorf("user created (ID: %s) but password set failed: %w", userID, err)
+				}
+			}
+
+			fmt.Printf("User created: %s (ID: %s)\n", username, userID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&username, "username", "", "Username (required)")
+	cmd.Flags().StringVar(&email, "email", "", "Email address (required)")
+	cmd.Flags().StringVar(&firstName, "first-name", "", "First name")
+	cmd.Flags().StringVar(&lastName, "last-name", "", "Last name")
+	cmd.Flags().StringVar(&password, "password", "", "Initial password")
+	return cmd
+}
+
+func usersDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete [user-id]",
+		Short: "Delete a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := kc.DeleteUser(ctx, args[0]); err != nil {
+				return fmt.Errorf("deleting user: %w", err)
+			}
+
+			fmt.Printf("User %s deleted.\n", args[0])
+			return nil
+		},
+	}
+}
+
+func usersToggleCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "toggle [user-id]",
+		Short: "Enable or disable a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			user, err := kc.GetUser(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("getting user: %w", err)
+			}
+
+			user.Enabled = !user.Enabled
+			if err := kc.UpdateUser(ctx, user); err != nil {
+				return fmt.Errorf("updating user: %w", err)
+			}
+
+			status := "enabled"
+			if !user.Enabled {
+				status = "disabled"
+			}
+			fmt.Printf("User %s (%s) is now %s.\n", user.Username, user.ID, status)
+			return nil
+		},
+	}
+}
+
+func usersResetPasswordCmd() *cobra.Command {
+	var password string
+	var temporary bool
+
+	cmd := &cobra.Command{
+		Use:   "reset-password [user-id]",
+		Short: "Reset a user's password",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if password == "" {
+				return fmt.Errorf("--password is required")
+			}
+
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			if err := kc.ResetPassword(ctx, args[0], password, temporary); err != nil {
+				return fmt.Errorf("resetting password: %w", err)
+			}
+
+			msg := "Password reset for user %s."
+			if temporary {
+				msg = "Temporary password set for user %s (will be prompted to change on next login)."
+			}
+			fmt.Printf(msg+"\n", args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&password, "password", "", "New password (required)")
+	cmd.Flags().BoolVar(&temporary, "temporary", false, "Require password change on next login")
+	return cmd
+}
+
+func usersRolesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "roles [user-id]",
+		Short: "List roles assigned to a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+
+			// Get user info for display
+			user, err := kc.GetUser(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("getting user: %w", err)
+			}
+
+			roles, err := kc.GetUserRoles(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("getting roles: %w", err)
+			}
+
+			if len(roles) == 0 {
+				fmt.Printf("User %s (%s) has no realm roles assigned.\n", user.Username, user.ID)
+				return nil
+			}
+
+			fmt.Printf("Roles for %s (%s):\n", user.Username, user.Email)
+			fmt.Printf("%-36s %-30s\n", "ROLE ID", "ROLE NAME")
+			for _, r := range roles {
+				fmt.Printf("%-36s %-30s\n", r.ID, r.Name)
+			}
+			return nil
+		},
+	}
+}
+
+func usersAssignRoleCmd() *cobra.Command {
+	var roleID, roleName string
+
+	cmd := &cobra.Command{
+		Use:   "assign-role [user-id]",
+		Short: "Assign a realm role to a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if roleID == "" || roleName == "" {
+				return fmt.Errorf("--role-id and --role-name are required")
+			}
+
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			roles := []auth.KeycloakRole{{ID: roleID, Name: roleName}}
+			if err := kc.AssignUserRole(ctx, args[0], roles); err != nil {
+				return fmt.Errorf("assigning role: %w", err)
+			}
+
+			fmt.Printf("Role %q assigned to user %s.\n", roleName, args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (required)")
+	cmd.Flags().StringVar(&roleName, "role-name", "", "Keycloak role name (required)")
+	return cmd
+}
+
+func usersRemoveRoleCmd() *cobra.Command {
+	var roleID, roleName string
+
+	cmd := &cobra.Command{
+		Use:   "remove-role [user-id]",
+		Short: "Remove a realm role from a user",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if roleID == "" || roleName == "" {
+				return fmt.Errorf("--role-id and --role-name are required")
+			}
+
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			roles := []auth.KeycloakRole{{ID: roleID, Name: roleName}}
+			if err := kc.RemoveUserRole(ctx, args[0], roles); err != nil {
+				return fmt.Errorf("removing role: %w", err)
+			}
+
+			fmt.Printf("Role %q removed from user %s.\n", roleName, args[0])
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (required)")
+	cmd.Flags().StringVar(&roleName, "role-name", "", "Keycloak role name (required)")
+	return cmd
+}
+
+// usersRealmRolesCmd lists all available realm roles (helper for discovering role IDs).
+func usersRealmRolesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "realm-roles",
+		Short: "List all available realm roles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kc, err := newKeycloakAdmin()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			roles, err := kc.GetRealmRoles(ctx)
+			if err != nil {
+				return fmt.Errorf("listing realm roles: %w", err)
+			}
+
+			if len(roles) == 0 {
+				fmt.Println("No realm roles found.")
+				return nil
+			}
+
+			fmt.Printf("%-36s %-30s\n", "ID", "NAME")
+			for _, r := range roles {
+				// Skip internal Keycloak roles
+				if strings.HasPrefix(r.Name, "uma_") || r.Name == "offline_access" || r.Name == "default-roles-microfoundry" {
+					continue
+				}
+				fmt.Printf("%-36s %-30s\n", r.ID, r.Name)
+			}
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Add `mf users` command group with 9 subcommands for Keycloak user CRUD, role management, and password reset
- Add `mf orgs` command group with 7 subcommands for organization lifecycle and membership management
- Both command groups use direct backend access (Keycloak Admin REST API and K8s ConfigMap OrgStore), same pattern as `mf services`

Closes #57

## Commands

### `mf users`
| Command | Description |
|---------|-------------|
| `mf users list [--search TERM]` | List users with optional filter |
| `mf users create --username NAME --email EMAIL` | Create user |
| `mf users delete USER_ID` | Delete user |
| `mf users toggle USER_ID` | Enable/disable user |
| `mf users reset-password USER_ID --password P` | Reset password |
| `mf users roles USER_ID` | List user's realm roles |
| `mf users assign-role USER_ID --role-id ID --role-name NAME` | Assign role |
| `mf users remove-role USER_ID --role-id ID --role-name NAME` | Remove role |
| `mf users realm-roles` | List available realm roles |

### `mf orgs`
| Command | Description |
|---------|-------------|
| `mf orgs list` | List organizations |
| `mf orgs create --name NAME --owner EMAIL` | Create org |
| `mf orgs delete ORG_ID` | Delete org + namespace |
| `mf orgs members ORG_ID` | List org members |
| `mf orgs add-member ORG_ID --email EMAIL [--role R]` | Add member |
| `mf orgs remove-member ORG_ID --email EMAIL` | Remove member |
| `mf orgs set-role ORG_ID --email EMAIL --role ROLE` | Change member role |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `mf users --help` shows subcommands
- [ ] `mf orgs --help` shows subcommands
- [ ] Verify with Keycloak: `mf users list`, `mf users create`, `mf users roles`
- [ ] Verify with K8s: `mf orgs list`, `mf orgs create`, `mf orgs members`

🤖 Generated with [Claude Code](https://claude.com/claude-code)