### PR TITLE
fix: route URL double-protocol and topology save for new plans

### DIFF
--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -562,7 +562,7 @@ func (c *Client) getAppRoutes(ctx context.Context, appName string) []models.Rout
 					Host:     hostPart,
 					Domain:   domainPart,
 					Path:     path.Path,
-					URL:      scheme + "://" + host + path.Path,
+					URL:      host + path.Path,
 					Protocol: scheme,
 				})
 			}

--- a/pkg/terraform/storage.go
+++ b/pkg/terraform/storage.go
@@ -81,8 +81,9 @@ func (s *TopologyStore) Save(ctx context.Context, config *models.TopologyConfig)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
+	isNew := errors.IsNotFound(err)
 
-	if errors.IsNotFound(err) {
+	if isNew {
 		// New topology
 		config.Metadata.Version = 1
 		config.Metadata.CreatedAt = time.Now()
@@ -121,7 +122,7 @@ func (s *TopologyStore) Save(ctx context.Context, config *models.TopologyConfig)
 		Data: data,
 	}
 
-	if errors.IsNotFound(err) {
+	if isNew {
 		_, err = s.k8sClient.Clientset.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 	} else {
 		cm.ResourceVersion = existing.ResourceVersion


### PR DESCRIPTION
## Summary

- Fix double protocol prefix in route URLs (`https://https://hello-world.cf-local.dev/`)
- Fix topology save failing for new service plans (`configmaps "mf-tf-topology-mariadb-small" not found`)

## Bug 1: Route URL double-protocol

**Root cause**: `getAppRoutes()` in `pkg/k8s/app.go` stored the full URL with scheme (`https://host/path`) in `RouteDetail.URL`, but the templates already prepend `{{.Protocol}}://{{.URL}}`, producing `https://https://host/path`.

**Fix**: Store only bare `host + path.Path` in `.URL`.

## Bug 2: Topology save for new plans

**Root cause**: In `TopologyStore.Save()`, the `err` variable from the initial ConfigMap Get was overwritten by `json.Marshal(config.Metadata)` on line 103. The Create-vs-Update check on line 124 then evaluated `errors.IsNotFound(nil)` = false, always taking the Update path — which fails for ConfigMaps that don't exist yet.

**Fix**: Capture `isNew := errors.IsNotFound(err)` immediately after the Get call, before any other operations can overwrite `err`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Route URL shows `https://hello-world.cf-local.dev/` (no double prefix)
- [ ] Topology save works for new plans in Service Catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)