### PR TITLE
feat: workspace hierarchy, 5-tier RBAC, CLI auth & role-based UI

### DIFF
--- a/cmd/mf/admin.go
+++ b/cmd/mf/admin.go
@@ -51,6 +51,7 @@ func adminCmd() *cobra.Command {
 				}
 
 				orgStore := auth.NewOrgStore(activeClient.Clientset, activeClient.Namespace)
+				wsStore := auth.NewWorkspaceStore(activeClient.Clientset, activeClient.Namespace)
 
 				authCfg := auth.AuthConfig{
 					Enabled:      cfg.Auth.Enabled,
@@ -61,12 +62,13 @@ func adminCmd() *cobra.Command {
 					SessionKey:   cfg.Auth.SessionKey,
 				}
 
-				oidcAuth, err := auth.NewOIDCAuthenticator(ctx, authCfg, sessions, orgStore)
+				oidcAuth, err := auth.NewOIDCAuthenticator(ctx, authCfg, sessions, orgStore, wsStore)
 				if err != nil {
 					return fmt.Errorf("initializing OIDC: %w", err)
 				}
 
 				opts = append(opts, admin.WithAuth(oidcAuth, sessions, orgStore))
+				opts = append(opts, admin.WithWorkspaceStore(wsStore))
 				fmt.Printf("Authentication enabled (Keycloak: %s)\n", cfg.Auth.IssuerURL)
 
 				// Keycloak Admin API client (optional — needs admin_base_url)

--- a/cmd/mf/login.go
+++ b/cmd/mf/login.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/younjinjeong/microfoundry/pkg/auth"
+	"github.com/younjinjeong/microfoundry/pkg/config"
+	"golang.org/x/term"
+)
+
+func loginCmd() *cobra.Command {
+	var username, password string
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate with MicroFoundry",
+		Long:  "Login to MicroFoundry using Keycloak credentials. Stores an access token for subsequent CLI commands.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			if !cfg.Auth.Enabled {
+				return fmt.Errorf("authentication is not enabled in mf.yaml")
+			}
+			if cfg.Auth.IssuerURL == "" {
+				return fmt.Errorf("auth.issuer_url is not configured in mf.yaml")
+			}
+
+			// Interactive prompts if flags not provided
+			if username == "" {
+				fmt.Print("Username: ")
+				scanner := bufio.NewScanner(os.Stdin)
+				if scanner.Scan() {
+					username = strings.TrimSpace(scanner.Text())
+				}
+				if username == "" {
+					return fmt.Errorf("username is required")
+				}
+			}
+
+			if password == "" {
+				fmt.Print("Password: ")
+				pwBytes, err := term.ReadPassword(int(syscall.Stdin))
+				if err != nil {
+					return fmt.Errorf("reading password: %w", err)
+				}
+				fmt.Println() // newline after hidden input
+				password = string(pwBytes)
+				if password == "" {
+					return fmt.Errorf("password is required")
+				}
+			}
+
+			token, err := auth.LoginWithPassword(
+				cfg.Auth.IssuerURL,
+				cfg.Auth.ClientID,
+				cfg.Auth.ClientSecret,
+				username,
+				password,
+			)
+			if err != nil {
+				return err
+			}
+
+			if err := auth.SaveToken(token); err != nil {
+				return fmt.Errorf("saving token: %w", err)
+			}
+
+			roles := "none"
+			if len(token.Roles) > 0 {
+				roles = strings.Join(token.Roles, ", ")
+			}
+			fmt.Printf("Logged in as %s (%s)\n", token.Username, token.Email)
+			fmt.Printf("Roles: %s\n", roles)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&username, "username", "u", "", "Username")
+	cmd.Flags().StringVarP(&password, "password", "p", "", "Password")
+	return cmd
+}
+
+func logoutCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Clear stored authentication token",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := auth.ClearToken(); err != nil {
+				return fmt.Errorf("clearing token: %w", err)
+			}
+			fmt.Println("Logged out.")
+			return nil
+		},
+	}
+}
+
+func whoamiCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "whoami",
+		Short: "Display current authenticated user",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token, err := auth.LoadToken()
+			if err != nil {
+				return err
+			}
+
+			// Refresh if expired
+			if token.IsExpired() {
+				cfg, err := config.Load()
+				if err != nil {
+					return fmt.Errorf("loading config: %w", err)
+				}
+				if err := auth.RefreshToken(
+					cfg.Auth.IssuerURL,
+					cfg.Auth.ClientID,
+					cfg.Auth.ClientSecret,
+					token,
+				); err != nil {
+					return err
+				}
+				if err := auth.SaveToken(token); err != nil {
+					return fmt.Errorf("saving refreshed token: %w", err)
+				}
+			}
+
+			roles := "none"
+			if len(token.Roles) > 0 {
+				roles = strings.Join(token.Roles, ", ")
+			}
+			fmt.Printf("Username:  %s\n", token.Username)
+			fmt.Printf("Email:     %s\n", token.Email)
+			fmt.Printf("Roles:     %s\n", roles)
+			fmt.Printf("Expires:   %s\n", token.ExpiresAt.Format("2006-01-02 15:04:05"))
+			return nil
+		},
+	}
+}

--- a/cmd/mf/main.go
+++ b/cmd/mf/main.go
@@ -25,6 +25,9 @@ func main() {
 
 	rootCmd.AddCommand(
 		versionCmd(),
+		loginCmd(),
+		logoutCmd(),
+		whoamiCmd(),
 		pushCmd(),
 		appsCmd(),
 		appCmd(),
@@ -45,6 +48,7 @@ func main() {
 		deleteSecretCmd(),
 		usersCmd(),
 		orgsCmd(),
+		workspacesCmd(),
 		setupRoot,
 	)
 

--- a/cmd/mf/scale.go
+++ b/cmd/mf/scale.go
@@ -1,25 +1,70 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
+// parseMemoryString parses CF-style memory strings like "256M", "1G", "512m", "2g" into MB.
+func parseMemoryString(s string) (int, error) {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	if s == "" {
+		return 0, fmt.Errorf("empty memory string")
+	}
+	if strings.HasSuffix(s, "G") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "G"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", s)
+		}
+		return n * 1024, nil
+	}
+	if strings.HasSuffix(s, "M") {
+		n, err := strconv.Atoi(strings.TrimSuffix(s, "M"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid memory value: %s", s)
+		}
+		return n, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid memory value: %s (use e.g. 256M or 1G)", s)
+	}
+	return n, nil
+}
+
 func scaleCmd() *cobra.Command {
-	var instances int
+	var (
+		instances int
+		memory    string
+		disk      string
+		force     bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "scale [app-name]",
-		Short: "Scale application instances",
-		Args:  cobra.ExactArgs(1),
+		Short: "Scale application instances, memory, and disk",
+		Long: `Scale application resources. Examples:
+  mf scale hello-world -i 3
+  mf scale hello-world -m 512M
+  mf scale hello-world -k 1G
+  mf scale hello-world -m 512M -k 1G -f`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			name := args[0]
 
-			if instances <= 0 {
-				return fmt.Errorf("--instances (-i) must be a positive number")
+			hasInstances := cmd.Flags().Changed("instances")
+			hasMemory := memory != ""
+			hasDisk := disk != ""
+
+			if !hasInstances && !hasMemory && !hasDisk {
+				return fmt.Errorf("at least one of --instances (-i), --memory (-m), or --disk (-k) is required")
 			}
 
 			k8sClient, err := newK8sClient()
@@ -27,18 +72,76 @@ func scaleCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Scaling %s to %d instances...\n", name, instances)
-			if err := k8sClient.ScaleApp(ctx, name, instances); err != nil {
-				return err
+			// Scale instances (no restart required)
+			if hasInstances {
+				if instances <= 0 {
+					return fmt.Errorf("--instances (-i) must be a positive number")
+				}
+				fmt.Printf("Scaling %s to %d instances...\n", name, instances)
+				if err := k8sClient.ScaleApp(ctx, name, instances); err != nil {
+					return err
+				}
+				fmt.Printf("App %s scaled to %d instances.\n", name, instances)
 			}
 
-			fmt.Printf("App %s scaled to %d instances.\n", name, instances)
+			// Update memory/disk (triggers restart)
+			if hasMemory || hasDisk {
+				var memMB, diskMB int
+
+				if hasMemory {
+					memMB, err = parseMemoryString(memory)
+					if err != nil {
+						return err
+					}
+					if memMB < 64 || memMB > 8192 {
+						return fmt.Errorf("memory must be between 64M and 8G")
+					}
+				}
+				if hasDisk {
+					diskMB, err = parseMemoryString(disk)
+					if err != nil {
+						return err
+					}
+					if diskMB < 256 || diskMB > 8192 {
+						return fmt.Errorf("disk must be between 256M and 8G")
+					}
+				}
+
+				// Prompt for restart unless --force
+				if !force {
+					fmt.Print("This will restart the app. Continue? [y/N]: ")
+					scanner := bufio.NewScanner(os.Stdin)
+					scanner.Scan()
+					answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+					if answer != "y" && answer != "yes" {
+						fmt.Println("Aborted.")
+						return nil
+					}
+				}
+
+				desc := []string{}
+				if memMB > 0 {
+					desc = append(desc, fmt.Sprintf("memory=%dM", memMB))
+				}
+				if diskMB > 0 {
+					desc = append(desc, fmt.Sprintf("disk=%dM", diskMB))
+				}
+				fmt.Printf("Updating %s resources (%s)...\n", name, strings.Join(desc, ", "))
+
+				if err := k8sClient.UpdateAppResources(ctx, name, memMB, diskMB); err != nil {
+					return err
+				}
+				fmt.Printf("App %s resources updated. App is restarting.\n", name)
+			}
+
 			return nil
 		},
 	}
 
 	cmd.Flags().IntVarP(&instances, "instances", "i", 0, "Number of instances")
-	_ = cmd.MarkFlagRequired("instances")
+	cmd.Flags().StringVarP(&memory, "memory", "m", "", "Memory limit (e.g. 256M, 1G)")
+	cmd.Flags().StringVarP(&disk, "disk", "k", "", "Disk limit (e.g. 256M, 1G)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force restart without prompt")
 
 	return cmd
 }

--- a/cmd/mf/users.go
+++ b/cmd/mf/users.go
@@ -111,6 +111,14 @@ func usersCreateCmd() *cobra.Command {
 				return err
 			}
 
+			// Default first/last name to username if not provided (Keycloak requires non-empty profile)
+			if firstName == "" {
+				firstName = username
+			}
+			if lastName == "" {
+				lastName = "-"
+			}
+
 			ctx := context.Background()
 			user := &auth.KeycloakUser{
 				Username:      username,
@@ -275,21 +283,46 @@ func usersRolesCmd() *cobra.Command {
 	}
 }
 
+// lookupRoleByName finds a realm role by name, returning its ID.
+func lookupRoleByName(kc *auth.KeycloakAdminClient, name string) (auth.KeycloakRole, error) {
+	ctx := context.Background()
+	roles, err := kc.GetRealmRoles(ctx)
+	if err != nil {
+		return auth.KeycloakRole{}, fmt.Errorf("listing realm roles: %w", err)
+	}
+	for _, r := range roles {
+		if r.Name == name {
+			return r, nil
+		}
+	}
+	return auth.KeycloakRole{}, fmt.Errorf("role %q not found in realm", name)
+}
+
 func usersAssignRoleCmd() *cobra.Command {
 	var roleID, roleName string
 
 	cmd := &cobra.Command{
 		Use:   "assign-role [user-id]",
 		Short: "Assign a realm role to a user",
+		Long:  "Assign a realm role to a user. Use --role-name to auto-lookup the role ID, or provide both --role-id and --role-name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if roleID == "" || roleName == "" {
-				return fmt.Errorf("--role-id and --role-name are required")
+			if roleName == "" {
+				return fmt.Errorf("--role-name is required")
 			}
 
 			kc, err := newKeycloakAdmin()
 			if err != nil {
 				return err
+			}
+
+			// Auto-lookup role ID if not provided
+			if roleID == "" {
+				role, err := lookupRoleByName(kc, roleName)
+				if err != nil {
+					return err
+				}
+				roleID = role.ID
 			}
 
 			ctx := context.Background()
@@ -303,7 +336,7 @@ func usersAssignRoleCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (required)")
+	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (auto-resolved if omitted)")
 	cmd.Flags().StringVar(&roleName, "role-name", "", "Keycloak role name (required)")
 	return cmd
 }
@@ -314,15 +347,25 @@ func usersRemoveRoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove-role [user-id]",
 		Short: "Remove a realm role from a user",
+		Long:  "Remove a realm role from a user. Use --role-name to auto-lookup the role ID, or provide both --role-id and --role-name.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if roleID == "" || roleName == "" {
-				return fmt.Errorf("--role-id and --role-name are required")
+			if roleName == "" {
+				return fmt.Errorf("--role-name is required")
 			}
 
 			kc, err := newKeycloakAdmin()
 			if err != nil {
 				return err
+			}
+
+			// Auto-lookup role ID if not provided
+			if roleID == "" {
+				role, err := lookupRoleByName(kc, roleName)
+				if err != nil {
+					return err
+				}
+				roleID = role.ID
 			}
 
 			ctx := context.Background()
@@ -336,7 +379,7 @@ func usersRemoveRoleCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (required)")
+	cmd.Flags().StringVar(&roleID, "role-id", "", "Keycloak role ID (auto-resolved if omitted)")
 	cmd.Flags().StringVar(&roleName, "role-name", "", "Keycloak role name (required)")
 	return cmd
 }

--- a/cmd/mf/workspaces.go
+++ b/cmd/mf/workspaces.go
@@ -8,141 +8,136 @@ import (
 	"github.com/younjinjeong/microfoundry/pkg/auth"
 )
 
-// newOrgStore creates an OrgStore from the active K8s cluster.
-func newOrgStore() (*auth.OrgStore, error) {
+// newWorkspaceStore creates a WorkspaceStore from the active K8s cluster.
+func newWorkspaceStore() (*auth.WorkspaceStore, error) {
 	k8sClient, err := newK8sClient()
 	if err != nil {
 		return nil, err
 	}
-	return auth.NewOrgStore(k8sClient.Clientset, k8sClient.Namespace), nil
+	return auth.NewWorkspaceStore(k8sClient.Clientset, k8sClient.Namespace), nil
 }
 
-func orgsCmd() *cobra.Command {
+func workspacesCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "orgs",
-		Short: "Manage organizations",
-		Long:  "List, create, delete, and manage organizations and their members.",
+		Use:   "workspaces",
+		Short: "Manage workspaces",
+		Long:  "List, create, delete, and manage workspaces and their members.",
 	}
 
 	cmd.AddCommand(
-		orgsListCmd(),
-		orgsCreateCmd(),
-		orgsDeleteCmd(),
-		orgsMembersCmd(),
-		orgsAddMemberCmd(),
-		orgsRemoveMemberCmd(),
-		orgsSetRoleCmd(),
+		workspacesListCmd(),
+		workspacesCreateCmd(),
+		workspacesDeleteCmd(),
+		workspacesMembersCmd(),
+		workspacesAddMemberCmd(),
+		workspacesRemoveMemberCmd(),
+		workspacesSetRoleCmd(),
+		workspacesOrgsCmd(),
 	)
 
 	return cmd
 }
 
-func orgsListCmd() *cobra.Command {
+func workspacesListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
-		Short: "List all organizations",
+		Short: "List all workspaces",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
 
 			ctx := context.Background()
-			orgs, err := store.List(ctx)
+			workspaces, err := store.List(ctx)
 			if err != nil {
-				return fmt.Errorf("listing organizations: %w", err)
+				return fmt.Errorf("listing workspaces: %w", err)
 			}
 
-			if len(orgs) == 0 {
-				fmt.Println("No organizations found.")
-				fmt.Println("Use 'mf orgs create --name <name> --owner <email>' to create one.")
+			if len(workspaces) == 0 {
+				fmt.Println("No workspaces found.")
+				fmt.Println("Use 'mf workspaces create --name <name> --owner <email>' to create one.")
 				return nil
 			}
 
-			fmt.Printf("%-20s %-30s %-30s %-20s %-20s\n", "ID", "NAME", "OWNER", "NAMESPACE", "CREATED")
-			for _, o := range orgs {
-				created := o.CreatedAt
+			fmt.Printf("%-20s %-30s %-30s %-20s\n", "ID", "NAME", "OWNER", "CREATED")
+			for _, ws := range workspaces {
+				created := ws.CreatedAt
 				if len(created) > 16 {
 					created = created[:16]
 				}
-				fmt.Printf("%-20s %-30s %-30s %-20s %-20s\n",
-					o.ID, o.Name, o.OwnerEmail, o.Namespace, created)
+				fmt.Printf("%-20s %-30s %-30s %-20s\n",
+					ws.ID, ws.Name, ws.OwnerEmail, created)
 			}
 			return nil
 		},
 	}
 }
 
-func orgsCreateCmd() *cobra.Command {
-	var name, owner, workspace string
+func workspacesCreateCmd() *cobra.Command {
+	var name, owner string
 
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a new organization",
+		Short: "Create a new workspace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" || owner == "" {
 				return fmt.Errorf("--name and --owner are required")
 			}
 
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
 
 			ctx := context.Background()
-			org, err := store.Create(ctx, name, owner, workspace)
+			ws, err := store.Create(ctx, name, owner)
 			if err != nil {
-				return fmt.Errorf("creating organization: %w", err)
+				return fmt.Errorf("creating workspace: %w", err)
 			}
 
-			fmt.Printf("Organization created:\n")
-			fmt.Printf("  ID:         %s\n", org.ID)
-			fmt.Printf("  Name:       %s\n", org.Name)
-			fmt.Printf("  Owner:      %s\n", org.OwnerEmail)
-			fmt.Printf("  Namespace:  %s\n", org.Namespace)
-			if org.WorkspaceID != "" {
-				fmt.Printf("  Workspace:  %s\n", org.WorkspaceID)
-			}
+			fmt.Printf("Workspace created:\n")
+			fmt.Printf("  ID:    %s\n", ws.ID)
+			fmt.Printf("  Name:  %s\n", ws.Name)
+			fmt.Printf("  Owner: %s\n", ws.OwnerEmail)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "Organization name (required)")
+	cmd.Flags().StringVar(&name, "name", "", "Workspace name (required)")
 	cmd.Flags().StringVar(&owner, "owner", "", "Owner email address (required)")
-	cmd.Flags().StringVar(&workspace, "workspace", "", "Workspace ID to associate with (optional)")
 	return cmd
 }
 
-func orgsDeleteCmd() *cobra.Command {
+func workspacesDeleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete [org-id]",
-		Short: "Delete an organization",
-		Long:  "Delete an organization, its member list, and its Kubernetes namespace.",
+		Use:   "delete [ws-id]",
+		Short: "Delete a workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			if err := store.Delete(ctx, args[0]); err != nil {
-				return fmt.Errorf("deleting organization: %w", err)
+				return fmt.Errorf("deleting workspace: %w", err)
 			}
 
-			fmt.Printf("Organization %s deleted.\n", args[0])
+			fmt.Printf("Workspace %s deleted.\n", args[0])
 			return nil
 		},
 	}
 }
 
-func orgsMembersCmd() *cobra.Command {
+func workspacesMembersCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "members [org-id]",
-		Short: "List members of an organization",
+		Use:   "members [ws-id]",
+		Short: "List members of a workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
@@ -154,11 +149,11 @@ func orgsMembersCmd() *cobra.Command {
 			}
 
 			if len(members) == 0 {
-				fmt.Printf("Organization %s has no members.\n", args[0])
+				fmt.Printf("Workspace %s has no members.\n", args[0])
 				return nil
 			}
 
-			fmt.Printf("Members of organization %s:\n\n", args[0])
+			fmt.Printf("Members of workspace %s:\n\n", args[0])
 			fmt.Printf("%-30s %-30s %-10s %-20s\n", "EMAIL", "NAME", "ROLE", "JOINED")
 			for _, m := range members {
 				joined := m.JoinedAt
@@ -173,12 +168,12 @@ func orgsMembersCmd() *cobra.Command {
 	}
 }
 
-func orgsAddMemberCmd() *cobra.Command {
+func workspacesAddMemberCmd() *cobra.Command {
 	var email, name, role string
 
 	cmd := &cobra.Command{
-		Use:   "add-member [org-id]",
-		Short: "Add a member to an organization",
+		Use:   "add-member [ws-id]",
+		Short: "Add a member to a workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if email == "" {
@@ -196,7 +191,7 @@ func orgsAddMemberCmd() *cobra.Command {
 				return fmt.Errorf("invalid role %q (must be admin, member, or viewer)", role)
 			}
 
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
@@ -206,7 +201,7 @@ func orgsAddMemberCmd() *cobra.Command {
 				return fmt.Errorf("adding member: %w", err)
 			}
 
-			fmt.Printf("Member %s added to organization %s with role %s.\n", email, args[0], role)
+			fmt.Printf("Member %s added to workspace %s with role %s.\n", email, args[0], role)
 			return nil
 		},
 	}
@@ -217,19 +212,19 @@ func orgsAddMemberCmd() *cobra.Command {
 	return cmd
 }
 
-func orgsRemoveMemberCmd() *cobra.Command {
+func workspacesRemoveMemberCmd() *cobra.Command {
 	var email string
 
 	cmd := &cobra.Command{
-		Use:   "remove-member [org-id]",
-		Short: "Remove a member from an organization",
+		Use:   "remove-member [ws-id]",
+		Short: "Remove a member from a workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if email == "" {
 				return fmt.Errorf("--email is required")
 			}
 
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
@@ -239,7 +234,7 @@ func orgsRemoveMemberCmd() *cobra.Command {
 				return fmt.Errorf("removing member: %w", err)
 			}
 
-			fmt.Printf("Member %s removed from organization %s.\n", email, args[0])
+			fmt.Printf("Member %s removed from workspace %s.\n", email, args[0])
 			return nil
 		},
 	}
@@ -248,12 +243,12 @@ func orgsRemoveMemberCmd() *cobra.Command {
 	return cmd
 }
 
-func orgsSetRoleCmd() *cobra.Command {
+func workspacesSetRoleCmd() *cobra.Command {
 	var email, role string
 
 	cmd := &cobra.Command{
-		Use:   "set-role [org-id]",
-		Short: "Change a member's role in an organization",
+		Use:   "set-role [ws-id]",
+		Short: "Change a member's role in a workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if email == "" || role == "" {
@@ -265,7 +260,7 @@ func orgsSetRoleCmd() *cobra.Command {
 				return fmt.Errorf("invalid role %q (must be admin, member, or viewer)", role)
 			}
 
-			store, err := newOrgStore()
+			store, err := newWorkspaceStore()
 			if err != nil {
 				return err
 			}
@@ -275,7 +270,7 @@ func orgsSetRoleCmd() *cobra.Command {
 				return fmt.Errorf("setting role: %w", err)
 			}
 
-			fmt.Printf("Member %s role set to %s in organization %s.\n", email, role, args[0])
+			fmt.Printf("Member %s role set to %s in workspace %s.\n", email, role, args[0])
 			return nil
 		},
 	}
@@ -283,4 +278,37 @@ func orgsSetRoleCmd() *cobra.Command {
 	cmd.Flags().StringVar(&email, "email", "", "Member email address (required)")
 	cmd.Flags().StringVar(&role, "role", "", "New role: admin, member, or viewer (required)")
 	return cmd
+}
+
+func workspacesOrgsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "orgs [ws-id]",
+		Short: "List organizations in a workspace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			store, err := newOrgStore()
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			orgs, err := store.ListByWorkspace(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("listing organizations: %w", err)
+			}
+
+			if len(orgs) == 0 {
+				fmt.Printf("Workspace %s has no organizations.\n", args[0])
+				return nil
+			}
+
+			fmt.Printf("Organizations in workspace %s:\n\n", args[0])
+			fmt.Printf("%-20s %-30s %-30s %-20s\n", "ID", "NAME", "OWNER", "NAMESPACE")
+			for _, o := range orgs {
+				fmt.Printf("%-20s %-30s %-30s %-20s\n",
+					o.ID, o.Name, o.OwnerEmail, o.Namespace)
+			}
+			return nil
+		},
+	}
 }

--- a/pkg/admin/api.go
+++ b/pkg/admin/api.go
@@ -73,14 +73,12 @@ func (s *Server) APIScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 
 	var body struct {
-		Instances int `json:"instances"`
+		Instances *int `json:"instances,omitempty"`
+		MemoryMB  *int `json:"memory_mb,omitempty"`
+		DiskMB    *int `json:"disk_mb,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-		return
-	}
-	if body.Instances < 0 || body.Instances > 20 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "instances must be between 0 and 20"})
 		return
 	}
 
@@ -90,16 +88,50 @@ func (s *Server) APIScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := client.ScaleApp(ctx, name, body.Instances); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
+	result := map[string]any{"name": name}
+
+	// Scale instances if provided
+	if body.Instances != nil {
+		if *body.Instances < 0 || *body.Instances > 20 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "instances must be between 0 and 20"})
+			return
+		}
+		if err := client.ScaleApp(ctx, name, *body.Instances); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		result["instances"] = *body.Instances
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"name":      name,
-		"instances": body.Instances,
-		"scaled":    true,
-	})
+	// Update memory/disk if provided
+	memMB := 0
+	diskMB := 0
+	if body.MemoryMB != nil {
+		if *body.MemoryMB < 64 || *body.MemoryMB > 8192 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "memory_mb must be between 64 and 8192"})
+			return
+		}
+		memMB = *body.MemoryMB
+		result["memory_mb"] = memMB
+	}
+	if body.DiskMB != nil {
+		if *body.DiskMB < 256 || *body.DiskMB > 8192 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "disk_mb must be between 256 and 8192"})
+			return
+		}
+		diskMB = *body.DiskMB
+		result["disk_mb"] = diskMB
+	}
+	if memMB > 0 || diskMB > 0 {
+		if err := client.UpdateAppResources(ctx, name, memMB, diskMB); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		result["restarting"] = true
+	}
+
+	result["scaled"] = true
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (s *Server) APIDeleteAppHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/admin/cluster_handlers.go
+++ b/pkg/admin/cluster_handlers.go
@@ -15,7 +15,7 @@ func (s *Server) ClustersListHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	clusters := s.clientManager.ListClusters(ctx)
 
-	data := s.pageData("Clusters", "clusters")
+	data := s.pageDataWithUser(r,"Clusters", "clusters")
 	data.Content = map[string]any{
 		"Clusters":      clusters,
 		"ActiveCluster": s.clientManager.GetActive(),
@@ -34,7 +34,7 @@ func (s *Server) ClusterDetailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := s.pageData(detail.Name, "clusters")
+	data := s.pageDataWithUser(r,detail.Name, "clusters")
 	data.Content = detail
 	s.templates.Render(w, "cluster_detail.html", data)
 }

--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -55,7 +55,7 @@ func (s *Server) DashboardHandler(w http.ResponseWriter, r *http.Request) {
 
 	apps, _ := client.ListApps(ctx)
 
-	data := s.pageData("Dashboard", "dashboard")
+	data := s.pageDataWithUser(r, "Dashboard", "dashboard")
 	data.Content = map[string]any{
 		"AppCount":  len(apps),
 		"Domain":    client.Domain,
@@ -90,7 +90,7 @@ func (s *Server) AppsListHandler(w http.ResponseWriter, r *http.Request) {
 				filtered = append(filtered, item)
 			}
 		}
-		data := s.pageData("Applications", "apps")
+		data := s.pageDataWithUser(r, "Applications", "apps")
 		data.Content = map[string]any{
 			"Apps":   filtered,
 			"Filter": filter,
@@ -99,7 +99,7 @@ func (s *Server) AppsListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := s.pageData("Applications", "apps")
+	data := s.pageDataWithUser(r, "Applications", "apps")
 	data.Content = map[string]any{
 		"Apps":   items,
 		"Filter": "all",
@@ -202,7 +202,7 @@ func (s *Server) AppDetailHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data := s.pageData(name, "apps")
+	data := s.pageDataWithUser(r, name, "apps")
 	data.Content = content
 	s.templates.Render(w, "app_detail.html", data)
 }
@@ -324,25 +324,50 @@ func (s *Server) ScaleAppHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
-	instancesStr := r.FormValue("instances")
-	instances, err := strconv.Atoi(instancesStr)
-	if err != nil || instances < 0 || instances > 20 {
-		http.Error(w, "instances must be between 0 and 20", http.StatusBadRequest)
-		return
-	}
-
 	client, err := s.getClient(r)
 	if err != nil {
 		http.Error(w, "No cluster available: "+err.Error(), http.StatusServiceUnavailable)
 		return
 	}
 
-	if err := client.ScaleApp(ctx, name, instances); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+	// Handle instance scaling
+	if instancesStr := r.FormValue("instances"); instancesStr != "" {
+		instances, err := strconv.Atoi(instancesStr)
+		if err != nil || instances < 0 || instances > 20 {
+			http.Error(w, "instances must be between 0 and 20", http.StatusBadRequest)
+			return
+		}
+		if err := client.ScaleApp(ctx, name, instances); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		s.metrics.ScaleEvents.WithLabelValues(s.clientManager.GetActive(), name).Inc()
 	}
 
-	s.metrics.ScaleEvents.WithLabelValues(s.clientManager.GetActive(), name).Inc()
+	// Handle memory/disk resource update
+	memStr := r.FormValue("memory_mb")
+	diskStr := r.FormValue("disk_mb")
+	if memStr != "" || diskStr != "" {
+		var memMB, diskMB int
+		if memStr != "" {
+			memMB, err = strconv.Atoi(memStr)
+			if err != nil || memMB < 64 || memMB > 8192 {
+				http.Error(w, "memory must be between 64 and 8192 MB", http.StatusBadRequest)
+				return
+			}
+		}
+		if diskStr != "" {
+			diskMB, err = strconv.Atoi(diskStr)
+			if err != nil || diskMB < 256 || diskMB > 8192 {
+				http.Error(w, "disk must be between 256 and 8192 MB", http.StatusBadRequest)
+				return
+			}
+		}
+		if err := client.UpdateAppResources(ctx, name, memMB, diskMB); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 
 	// Return updated app row via ListAppItems
 	items, _ := client.ListAppItems(ctx)
@@ -385,7 +410,7 @@ func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		namespace = client.Namespace
 	}
 
-	data := s.pageData("Configuration", "config")
+	data := s.pageDataWithUser(r, "Configuration", "config")
 	data.Content = map[string]any{
 		"Domain":    domain,
 		"Namespace": namespace,
@@ -395,6 +420,12 @@ func (s *Server) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 		"Repo":      s.config.GitHub.Repo,
 	}
 	s.templates.Render(w, "config.html", data)
+}
+
+// DeniedHandler renders the access denied page.
+func (s *Server) DeniedHandler(w http.ResponseWriter, r *http.Request) {
+	data := s.pageDataWithUser(r, "Access Denied", "")
+	s.templates.Render(w, "denied.html", data)
 }
 
 // UsersHandler is now replaced by OrgsPageHandler in org_handlers.go

--- a/pkg/admin/iam_handlers.go
+++ b/pkg/admin/iam_handlers.go
@@ -352,6 +352,182 @@ func (s *Server) APIPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"policies": s.opa.GetPolicies()})
 }
 
+// APICreateUserHandler handles POST /api/users.
+func (s *Server) APICreateUserHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	var body struct {
+		Username  string `json:"username"`
+		Email     string `json:"email"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Password  string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.Username == "" || body.Email == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username and email are required"})
+		return
+	}
+
+	user := &auth.KeycloakUser{
+		Username:      body.Username,
+		Email:         body.Email,
+		FirstName:     body.FirstName,
+		LastName:      body.LastName,
+		Enabled:       true,
+		EmailVerified: true,
+	}
+
+	userID, err := s.keycloakAdmin.CreateUser(r.Context(), user)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if body.Password != "" {
+		if err := s.keycloakAdmin.ResetPassword(r.Context(), userID, body.Password, false); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "user created but password set failed: " + err.Error()})
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"id": userID})
+}
+
+// APIDeleteUserHandler handles DELETE /api/users/{id}.
+func (s *Server) APIDeleteUserHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	userID := r.PathValue("id")
+	if err := s.keycloakAdmin.DeleteUser(r.Context(), userID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// APIToggleUserHandler handles POST /api/users/{id}/toggle.
+func (s *Server) APIToggleUserHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	userID := r.PathValue("id")
+	user, err := s.keycloakAdmin.GetUser(r.Context(), userID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	user.Enabled = !user.Enabled
+	if err := s.keycloakAdmin.UpdateUser(r.Context(), user); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"id": userID, "enabled": user.Enabled})
+}
+
+// APIAssignRoleHandler handles POST /api/users/{id}/roles.
+func (s *Server) APIAssignRoleHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	userID := r.PathValue("id")
+	var body struct {
+		RoleID   string `json:"role_id"`
+		RoleName string `json:"role_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.RoleID == "" || body.RoleName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role_id and role_name are required"})
+		return
+	}
+
+	roles := []auth.KeycloakRole{{ID: body.RoleID, Name: body.RoleName}}
+	if err := s.keycloakAdmin.AssignUserRole(r.Context(), userID, roles); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "assigned"})
+}
+
+// APIRemoveRoleHandler handles DELETE /api/users/{id}/roles.
+func (s *Server) APIRemoveRoleHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	userID := r.PathValue("id")
+	var body struct {
+		RoleID   string `json:"role_id"`
+		RoleName string `json:"role_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.RoleID == "" || body.RoleName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role_id and role_name are required"})
+		return
+	}
+
+	roles := []auth.KeycloakRole{{ID: body.RoleID, Name: body.RoleName}}
+	if err := s.keycloakAdmin.RemoveUserRole(r.Context(), userID, roles); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
+}
+
+// APIResetPasswordHandler handles POST /api/users/{id}/password.
+func (s *Server) APIResetPasswordHandler(w http.ResponseWriter, r *http.Request) {
+	if s.keycloakAdmin == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "keycloak admin not configured"})
+		return
+	}
+
+	userID := r.PathValue("id")
+	var body struct {
+		Password  string `json:"password"`
+		Temporary bool   `json:"temporary"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.Password == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "password is required"})
+		return
+	}
+
+	if err := s.keycloakAdmin.ResetPassword(r.Context(), userID, body.Password, body.Temporary); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "password_reset"})
+}
+
 // APISavePolicyHandler handles PUT /api/policies.
 func (s *Server) APISavePolicyHandler(w http.ResponseWriter, r *http.Request) {
 	if s.opa == nil {

--- a/pkg/admin/monitoring_handlers.go
+++ b/pkg/admin/monitoring_handlers.go
@@ -52,7 +52,7 @@ func (s *Server) MonitoringHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	data := s.pageData("Metrics & Alerts", "monitoring")
+	data := s.pageDataWithUser(r,"Metrics & Alerts", "monitoring")
 	data.Content = map[string]any{
 		"OverviewIframeURL": overviewURL,
 		"ClusterIframeURL":  clusterURL,

--- a/pkg/admin/org_handlers.go
+++ b/pkg/admin/org_handlers.go
@@ -151,7 +151,7 @@ func (s *Server) CreateOrgHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := s.orgStore()
-	org, err := store.Create(r.Context(), name, user.Email)
+	org, err := store.Create(r.Context(), name, user.Email, user.ActiveWorkspaceID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -338,13 +338,87 @@ func (s *Server) APICreateOrgHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := s.orgStore()
-	org, err := store.Create(r.Context(), body.Name, user.Email)
+	org, err := store.Create(r.Context(), body.Name, user.Email, user.ActiveWorkspaceID)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 
 	writeJSON(w, http.StatusCreated, org)
+}
+
+func (s *Server) APIDeleteOrgHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	orgID := r.PathValue("id")
+	store := s.orgStore()
+
+	if err := store.Delete(r.Context(), orgID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) APIAddMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	orgID := r.PathValue("id")
+	var body struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.Email == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+	if body.Name == "" {
+		body.Name = body.Email
+	}
+	if body.Role == "" {
+		body.Role = "member"
+	}
+
+	store := s.orgStore()
+	if err := store.AddMember(r.Context(), orgID, body.Email, body.Name, body.Role); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"status": "added"})
+}
+
+func (s *Server) APIRemoveMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	orgID := r.PathValue("id")
+	email := r.PathValue("email")
+
+	store := s.orgStore()
+	if err := store.RemoveMember(r.Context(), orgID, email); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) APIListMembersHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/admin/secret_handlers.go
+++ b/pkg/admin/secret_handlers.go
@@ -42,7 +42,7 @@ func (s *Server) SecretsListHandler(w http.ResponseWriter, r *http.Request) {
 		items = filtered
 	}
 
-	data := s.pageData("Secrets Manager", "secrets")
+	data := s.pageDataWithUser(r,"Secrets Manager", "secrets")
 	data.Content = map[string]any{
 		"Secrets": items,
 		"Filter":  filter,
@@ -68,7 +68,7 @@ func (s *Server) SecretDetailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := s.pageData(name, "secrets")
+	data := s.pageDataWithUser(r,name, "secrets")
 	data.Content = map[string]any{
 		"Detail": detail,
 	}
@@ -100,7 +100,7 @@ func (s *Server) SecretRevealHandler(w http.ResponseWriter, r *http.Request) {
 
 // CreateSecretFormHandler renders the secret creation form.
 func (s *Server) CreateSecretFormHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Create Secret", "secrets")
+	data := s.pageDataWithUser(r,"Create Secret", "secrets")
 	s.templates.Render(w, "secret_create.html", data)
 }
 

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	oidcAuth  *auth.OIDCAuthenticator
 	sessions  *auth.SessionManager
 	orgStore_ *auth.OrgStore
+	wsStore   *auth.WorkspaceStore
 	// IAM (nil when not configured)
 	keycloakAdmin *auth.KeycloakAdminClient
 	opa           *auth.OPAEngine
@@ -54,6 +55,13 @@ func WithAuth(oidc *auth.OIDCAuthenticator, sessions *auth.SessionManager, orgSt
 		s.oidcAuth = oidc
 		s.sessions = sessions
 		s.orgStore_ = orgStore
+	}
+}
+
+// WithWorkspaceStore sets the workspace store.
+func WithWorkspaceStore(wsStore *auth.WorkspaceStore) ServerOption {
+	return func(s *Server) {
+		s.wsStore = wsStore
 	}
 }
 
@@ -219,6 +227,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /auth/login", s.AuthLoginHandler)
 	s.mux.HandleFunc("GET /auth/callback", s.AuthCallbackHandler)
 	s.mux.HandleFunc("GET /auth/logout", s.AuthLogoutHandler)
+	s.mux.HandleFunc("GET /denied", s.DeniedHandler)
 
 	// Page routes
 	s.mux.HandleFunc("GET /{$}", s.DashboardHandler)
@@ -347,15 +356,43 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/settings/endpoints", s.APIGetEndpointsHandler)
 	s.mux.HandleFunc("PUT /api/settings/endpoints", s.APISaveEndpointsHandler)
 
+	// Workspace routes
+	s.mux.HandleFunc("GET /workspaces", s.WorkspacesPageHandler)
+	s.mux.HandleFunc("POST /workspaces", s.CreateWorkspaceHandler)
+	s.mux.HandleFunc("DELETE /workspaces/{id}", s.DeleteWorkspaceHandler)
+	s.mux.HandleFunc("POST /workspaces/{id}/members", s.InviteWorkspaceMemberHandler)
+	s.mux.HandleFunc("DELETE /workspaces/{id}/members/{email}", s.RemoveWorkspaceMemberHandler)
+	s.mux.HandleFunc("POST /workspaces/{id}/members/{email}/role", s.SetWorkspaceMemberRoleHandler)
+	s.mux.HandleFunc("POST /workspaces/{id}/activate", s.SwitchWorkspaceHandler)
+
+	// Workspace API routes
+	s.mux.HandleFunc("GET /api/workspaces", s.APIListWorkspacesHandler)
+	s.mux.HandleFunc("GET /api/workspaces/{id}", s.APIGetWorkspaceHandler)
+	s.mux.HandleFunc("POST /api/workspaces", s.APICreateWorkspaceHandler)
+	s.mux.HandleFunc("DELETE /api/workspaces/{id}", s.APIDeleteWorkspaceHandler)
+	s.mux.HandleFunc("GET /api/workspaces/{id}/members", s.APIListWorkspaceMembersHandler)
+	s.mux.HandleFunc("POST /api/workspaces/{id}/members", s.APIAddWorkspaceMemberHandler)
+	s.mux.HandleFunc("DELETE /api/workspaces/{id}/members/{email}", s.APIRemoveWorkspaceMemberHandler)
+	s.mux.HandleFunc("GET /api/workspaces/{id}/orgs", s.APIListWorkspaceOrgsHandler)
+
 	// Org API routes
 	s.mux.HandleFunc("GET /api/orgs", s.APIListOrgsHandler)
 	s.mux.HandleFunc("GET /api/orgs/{id}", s.APIGetOrgHandler)
 	s.mux.HandleFunc("POST /api/orgs", s.APICreateOrgHandler)
+	s.mux.HandleFunc("DELETE /api/orgs/{id}", s.APIDeleteOrgHandler)
 	s.mux.HandleFunc("GET /api/orgs/{id}/members", s.APIListMembersHandler)
+	s.mux.HandleFunc("POST /api/orgs/{id}/members", s.APIAddMemberHandler)
+	s.mux.HandleFunc("DELETE /api/orgs/{id}/members/{email}", s.APIRemoveMemberHandler)
 
 	// IAM API routes
 	s.mux.HandleFunc("GET /api/audit", s.APIAuditLogHandler)
 	s.mux.HandleFunc("GET /api/users", s.APIKeycloakUsersHandler)
+	s.mux.HandleFunc("POST /api/users", s.APICreateUserHandler)
+	s.mux.HandleFunc("DELETE /api/users/{id}", s.APIDeleteUserHandler)
+	s.mux.HandleFunc("POST /api/users/{id}/toggle", s.APIToggleUserHandler)
+	s.mux.HandleFunc("POST /api/users/{id}/roles", s.APIAssignRoleHandler)
+	s.mux.HandleFunc("DELETE /api/users/{id}/roles", s.APIRemoveRoleHandler)
+	s.mux.HandleFunc("POST /api/users/{id}/password", s.APIResetPasswordHandler)
 	s.mux.HandleFunc("GET /api/policies", s.APIPoliciesHandler)
 	s.mux.HandleFunc("PUT /api/policies", s.APISavePolicyHandler)
 
@@ -376,7 +413,7 @@ func (s *Server) ListenAndServe(addr string) error {
 
 	// OPA authorization (needs user from context → must wrap AFTER InjectUser)
 	if s.opa != nil {
-		handler = auth.OPAMiddleware(s.opa, s.sessions, s.orgStore_, s.auditLog)(handler)
+		handler = auth.OPAMiddleware(s.opa, s.sessions, s.orgStore_, s.wsStore, s.auditLog)(handler)
 	}
 
 	// InjectUser populates user in context (wraps OUTSIDE OPA so it runs first)

--- a/pkg/admin/service_handlers.go
+++ b/pkg/admin/service_handlers.go
@@ -52,7 +52,7 @@ func (s *Server) ServicesListHandler(w http.ResponseWriter, r *http.Request) {
 		catalog = []models.ServiceType{}
 	}
 
-	data := s.pageData("Backing Services", "services")
+	data := s.pageDataWithUser(r,"Backing Services", "services")
 	data.Content = map[string]any{
 		"Services": items,
 		"Catalog":  catalog,
@@ -81,7 +81,7 @@ func (s *Server) ServiceDetailHandler(w http.ResponseWriter, r *http.Request) {
 	// Find plan details from catalog
 	plan, _ := service.FindPlan(inst.ServiceType, inst.Plan)
 
-	data := s.pageData(name, "services")
+	data := s.pageDataWithUser(r,name, "services")
 	data.Content = map[string]any{
 		"Instance": inst,
 		"Plan":     plan,
@@ -142,7 +142,7 @@ func (s *Server) CatalogHandler(w http.ResponseWriter, r *http.Request) {
 		items = append(items, pageItem)
 	}
 
-	data := s.pageData("Service Catalog", "catalog")
+	data := s.pageDataWithUser(r,"Service Catalog", "catalog")
 	data.Content = map[string]any{
 		"Items":              items,
 		"TerraformAvailable": terraform.IsAvailable(),

--- a/pkg/admin/settings_handlers.go
+++ b/pkg/admin/settings_handlers.go
@@ -38,7 +38,7 @@ func (s *Server) RegistrySettingsHandler(w http.ResponseWriter, r *http.Request)
 	ps, _ := store.Get(ctx)
 	hasPwd, _ := store.GetCredential(ctx, "registry-password")
 
-	data := s.pageData("Registry", "settings-registry")
+	data := s.pageDataWithUser(r,"Registry", "settings-registry")
 	data.Content = map[string]any{
 		"Registry":    ps.Registry,
 		"HasPassword": hasPwd != "",
@@ -153,7 +153,7 @@ func (s *Server) WebhooksSettingsHandler(w http.ResponseWriter, r *http.Request)
 
 	ps, _ := store.Get(r.Context())
 
-	data := s.pageData("Webhooks", "settings-webhooks")
+	data := s.pageDataWithUser(r,"Webhooks", "settings-webhooks")
 	data.Content = map[string]any{
 		"Webhooks":   ps.Webhooks,
 		"EventTypes": models.WebhookEventTypes,
@@ -271,7 +271,7 @@ func (s *Server) SMTPSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	ps, _ := store.Get(ctx)
 	hasPwd, _ := store.GetCredential(ctx, "smtp-password")
 
-	data := s.pageData("SMTP", "settings-smtp")
+	data := s.pageDataWithUser(r,"SMTP", "settings-smtp")
 	data.Content = map[string]any{
 		"SMTP":        ps.SMTP,
 		"HasPassword": hasPwd != "",
@@ -478,7 +478,7 @@ func (s *Server) EndpointsSettingsHandler(w http.ResponseWriter, r *http.Request
 	ps, _ := store.Get(ctx)
 	endpoints := client.DiscoverPlatformServices(ctx, client.Domain, ps.Endpoints.Overrides)
 
-	data := s.pageData("Service Endpoints", "settings-endpoints")
+	data := s.pageDataWithUser(r,"Service Endpoints", "settings-endpoints")
 	data.Content = map[string]any{
 		"Endpoints": endpoints,
 		"Domain":    client.Domain,

--- a/pkg/admin/static/templates/denied.html
+++ b/pkg/admin/static/templates/denied.html
@@ -1,0 +1,31 @@
+{{define "denied.html"}}
+<!DOCTYPE html>
+<html lang="en" class="h-full bg-gray-50">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access Denied - MicroFoundry</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="h-full flex items-center justify-center">
+    <div class="max-w-md w-full space-y-8 p-8 text-center">
+        <div class="mx-auto h-16 w-16 bg-red-100 rounded-full flex items-center justify-center">
+            <svg class="w-10 h-10 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
+            </svg>
+        </div>
+        <h2 class="mt-6 text-3xl font-extrabold text-gray-900">Access Denied</h2>
+        <p class="mt-2 text-sm text-gray-600">
+            You do not have permission to access this resource.
+            Contact your platform administrator if you believe this is an error.
+        </p>
+        <div class="mt-6">
+            <a href="/"
+               class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-gray-900 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transition-colors">
+                Back to Dashboard
+            </a>
+        </div>
+    </div>
+</body>
+</html>
+{{end}}

--- a/pkg/admin/static/templates/partials/nav.html
+++ b/pkg/admin/static/templates/partials/nav.html
@@ -15,7 +15,7 @@
         {{end}}
     </div>
     <nav class="flex-1 p-3 space-y-1">
-        <!-- Operations -->
+        <!-- Operations (visible to all authenticated users) -->
         <div class="px-3 pt-3 pb-1">
             <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Operations</span>
         </div>
@@ -52,7 +52,32 @@
             Secrets
         </a>
 
-        <!-- Settings -->
+        <!-- Workspaces (platform-admin + workspace-admin) -->
+        {{if and .User (or (hasRole .User.Roles "platform-admin") (hasRole .User.Roles "workspace-admin"))}}
+        <a href="/workspaces"
+           data-tooltip="Manage workspaces (company-level groupings of organizations)" data-tooltip-pos="right"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "workspaces"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+            </svg>
+            Workspaces
+        </a>
+        {{end}}
+
+        <!-- Users & Orgs (platform-admin + workspace-admin + org-admin) -->
+        {{if and .User (or (hasRole .User.Roles "platform-admin") (hasRole .User.Roles "workspace-admin") (hasRole .User.Roles "org-admin"))}}
+        <a href="/users"
+           data-tooltip="Manage organizations, users, roles, and authorization policies" data-tooltip-pos="right"
+           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
+            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            Users & Orgs
+        </a>
+        {{end}}
+
+        <!-- Settings (platform-admin only) -->
+        {{if and .User (hasRole .User.Roles "platform-admin")}}
         <div class="px-3 pt-5 pb-1">
             <span class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Settings</span>
         </div>
@@ -113,14 +138,6 @@
             </svg>
             Metrics & Alerts
         </a>
-        <a href="/users"
-           data-tooltip="Manage organizations, users, roles, and authorization policies" data-tooltip-pos="right"
-           class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "users"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
-            <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"/>
-            </svg>
-            Users & Orgs
-        </a>
         <a href="/config"
            data-tooltip="View platform-wide configuration and routing" data-tooltip-pos="right"
            class="flex items-center px-3 py-2 rounded-md text-sm font-medium {{if eq .Active "config"}}bg-gray-800 text-white{{else}}hover:bg-gray-800 hover:text-white{{end}}">
@@ -130,6 +147,7 @@
             </svg>
             Platform
         </a>
+        {{end}}
     </nav>
 </aside>
 {{end}}

--- a/pkg/admin/static/templates/tabs/tab_config.html
+++ b/pkg/admin/static/templates/tabs/tab_config.html
@@ -38,26 +38,41 @@
 
     <!-- Resource Limits -->
     <div>
-        <h4 class="text-sm font-medium text-gray-500 mb-3">Resource Limits</h4>
+        <div class="flex items-center justify-between mb-3">
+            <h4 class="text-sm font-medium text-gray-500">Resource Limits</h4>
+            <span class="text-xs text-gray-400">Changing memory or disk will restart the app</span>
+        </div>
         <div class="bg-gray-50 rounded-lg p-4">
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div>
-                    <p class="text-xs text-gray-500">Memory Request</p>
-                    <p class="text-sm font-medium text-gray-900">{{memFmt .MemoryMB}}</p>
+            <form hx-post="/apps/{{.Name}}/scale" hx-swap="none"
+                  hx-on::after-request="if(event.detail.successful) { document.getElementById('resource-save-ok').classList.remove('hidden'); setTimeout(function(){ document.getElementById('resource-save-ok').classList.add('hidden'); }, 3000); }">
+                <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+                    <div>
+                        <label for="memory_mb" class="block text-xs text-gray-500 mb-1">Memory (MB)</label>
+                        <input type="number" name="memory_mb" id="memory_mb" value="{{.MemoryMB}}"
+                               min="64" max="8192" step="64"
+                               class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                    </div>
+                    <div>
+                        <label for="disk_mb" class="block text-xs text-gray-500 mb-1">Disk (MB)</label>
+                        <input type="number" name="disk_mb" id="disk_mb" value="{{.DiskMB}}"
+                               min="256" max="8192" step="256"
+                               class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                    </div>
+                    <div>
+                        <p class="text-xs text-gray-500 mb-1">CPU Request</p>
+                        <p class="text-sm font-medium text-gray-900 py-1.5">{{if .CPUMillis}}{{.CPUMillis}}m{{else}}-{{end}}</p>
+                    </div>
+                    <div class="flex items-end">
+                        <button type="submit"
+                                class="px-4 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                            Save Resources
+                        </button>
+                    </div>
                 </div>
-                <div>
-                    <p class="text-xs text-gray-500">Memory Limit</p>
-                    <p class="text-sm font-medium text-gray-900">{{memFmt .MemoryMB}}</p>
+                <div id="resource-save-ok" class="hidden text-sm text-green-600 font-medium">
+                    Resources updated. App is restarting with new limits.
                 </div>
-                <div>
-                    <p class="text-xs text-gray-500">CPU Request</p>
-                    <p class="text-sm font-medium text-gray-900">{{if .CPUMillis}}{{.CPUMillis}}m{{else}}-{{end}}</p>
-                </div>
-                <div>
-                    <p class="text-xs text-gray-500">CPU Limit</p>
-                    <p class="text-sm font-medium text-gray-900">-</p>
-                </div>
-            </div>
+            </form>
         </div>
     </div>
 

--- a/pkg/admin/static/templates/workspaces.html
+++ b/pkg/admin/static/templates/workspaces.html
@@ -1,0 +1,187 @@
+{{define "workspaces.html"}}
+{{template "layout" .}}
+{{end}}
+
+{{define "content"}}
+{{$c := .Content}}
+{{$user := .User}}
+<div class="space-y-6">
+    {{if not $user}}
+    <div class="bg-white rounded-lg shadow p-12 text-center">
+        <h3 class="text-xl font-bold text-gray-900 mt-2">Workspaces</h3>
+        <p class="text-gray-500 mt-2">Enable authentication to manage workspaces.</p>
+    </div>
+    {{else}}
+    <div class="flex gap-6">
+        <!-- Left: Workspace list -->
+        <div class="w-72 flex-shrink-0">
+            <div class="bg-white rounded-lg shadow">
+                <div class="p-4 border-b border-gray-200 flex items-center justify-between">
+                    <h3 class="font-semibold text-gray-900">Workspaces</h3>
+                </div>
+                <div class="divide-y divide-gray-100">
+                    {{if $c}}
+                    {{with index $c "Workspaces"}}
+                    {{range .}}
+                    <a href="/workspaces?ws={{.ID}}"
+                       class="block px-4 py-3 hover:bg-gray-50 {{if and $c (eq .ID (index $c "SelectedWS"))}}bg-blue-50 border-l-2 border-blue-600{{end}}">
+                        <div class="font-medium text-sm text-gray-900">{{.Name}}</div>
+                        <div class="text-xs text-gray-500">{{.ID}}</div>
+                        {{if and $c (eq .ID (index $c "ActiveWS"))}}
+                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 mt-1">Active</span>
+                        {{end}}
+                    </a>
+                    {{end}}
+                    {{end}}
+                    {{end}}
+                </div>
+                <!-- Create workspace form -->
+                <div class="p-4 border-t border-gray-200">
+                    <form method="POST" action="/workspaces" class="flex gap-2">
+                        <input type="text" name="name" placeholder="New workspace..." required
+                               class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500">
+                        <button type="submit"
+                                class="px-3 py-1.5 bg-gray-900 text-white text-sm rounded-md hover:bg-gray-800">
+                            Create
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Right: Workspace detail -->
+        <div class="flex-1 space-y-6">
+            {{if and $c (index $c "WSDetail")}}
+            {{$ws := index $c "WSDetail"}}
+            <div class="bg-white rounded-lg shadow">
+                <div class="p-6 border-b border-gray-200">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h2 class="text-xl font-bold text-gray-900">{{$ws.Name}}</h2>
+                            <p class="text-sm text-gray-500 mt-1">ID: {{$ws.ID}} &middot; Owner: {{$ws.OwnerEmail}}</p>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            {{if and $c (ne (index $c "ActiveWS") $ws.ID)}}
+                            <form method="POST" action="/workspaces/{{$ws.ID}}/activate">
+                                <button type="submit"
+                                        class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700">
+                                    Set Active
+                                </button>
+                            </form>
+                            {{end}}
+                            <button hx-delete="/workspaces/{{$ws.ID}}"
+                                    hx-confirm="Delete workspace {{$ws.Name}}? This cannot be undone."
+                                    class="px-3 py-1.5 text-sm bg-red-600 text-white rounded-md hover:bg-red-700">
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Members -->
+                <div class="p-6">
+                    <h3 class="font-semibold text-gray-900 mb-4">Members</h3>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
+                                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100">
+                            {{if $c}}{{with index $c "Members"}}
+                            {{range .}}
+                            <tr>
+                                <td class="px-4 py-2 text-sm text-gray-900">{{.Email}}</td>
+                                <td class="px-4 py-2 text-sm text-gray-500">{{.Name}}</td>
+                                <td class="px-4 py-2">
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+                                        {{if eq .Role "admin"}}bg-purple-100 text-purple-800
+                                        {{else if eq .Role "member"}}bg-blue-100 text-blue-800
+                                        {{else}}bg-gray-100 text-gray-800{{end}}">
+                                        {{.Role}}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-2 text-right">
+                                    <button hx-delete="/workspaces/{{$ws.ID}}/members/{{.Email}}"
+                                            hx-confirm="Remove {{.Email}} from workspace?"
+                                            hx-target="closest tr"
+                                            hx-swap="outerHTML"
+                                            class="text-xs text-red-600 hover:text-red-800">Remove</button>
+                                </td>
+                            </tr>
+                            {{end}}
+                            {{end}}{{end}}
+                        </tbody>
+                    </table>
+
+                    <!-- Add member form -->
+                    <form method="POST" action="/workspaces/{{$ws.ID}}/members" class="mt-4 flex gap-2 items-end">
+                        <div>
+                            <label class="text-xs text-gray-500">Email</label>
+                            <input type="email" name="email" required
+                                   class="block px-3 py-1.5 text-sm border border-gray-300 rounded-md">
+                        </div>
+                        <div>
+                            <label class="text-xs text-gray-500">Name</label>
+                            <input type="text" name="name"
+                                   class="block px-3 py-1.5 text-sm border border-gray-300 rounded-md">
+                        </div>
+                        <div>
+                            <label class="text-xs text-gray-500">Role</label>
+                            <select name="role" class="block px-3 py-1.5 text-sm border border-gray-300 rounded-md">
+                                <option value="admin">Admin</option>
+                                <option value="member" selected>Member</option>
+                                <option value="viewer">Viewer</option>
+                            </select>
+                        </div>
+                        <button type="submit"
+                                class="px-3 py-1.5 bg-gray-900 text-white text-sm rounded-md hover:bg-gray-800">
+                            Add Member
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            <!-- Organizations in this workspace -->
+            <div class="bg-white rounded-lg shadow">
+                <div class="p-6">
+                    <h3 class="font-semibold text-gray-900 mb-4">Organizations in this Workspace</h3>
+                    {{if and $c (index $c "Orgs")}}
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                            <tr>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">ID</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Owner</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Namespace</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100">
+                            {{range index $c "Orgs"}}
+                            <tr>
+                                <td class="px-4 py-2 text-sm font-medium text-gray-900">{{.Name}}</td>
+                                <td class="px-4 py-2 text-sm text-gray-500">{{.ID}}</td>
+                                <td class="px-4 py-2 text-sm text-gray-500">{{.OwnerEmail}}</td>
+                                <td class="px-4 py-2 text-sm text-gray-500">{{.Namespace}}</td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                    {{else}}
+                    <p class="text-sm text-gray-500">No organizations in this workspace yet.</p>
+                    {{end}}
+                </div>
+            </div>
+            {{else}}
+            <div class="bg-white rounded-lg shadow p-12 text-center">
+                <p class="text-gray-500">Select a workspace from the list or create a new one.</p>
+            </div>
+            {{end}}
+        </div>
+    </div>
+    {{end}}
+</div>
+{{end}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -132,6 +132,14 @@ func templateFuncs() template.FuncMap {
 			}
 			return fmt.Sprintf("%.2fs", seconds)
 		},
+		"hasRole": func(roles []string, target string) bool {
+			for _, r := range roles {
+				if r == target {
+					return true
+				}
+			}
+			return false
+		},
 	}
 }
 
@@ -176,6 +184,8 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"settings_smtp.html",
 		"settings_endpoints.html",
 		"login.html",
+		"denied.html",
+		"workspaces.html",
 	}
 
 	pages := make(map[string]*template.Template, len(pageFiles)+3)

--- a/pkg/admin/topology_handlers.go
+++ b/pkg/admin/topology_handlers.go
@@ -30,7 +30,7 @@ func (s *Server) TopologiesListHandler(w http.ResponseWriter, r *http.Request) {
 		items = []models.TopologyListItem{}
 	}
 
-	data := s.pageData("Service Topologies", "topologies")
+	data := s.pageDataWithUser(r,"Service Topologies", "topologies")
 	data.Content = map[string]any{
 		"Items":              items,
 		"TerraformAvailable": terraform.IsAvailable(),
@@ -75,7 +75,7 @@ func (s *Server) TopologyDetailHandler(w http.ResponseWriter, r *http.Request) {
 		content["Files"] = topo.Files
 	}
 
-	data := s.pageData(serviceType+"/"+planID, "catalog")
+	data := s.pageDataWithUser(r,serviceType+"/"+planID, "catalog")
 	data.Content = content
 	s.templates.Render(w, "topology_detail.html", data)
 }
@@ -231,7 +231,7 @@ func (s *Server) TopologyPreviewHandler(w http.ResponseWriter, r *http.Request) 
 
 // TopologyUploadHandler shows the upload form.
 func (s *Server) TopologyUploadHandler(w http.ResponseWriter, r *http.Request) {
-	data := s.pageData("Upload Topology", "catalog")
+	data := s.pageDataWithUser(r,"Upload Topology", "catalog")
 	data.Content = map[string]any{
 		"ServiceTypes": service.Catalog(),
 	}

--- a/pkg/admin/workspace_handlers.go
+++ b/pkg/admin/workspace_handlers.go
@@ -1,0 +1,407 @@
+package admin
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/younjinjeong/microfoundry/pkg/auth"
+)
+
+// WorkspacesPageHandler renders the workspace management page.
+func (s *Server) WorkspacesPageHandler(w http.ResponseWriter, r *http.Request) {
+	data := s.pageDataWithUser(r, "Workspaces", "workspaces")
+
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		s.templates.Render(w, "workspaces.html", data)
+		return
+	}
+
+	store := s.wsStore
+	if store == nil {
+		data.Content = map[string]any{"Error": "Workspace store not available"}
+		s.templates.Render(w, "workspaces.html", data)
+		return
+	}
+
+	ctx := r.Context()
+	workspaces, err := store.GetUserWorkspaces(ctx, user.Email)
+	if err != nil {
+		log.Printf("[Workspaces] failed to get user workspaces for %s: %v", user.Email, err)
+	}
+
+	// Platform admins see all workspaces
+	for _, role := range user.Roles {
+		if role == "platform-admin" {
+			workspaces, err = store.List(ctx)
+			if err != nil {
+				log.Printf("[Workspaces] failed to list all workspaces: %v", err)
+			}
+			break
+		}
+	}
+
+	selectedWS := r.URL.Query().Get("ws")
+	if selectedWS == "" && len(workspaces) > 0 {
+		selectedWS = workspaces[0].ID
+	}
+
+	content := map[string]any{
+		"Workspaces":  workspaces,
+		"SelectedWS":  selectedWS,
+		"ActiveWS":    user.ActiveWorkspaceID,
+		"User":        user,
+	}
+
+	if selectedWS != "" {
+		wsDetail, err := store.Get(ctx, selectedWS)
+		if err == nil {
+			content["WSDetail"] = wsDetail
+			members, err := store.ListMembers(ctx, selectedWS)
+			if err != nil {
+				log.Printf("[Workspaces] failed to list members for ws %s: %v", selectedWS, err)
+			}
+			content["Members"] = members
+
+			// List orgs in this workspace
+			if s.orgStore_ != nil {
+				orgs, err := s.orgStore_.ListByWorkspace(ctx, selectedWS)
+				if err != nil {
+					log.Printf("[Workspaces] failed to list orgs for ws %s: %v", selectedWS, err)
+				}
+				content["Orgs"] = orgs
+			}
+
+			userRole := "viewer"
+			for _, m := range members {
+				if m.Email == user.Email {
+					userRole = m.Role
+					break
+				}
+			}
+			content["UserRole"] = userRole
+		}
+	}
+
+	data.Content = content
+	s.templates.Render(w, "workspaces.html", data)
+}
+
+// CreateWorkspaceHandler creates a new workspace.
+func (s *Server) CreateWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	name := r.FormValue("name")
+	if name == "" {
+		http.Error(w, "Workspace name is required", http.StatusBadRequest)
+		return
+	}
+
+	ws, err := s.wsStore.Create(r.Context(), name, user.Email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/workspaces?ws="+ws.ID, http.StatusSeeOther)
+}
+
+// DeleteWorkspaceHandler deletes a workspace.
+func (s *Server) DeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if err := s.wsStore.Delete(r.Context(), wsID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/workspaces")
+	w.WriteHeader(http.StatusOK)
+}
+
+// InviteWorkspaceMemberHandler adds a member to a workspace.
+func (s *Server) InviteWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.FormValue("email")
+	name := r.FormValue("name")
+	role := r.FormValue("role")
+
+	if email == "" {
+		http.Error(w, "Email is required", http.StatusBadRequest)
+		return
+	}
+	if name == "" {
+		name = email
+	}
+	if role == "" {
+		role = "member"
+	}
+
+	if err := s.wsStore.AddMember(r.Context(), wsID, email, name, role); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/workspaces?ws="+wsID, http.StatusSeeOther)
+}
+
+// RemoveWorkspaceMemberHandler removes a member from a workspace.
+func (s *Server) RemoveWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.PathValue("email")
+
+	if err := s.wsStore.RemoveMember(r.Context(), wsID, email); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// SetWorkspaceMemberRoleHandler changes a workspace member's role.
+func (s *Server) SetWorkspaceMemberRoleHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.PathValue("email")
+	role := r.FormValue("role")
+
+	validRoles := map[string]bool{"admin": true, "member": true, "viewer": true}
+	if !validRoles[role] {
+		http.Error(w, "Invalid role", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.wsStore.SetMemberRole(r.Context(), wsID, email, role); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/workspaces?ws="+wsID, http.StatusSeeOther)
+}
+
+// SwitchWorkspaceHandler sets the active workspace for the user's session.
+func (s *Server) SwitchWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	if s.sessions == nil {
+		http.Error(w, "Auth not enabled", http.StatusBadRequest)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if err := s.sessions.SetActiveWorkspace(w, r, wsID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Also set the first org in this workspace as active org
+	if s.orgStore_ != nil {
+		orgs, err := s.orgStore_.ListByWorkspace(r.Context(), wsID)
+		if err == nil && len(orgs) > 0 {
+			_ = s.sessions.SetActiveOrg(w, r, orgs[0].ID)
+		}
+	}
+
+	http.Redirect(w, r, "/workspaces?ws="+wsID, http.StatusSeeOther)
+}
+
+// --- JSON API handlers ---
+
+func (s *Server) APIListWorkspacesHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	workspaces, err := s.wsStore.GetUserWorkspaces(r.Context(), user.Email)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, workspaces)
+}
+
+func (s *Server) APIGetWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	ws, err := s.wsStore.Get(r.Context(), wsID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+
+	members, err := s.wsStore.ListMembers(r.Context(), wsID)
+	if err != nil {
+		log.Printf("[Workspaces] failed to list members for ws %s: %v", wsID, err)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"workspace": ws,
+		"members":   members,
+	})
+}
+
+func (s *Server) APICreateWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+
+	ws, err := s.wsStore.Create(r.Context(), body.Name, user.Email)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, ws)
+}
+
+func (s *Server) APIDeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if err := s.wsStore.Delete(r.Context(), wsID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) APIListWorkspaceMembersHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	members, err := s.wsStore.ListMembers(r.Context(), wsID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, members)
+}
+
+func (s *Server) APIAddWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	var body struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.Email == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+		return
+	}
+	if body.Name == "" {
+		body.Name = body.Email
+	}
+	if body.Role == "" {
+		body.Role = "member"
+	}
+
+	if err := s.wsStore.AddMember(r.Context(), wsID, body.Email, body.Name, body.Role); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]string{"status": "added"})
+}
+
+func (s *Server) APIRemoveWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.PathValue("email")
+
+	if err := s.wsStore.RemoveMember(r.Context(), wsID, email); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) APIListWorkspaceOrgsHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if s.orgStore_ == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "org store not available"})
+		return
+	}
+
+	orgs, err := s.orgStore_.ListByWorkspace(r.Context(), wsID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, orgs)
+}

--- a/pkg/auth/keycloak_setup.go
+++ b/pkg/auth/keycloak_setup.go
@@ -76,7 +76,7 @@ func (kc *KeycloakConfigurator) ConfigureRealm(adminUser, adminPass, clientSecre
 		// Realm already exists — continue
 	}
 
-	// Create client
+	// Create client (with service account for admin API access)
 	client := map[string]any{
 		"clientId":                  "mf-admin",
 		"name":                      "MicroFoundry Admin",
@@ -85,7 +85,8 @@ func (kc *KeycloakConfigurator) ConfigureRealm(adminUser, adminPass, clientSecre
 		"publicClient":              false,
 		"secret":                    clientSecret,
 		"standardFlowEnabled":       true,
-		"directAccessGrantsEnabled": false,
+		"directAccessGrantsEnabled": true,
+		"serviceAccountsEnabled":    true,
 		"redirectUris":              []string{redirectURI},
 		"webOrigins":                []string{"*"},
 		"attributes": map[string]string{
@@ -98,8 +99,11 @@ func (kc *KeycloakConfigurator) ConfigureRealm(adminUser, adminPass, clientSecre
 		}
 	}
 
+	// Assign realm-management roles to the service account for admin API access
+	kc.assignServiceAccountRoles(token, clientSecret)
+
 	// Create realm roles
-	roles := []string{"platform-admin", "org-admin", "org-member", "viewer"}
+	roles := []string{"platform-admin", "workspace-admin", "org-admin", "org-member", "viewer"}
 	for _, role := range roles {
 		roleBody := map[string]any{
 			"name": role,
@@ -141,6 +145,98 @@ func (kc *KeycloakConfigurator) AddIdentityProvider(adminUser, adminPass, provid
 	}
 
 	return nil
+}
+
+// assignServiceAccountRoles grants the mf-admin service account the realm-management roles
+// needed for user CRUD via the Keycloak Admin REST API.
+func (kc *KeycloakConfigurator) assignServiceAccountRoles(token, clientSecret string) {
+	// 1. Find the mf-admin client's internal ID
+	clientInternalID := kc.getJSON(token, "/admin/realms/microfoundry/clients?clientId=mf-admin", "id")
+	if clientInternalID == "" {
+		return
+	}
+
+	// 2. Get the service account user
+	saUserID := kc.getJSON(token, fmt.Sprintf("/admin/realms/microfoundry/clients/%s/service-account-user", clientInternalID), "id")
+	if saUserID == "" {
+		return
+	}
+
+	// 3. Find the realm-management client's internal ID
+	realmMgmtID := kc.getJSON(token, "/admin/realms/microfoundry/clients?clientId=realm-management", "id")
+	if realmMgmtID == "" {
+		return
+	}
+
+	// 4. Get available realm-management client roles
+	rolesURL := fmt.Sprintf("/admin/realms/microfoundry/clients/%s/roles", realmMgmtID)
+	roles := kc.getJSONArray(token, rolesURL)
+
+	// 5. Assign all realm-management roles to the service account
+	if len(roles) > 0 {
+		assignURL := fmt.Sprintf("/admin/realms/microfoundry/users/%s/role-mappings/clients/%s", saUserID, realmMgmtID)
+		_ = kc.post(token, assignURL, roles)
+	}
+}
+
+// getJSON fetches a JSON endpoint and returns the value of a field from the first array element or object.
+func (kc *KeycloakConfigurator) getJSON(token, path, field string) string {
+	req, err := http.NewRequest("GET", kc.baseURL+path, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := kc.httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return ""
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	// Try as array first
+	var arr []map[string]any
+	if json.Unmarshal(body, &arr) == nil && len(arr) > 0 {
+		if v, ok := arr[0][field].(string); ok {
+			return v
+		}
+	}
+
+	// Try as object
+	var obj map[string]any
+	if json.Unmarshal(body, &obj) == nil {
+		if v, ok := obj[field].(string); ok {
+			return v
+		}
+	}
+
+	return ""
+}
+
+// getJSONArray fetches a JSON array endpoint.
+func (kc *KeycloakConfigurator) getJSONArray(token, path string) []map[string]any {
+	req, err := http.NewRequest("GET", kc.baseURL+path, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := kc.httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var arr []map[string]any
+	json.NewDecoder(resp.Body).Decode(&arr)
+	return arr
 }
 
 func (kc *KeycloakConfigurator) post(token, path string, body any) error {

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -10,6 +10,7 @@ type contextKey string
 const (
 	userContextKey contextKey = "mf-user"
 	orgContextKey  contextKey = "mf-org"
+	wsContextKey   contextKey = "mf-workspace"
 )
 
 // UserFromContext returns the authenticated user from the request context, or nil.
@@ -24,6 +25,12 @@ func ActiveOrgFromContext(ctx context.Context) string {
 	return s
 }
 
+// ActiveWorkspaceFromContext returns the active workspace ID from the request context.
+func ActiveWorkspaceFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(wsContextKey).(string)
+	return s
+}
+
 // InjectUser reads the session and adds the user to the request context.
 // Does not block unauthenticated requests.
 func InjectUser(sessions *SessionManager) func(http.Handler) http.Handler {
@@ -33,6 +40,7 @@ func InjectUser(sessions *SessionManager) func(http.Handler) http.Handler {
 			if user != nil {
 				ctx := context.WithValue(r.Context(), userContextKey, user)
 				ctx = context.WithValue(ctx, orgContextKey, user.ActiveOrgID)
+				ctx = context.WithValue(ctx, wsContextKey, user.ActiveWorkspaceID)
 				r = r.WithContext(ctx)
 			}
 			next.ServeHTTP(w, r)
@@ -85,9 +93,9 @@ func RequireOrgRole(minRole string, sessions *SessionManager, orgStore *OrgStore
 				return
 			}
 
-			// Platform admins bypass org role checks
+			// Platform admins and workspace admins bypass org role checks
 			for _, role := range user.Roles {
-				if role == "platform-admin" {
+				if role == "platform-admin" || role == "workspace-admin" {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -19,13 +19,14 @@ type OIDCAuthenticator struct {
 	verifier     *oidc.IDTokenVerifier
 	sessions     *SessionManager
 	orgStore     *OrgStore
+	wsStore      *WorkspaceStore
 	issuerURL    string
 	clientID     string
 }
 
 // NewOIDCAuthenticator creates an authenticator from the auth config.
 // It performs OIDC discovery against the issuer URL.
-func NewOIDCAuthenticator(ctx context.Context, cfg AuthConfig, sessions *SessionManager, orgStore *OrgStore) (*OIDCAuthenticator, error) {
+func NewOIDCAuthenticator(ctx context.Context, cfg AuthConfig, sessions *SessionManager, orgStore *OrgStore, wsStore *WorkspaceStore) (*OIDCAuthenticator, error) {
 	provider, err := oidc.NewProvider(ctx, cfg.IssuerURL)
 	if err != nil {
 		return nil, fmt.Errorf("oidc discovery: %w", err)
@@ -47,6 +48,7 @@ func NewOIDCAuthenticator(ctx context.Context, cfg AuthConfig, sessions *Session
 		verifier:     verifier,
 		sessions:     sessions,
 		orgStore:     orgStore,
+		wsStore:      wsStore,
 		issuerURL:    cfg.IssuerURL,
 		clientID:     cfg.ClientID,
 	}, nil
@@ -145,6 +147,13 @@ func (a *OIDCAuthenticator) CallbackHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	// Ensure default workspace exists for this user
+	ws, err := a.wsStore.EnsureDefaultWorkspace(ctx, claims.Email, name)
+	if err != nil {
+		http.Error(w, "Failed to initialize workspace: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// Ensure default org exists for this user
 	org, err := a.orgStore.EnsureDefaultOrg(ctx, claims.Email, name)
 	if err != nil {
@@ -152,14 +161,22 @@ func (a *OIDCAuthenticator) CallbackHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Associate default org with workspace if not already
+	if org.WorkspaceID == "" {
+		org.WorkspaceID = ws.ID
+		// Best-effort update; don't block login on failure
+		_ = a.orgStore.UpdateWorkspaceID(ctx, org.ID, ws.ID)
+	}
+
 	// Create session
 	user := &UserSession{
-		UserID:        claims.Sub,
-		Email:         claims.Email,
-		Name:          name,
-		Roles:         roles,
-		ActiveOrgID:   org.ID,
-		Authenticated: true,
+		UserID:            claims.Sub,
+		Email:             claims.Email,
+		Name:              name,
+		Roles:             roles,
+		ActiveWorkspaceID: ws.ID,
+		ActiveOrgID:       org.ID,
+		Authenticated:     true,
 	}
 
 	if err := a.sessions.SetUser(w, r, user); err != nil {

--- a/pkg/auth/opa.go
+++ b/pkg/auth/opa.go
@@ -16,20 +16,22 @@ var defaultPolicies embed.FS
 
 // AuthzInput is the input document sent to OPA for authorization decisions.
 type AuthzInput struct {
-	User     *AuthzUser `json:"user"`
-	Action   string     `json:"action"`
-	Resource string     `json:"resource"`
-	OrgID    string     `json:"org_id,omitempty"`
-	Path     string     `json:"path"`
-	Method   string     `json:"method"`
+	User        *AuthzUser `json:"user"`
+	Action      string     `json:"action"`
+	Resource    string     `json:"resource"`
+	OrgID       string     `json:"org_id,omitempty"`
+	WorkspaceID string     `json:"workspace_id,omitempty"`
+	Path        string     `json:"path"`
+	Method      string     `json:"method"`
 }
 
 // AuthzUser represents the user context for OPA evaluation.
 type AuthzUser struct {
-	ID      string   `json:"id"`
-	Email   string   `json:"email"`
-	Roles   []string `json:"roles"`
-	OrgRole string   `json:"org_role"`
+	ID            string   `json:"id"`
+	Email         string   `json:"email"`
+	Roles         []string `json:"roles"`
+	OrgRole       string   `json:"org_role"`
+	WorkspaceRole string   `json:"workspace_role"`
 }
 
 // AuthzResult contains the OPA decision.
@@ -98,12 +100,13 @@ func (e *OPAEngine) Evaluate(ctx context.Context, input AuthzInput) (AuthzResult
 		rego.Query(e.query),
 		rego.Compiler(compiler),
 		rego.Input(map[string]any{
-			"user":     toMap(input.User),
-			"action":   input.Action,
-			"resource": input.Resource,
-			"org_id":   input.OrgID,
-			"path":     input.Path,
-			"method":   input.Method,
+			"user":         toMap(input.User),
+			"action":       input.Action,
+			"resource":     input.Resource,
+			"org_id":       input.OrgID,
+			"workspace_id": input.WorkspaceID,
+			"path":         input.Path,
+			"method":       input.Method,
 		}),
 	)
 
@@ -172,9 +175,10 @@ func toMap(user *AuthzUser) any {
 		return nil
 	}
 	return map[string]any{
-		"id":       user.ID,
-		"email":    user.Email,
-		"roles":    user.Roles,
-		"org_role": user.OrgRole,
+		"id":             user.ID,
+		"email":          user.Email,
+		"roles":          user.Roles,
+		"org_role":       user.OrgRole,
+		"workspace_role": user.WorkspaceRole,
 	}
 }

--- a/pkg/auth/opa_middleware.go
+++ b/pkg/auth/opa_middleware.go
@@ -9,7 +9,7 @@ import (
 
 // OPAMiddleware creates an HTTP middleware that evaluates OPA authorization policies.
 // When opa is nil (auth disabled), all requests are allowed.
-func OPAMiddleware(opa *OPAEngine, sessions *SessionManager, orgStore *OrgStore, auditLog *AuditLog) func(http.Handler) http.Handler {
+func OPAMiddleware(opa *OPAEngine, sessions *SessionManager, orgStore *OrgStore, wsStore *WorkspaceStore, auditLog *AuditLog) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip public paths
@@ -24,7 +24,7 @@ func OPAMiddleware(opa *OPAEngine, sessions *SessionManager, orgStore *OrgStore,
 				return
 			}
 
-			input := buildAuthzInput(r, orgStore)
+			input := buildAuthzInput(r, orgStore, wsStore)
 			result, err := opa.Evaluate(r.Context(), input)
 			if err != nil {
 				http.Error(w, "authorization error", http.StatusInternalServerError)
@@ -59,7 +59,14 @@ func OPAMiddleware(opa *OPAEngine, sessions *SessionManager, orgStore *OrgStore,
 					http.Redirect(w, r, "/login", http.StatusFound)
 					return
 				}
-				http.Error(w, "Forbidden", http.StatusForbidden)
+				// API routes get JSON 403; web routes redirect to denied page
+				if strings.HasPrefix(r.URL.Path, "/api/") {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusForbidden)
+					w.Write([]byte(`{"error":"forbidden"}`))
+					return
+				}
+				http.Redirect(w, r, "/denied", http.StatusFound)
 				return
 			}
 
@@ -82,20 +89,21 @@ func isPublicPath(path string) bool {
 			return true
 		}
 	}
-	return path == "/" || path == "/favicon.ico"
+	return path == "/" || path == "/favicon.ico" || path == "/denied"
 }
 
 // buildAuthzInput constructs the OPA input from the HTTP request context.
-func buildAuthzInput(r *http.Request, orgStore *OrgStore) AuthzInput {
+func buildAuthzInput(r *http.Request, orgStore *OrgStore, wsStore *WorkspaceStore) AuthzInput {
 	user := UserFromContext(r.Context())
 	action, resource := classifyRoute(r.Method, r.URL.Path)
 
 	input := AuthzInput{
-		Action:   action,
-		Resource: resource,
-		OrgID:    ActiveOrgFromContext(r.Context()),
-		Path:     r.URL.Path,
-		Method:   r.Method,
+		Action:      action,
+		Resource:    resource,
+		OrgID:       ActiveOrgFromContext(r.Context()),
+		WorkspaceID: ActiveWorkspaceFromContext(r.Context()),
+		Path:        r.URL.Path,
+		Method:      r.Method,
 	}
 
 	if user != nil {
@@ -112,11 +120,27 @@ func buildAuthzInput(r *http.Request, orgStore *OrgStore) AuthzInput {
 				}
 			}
 		}
+
+		wsRole := ""
+		if wsStore != nil && input.WorkspaceID != "" {
+			members, err := wsStore.ListMembers(r.Context(), input.WorkspaceID)
+			if err != nil {
+				log.Printf("[OPA] failed to list workspace members for ws %s: %v", input.WorkspaceID, err)
+			}
+			for _, m := range members {
+				if m.Email == user.Email {
+					wsRole = m.Role
+					break
+				}
+			}
+		}
+
 		input.User = &AuthzUser{
-			ID:      user.UserID,
-			Email:   user.Email,
-			Roles:   user.Roles,
-			OrgRole: orgRole,
+			ID:            user.UserID,
+			Email:         user.Email,
+			Roles:         user.Roles,
+			OrgRole:       orgRole,
+			WorkspaceRole: wsRole,
 		}
 	}
 
@@ -163,6 +187,8 @@ func classifyRoute(method, path string) (action, resource string) {
 		resource = "settings"
 	case "users":
 		resource = "users"
+	case "workspaces":
+		resource = "workspaces"
 	case "scim":
 		resource = "scim"
 	case "api":
@@ -189,6 +215,8 @@ func classifyRoute(method, path string) (action, resource string) {
 				resource = "settings"
 			case "audit":
 				resource = "audit"
+			case "workspaces":
+				resource = "workspaces"
 			default:
 				resource = parts[1]
 			}

--- a/pkg/auth/org.go
+++ b/pkg/auth/org.go
@@ -21,11 +21,12 @@ const (
 
 // Organization represents a multi-tenant org in MicroFoundry.
 type Organization struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	OwnerEmail string `json:"owner_email"`
-	CreatedAt  string `json:"created_at"`
-	Namespace  string `json:"namespace"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	OwnerEmail  string `json:"owner_email"`
+	CreatedAt   string `json:"created_at"`
+	Namespace   string `json:"namespace"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
 }
 
 // OrgMember represents a user's membership in an organization.
@@ -86,16 +87,40 @@ func (s *OrgStore) Get(ctx context.Context, orgID string) (*Organization, error)
 	return &org, nil
 }
 
+// UpdateWorkspaceID sets the workspace association for an existing organization.
+func (s *OrgStore) UpdateWorkspaceID(ctx context.Context, orgID, workspaceID string) error {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, orgPrefix+orgID, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting org %q: %w", orgID, err)
+	}
+
+	var org Organization
+	if err := json.Unmarshal([]byte(cm.Data["metadata"]), &org); err != nil {
+		return err
+	}
+
+	org.WorkspaceID = workspaceID
+	data, _ := json.Marshal(org)
+	cm.Data["metadata"] = string(data)
+
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating org workspace: %w", err)
+	}
+	return nil
+}
+
 // Create creates a new organization and its K8s namespace.
-func (s *OrgStore) Create(ctx context.Context, name, ownerEmail string) (*Organization, error) {
+// workspaceID is optional; when non-empty the org is associated with a workspace.
+func (s *OrgStore) Create(ctx context.Context, name, ownerEmail, workspaceID string) (*Organization, error) {
 	id := sanitizeID(name)
 
 	org := Organization{
-		ID:         id,
-		Name:       name,
-		OwnerEmail: ownerEmail,
-		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
-		Namespace:  "mf-" + id,
+		ID:          id,
+		Name:        name,
+		OwnerEmail:  ownerEmail,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Namespace:   "mf-" + id,
+		WorkspaceID: workspaceID,
 	}
 
 	orgData, _ := json.Marshal(org)
@@ -328,7 +353,23 @@ func (s *OrgStore) EnsureDefaultOrg(ctx context.Context, email, name string) (*O
 		orgName = email[:idx]
 	}
 
-	return s.Create(ctx, orgName, email)
+	return s.Create(ctx, orgName, email, "")
+}
+
+// ListByWorkspace returns all organizations belonging to a workspace.
+func (s *OrgStore) ListByWorkspace(ctx context.Context, workspaceID string) ([]Organization, error) {
+	allOrgs, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []Organization
+	for _, org := range allOrgs {
+		if org.WorkspaceID == workspaceID {
+			filtered = append(filtered, org)
+		}
+	}
+	return filtered, nil
 }
 
 // sanitizeID converts a name to a valid K8s resource name fragment.

--- a/pkg/auth/policies/authz.rego
+++ b/pkg/auth/policies/authz.rego
@@ -5,59 +5,123 @@ import rego.v1
 default allow := false
 
 # When auth is disabled, user is null — allow public resources only
-# SCIM, settings, clusters, and user management still require authentication
+# SCIM, settings, clusters, workspaces, and user management still require authentication
 allow if {
 	input.user == null
-	not input.resource in {"scim", "settings", "clusters", "users"}
+	not input.resource in {"scim", "settings", "clusters", "users", "workspaces", "monitoring", "config"}
 }
 
-# Platform admins have full access to all resources
+# ─── Platform Admin: full access to all resources ───
 allow if {
 	"platform-admin" in input.user.roles
 }
 
-# Any authenticated user can read any resource
+# ─── Workspace Admin: manages orgs within workspace + operations ───
+
+# Workspace admins can read operations resources
 allow if {
 	input.action == "read"
-	input.user.id != ""
+	"workspace-admin" in input.user.roles
+	input.resource in {"dashboard", "apps", "services", "secrets"}
 }
 
-# Org admins can write/update resources within their org
+# Workspace admins can write/delete operations resources
+allow if {
+	input.action in {"write", "delete"}
+	"workspace-admin" in input.user.roles
+	input.resource in {"apps", "services", "secrets"}
+}
+
+# Workspace admins can manage users, orgs, and workspaces
+allow if {
+	"workspace-admin" in input.user.roles
+	input.resource in {"users", "orgs", "workspaces"}
+}
+
+# Workspace admins can view audit logs
+allow if {
+	input.action == "read"
+	"workspace-admin" in input.user.roles
+	input.resource == "audit"
+}
+
+# ─── Org Admin: operations + org-scoped user management ───
+
+# Org admins can read operations resources
+allow if {
+	input.action == "read"
+	"org-admin" in input.user.roles
+	input.resource in {"dashboard", "apps", "services", "secrets"}
+}
+
+# Org admins can write/delete operations resources
+allow if {
+	input.action in {"write", "delete"}
+	"org-admin" in input.user.roles
+	input.resource in {"apps", "services", "secrets"}
+}
+
+# Org admins can read and manage users/orgs (their own org)
+allow if {
+	"org-admin" in input.user.roles
+	input.resource in {"users", "orgs"}
+}
+
+# Org admins can view audit logs
+allow if {
+	input.action == "read"
+	"org-admin" in input.user.roles
+	input.resource == "audit"
+}
+
+# ─── Org Member: operations only ───
+
+# Org members can read operations resources
+allow if {
+	input.action == "read"
+	"org-member" in input.user.roles
+	input.resource in {"dashboard", "apps", "services", "secrets"}
+}
+
+# Org members can write apps, services, secrets (deploy, bind, create)
 allow if {
 	input.action == "write"
-	input.user.org_role == "admin"
+	"org-member" in input.user.roles
+	input.resource in {"apps", "services", "secrets"}
 }
 
-# Org members can write apps, services, and secrets
+# ─── Fallback: any authenticated user with org_role ───
+
+# Org-level admin role also grants write access (for users without realm roles)
+allow if {
+	input.action in {"write", "delete"}
+	input.user.org_role == "admin"
+	input.resource in {"apps", "services", "secrets", "users", "orgs"}
+}
+
+# Org-level member role grants write for apps/services/secrets
 allow if {
 	input.action == "write"
 	input.user.org_role == "member"
 	input.resource in {"apps", "services", "secrets"}
 }
 
-# SCIM endpoints require platform-admin
+# Any authenticated user with an org_role can read operations resources
 allow if {
-	input.resource == "scim"
-	"platform-admin" in input.user.roles
+	input.action == "read"
+	input.user.id != ""
+	input.resource in {"dashboard", "apps", "services", "secrets"}
 }
 
-# Settings and cluster management require platform-admin for writes
+# ─── Fallback: workspace-level role ───
+
+# Workspace-level admin role grants access to workspaces, orgs, users, and operations
 allow if {
-	input.resource in {"settings", "clusters", "catalog"}
-	input.action in {"write", "delete", "admin"}
-	"platform-admin" in input.user.roles
+	input.user.workspace_role == "admin"
+	input.resource in {"dashboard", "apps", "services", "secrets", "users", "orgs", "workspaces"}
 }
 
-# Delete requires org admin role
-allow if {
-	input.action == "delete"
-	input.user.org_role == "admin"
-	input.resource in {"apps", "services", "secrets"}
-}
+# ─── Settings, clusters, catalog, monitoring, config: platform-admin only ───
+# (Implicitly denied for workspace-admin, org-admin and org-member by default allow := false)
 
-# User/org management: org admins can manage their own org
-allow if {
-	input.resource == "users"
-	input.action == "write"
-	input.user.org_role == "admin"
-}
+# SCIM endpoints require platform-admin (covered by the platform-admin rule above)

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -13,12 +13,13 @@ const sessionName = "mf-session"
 
 // UserSession represents the authenticated user's session data.
 type UserSession struct {
-	UserID        string   `json:"user_id"`
-	Email         string   `json:"email"`
-	Name          string   `json:"name"`
-	Roles         []string `json:"roles"`
-	ActiveOrgID   string   `json:"active_org"`
-	Authenticated bool     `json:"authenticated"`
+	UserID            string   `json:"user_id"`
+	Email             string   `json:"email"`
+	Name              string   `json:"name"`
+	Roles             []string `json:"roles"`
+	ActiveWorkspaceID string   `json:"active_workspace"`
+	ActiveOrgID       string   `json:"active_org"`
+	Authenticated     bool     `json:"authenticated"`
 }
 
 // SessionManager wraps gorilla/sessions for secure cookie management.
@@ -113,6 +114,16 @@ func (sm *SessionManager) GetOAuthState(r *http.Request) (state, verifier string
 	s, _ := session.Values["oauth_state"].(string)
 	v, _ := session.Values["pkce_verifier"].(string)
 	return s, v
+}
+
+// SetActiveWorkspace updates the active workspace in the session.
+func (sm *SessionManager) SetActiveWorkspace(w http.ResponseWriter, r *http.Request, wsID string) error {
+	user, err := sm.GetUser(r)
+	if err != nil || user == nil {
+		return err
+	}
+	user.ActiveWorkspaceID = wsID
+	return sm.SetUser(w, r, user)
 }
 
 // SetActiveOrg updates the active org in the session.

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,0 +1,230 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const tokenFileName = "token.json"
+
+// TokenData holds the persisted CLI authentication token.
+type TokenData struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	Username     string    `json:"username"`
+	Email        string    `json:"email"`
+	Roles        []string  `json:"roles"`
+}
+
+// IsExpired returns true if the access token has expired (with 30s safety margin).
+func (t *TokenData) IsExpired() bool {
+	return time.Now().After(t.ExpiresAt.Add(-30 * time.Second))
+}
+
+// tokenFilePath returns ~/.mf/token.json.
+func tokenFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".mf")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, tokenFileName), nil
+}
+
+// SaveToken writes the token data to ~/.mf/token.json.
+func SaveToken(data *TokenData) error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// LoadToken reads the token data from ~/.mf/token.json.
+func LoadToken() (*TokenData, error) {
+	path, err := tokenFilePath()
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("not logged in — run `mf login` first")
+		}
+		return nil, err
+	}
+	var data TokenData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return nil, fmt.Errorf("corrupted token file: %w", err)
+	}
+	return &data, nil
+}
+
+// ClearToken removes the stored token file.
+func ClearToken() error {
+	path, err := tokenFilePath()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// LoginWithPassword authenticates via Resource Owner Password Credentials grant.
+func LoginWithPassword(issuerURL, clientID, clientSecret, username, password string) (*TokenData, error) {
+	tokenURL := strings.TrimSuffix(issuerURL, "/") + "/protocol/openid-connect/token"
+
+	data := url.Values{
+		"grant_type":    {"password"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"username":      {username},
+		"password":      {password},
+		"scope":         {"openid profile email"},
+	}
+
+	resp, err := http.PostForm(tokenURL, data)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Keycloak: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		errMsg, _ := result["error_description"].(string)
+		if errMsg == "" {
+			errMsg, _ = result["error"].(string)
+		}
+		return nil, fmt.Errorf("authentication failed: %s", errMsg)
+	}
+
+	accessToken, _ := result["access_token"].(string)
+	refreshToken, _ := result["refresh_token"].(string)
+	expiresIn, _ := result["expires_in"].(float64)
+
+	claims, err := parseJWTClaims(accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("parsing token claims: %w", err)
+	}
+
+	return &TokenData{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(expiresIn) * time.Second),
+		Username:     claims.Username,
+		Email:        claims.Email,
+		Roles:        claims.Roles,
+	}, nil
+}
+
+// RefreshToken obtains a new access token using the refresh token.
+func RefreshToken(issuerURL, clientID, clientSecret string, token *TokenData) error {
+	tokenURL := strings.TrimSuffix(issuerURL, "/") + "/protocol/openid-connect/token"
+
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"refresh_token": {token.RefreshToken},
+	}
+
+	resp, err := http.PostForm(tokenURL, data)
+	if err != nil {
+		return fmt.Errorf("connecting to Keycloak: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token refresh failed — run `mf login` again")
+	}
+
+	accessToken, _ := result["access_token"].(string)
+	refreshToken, _ := result["refresh_token"].(string)
+	expiresIn, _ := result["expires_in"].(float64)
+
+	claims, err := parseJWTClaims(accessToken)
+	if err != nil {
+		return fmt.Errorf("parsing token claims: %w", err)
+	}
+
+	token.AccessToken = accessToken
+	token.RefreshToken = refreshToken
+	token.ExpiresAt = time.Now().Add(time.Duration(expiresIn) * time.Second)
+	token.Username = claims.Username
+	token.Email = claims.Email
+	token.Roles = claims.Roles
+	return nil
+}
+
+// jwtClaims holds the relevant fields from a Keycloak JWT.
+type jwtClaims struct {
+	Username string
+	Email    string
+	Roles    []string
+}
+
+// parseJWTClaims extracts claims from a JWT access token without signature verification
+// (the token was just received from Keycloak over HTTPS).
+func parseJWTClaims(token string) (*jwtClaims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decoding JWT payload: %w", err)
+	}
+
+	var raw struct {
+		PreferredUsername string `json:"preferred_username"`
+		Email            string `json:"email"`
+		RealmAccess      struct {
+			Roles []string `json:"roles"`
+		} `json:"realm_access"`
+	}
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, fmt.Errorf("parsing JWT claims: %w", err)
+	}
+
+	// Filter out Keycloak internal roles
+	var roles []string
+	for _, r := range raw.RealmAccess.Roles {
+		if !strings.HasPrefix(r, "default-roles-") && r != "offline_access" && r != "uma_authorization" {
+			roles = append(roles, r)
+		}
+	}
+
+	return &jwtClaims{
+		Username: raw.PreferredUsername,
+		Email:    raw.Email,
+		Roles:    roles,
+	}, nil
+}

--- a/pkg/auth/workspace.go
+++ b/pkg/auth/workspace.go
@@ -1,0 +1,306 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	wsLabelKey   = "microfoundry.io/type"
+	wsLabelValue = "workspace"
+	wsPrefix     = "mf-ws-"
+)
+
+// Workspace represents a company-level grouping that contains organizations.
+type Workspace struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	OwnerEmail string `json:"owner_email"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// WorkspaceMember represents a user's membership in a workspace.
+type WorkspaceMember struct {
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Role     string `json:"role"` // "admin", "member", "viewer"
+	JoinedAt string `json:"joined_at"`
+}
+
+// WorkspaceStore persists workspaces as ConfigMaps in the platform namespace.
+type WorkspaceStore struct {
+	clientset kubernetes.Interface
+	namespace string
+}
+
+// NewWorkspaceStore creates a workspace store backed by K8s ConfigMaps.
+func NewWorkspaceStore(clientset kubernetes.Interface, namespace string) *WorkspaceStore {
+	return &WorkspaceStore{clientset: clientset, namespace: namespace}
+}
+
+// List returns all workspaces.
+func (s *WorkspaceStore) List(ctx context.Context) ([]Workspace, error) {
+	cms, err := s.clientset.CoreV1().ConfigMaps(s.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: wsLabelKey + "=" + wsLabelValue,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing workspaces: %w", err)
+	}
+
+	var workspaces []Workspace
+	for _, cm := range cms.Items {
+		if members := cm.Data["members"]; members != "" {
+			continue // skip member ConfigMaps
+		}
+		var ws Workspace
+		if data := cm.Data["metadata"]; data != "" {
+			if err := json.Unmarshal([]byte(data), &ws); err != nil {
+				continue
+			}
+			workspaces = append(workspaces, ws)
+		}
+	}
+	return workspaces, nil
+}
+
+// Get returns a single workspace by ID.
+func (s *WorkspaceStore) Get(ctx context.Context, wsID string) (*Workspace, error) {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, wsPrefix+wsID, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting workspace %q: %w", wsID, err)
+	}
+
+	var ws Workspace
+	if err := json.Unmarshal([]byte(cm.Data["metadata"]), &ws); err != nil {
+		return nil, err
+	}
+	return &ws, nil
+}
+
+// Create creates a new workspace.
+func (s *WorkspaceStore) Create(ctx context.Context, name, ownerEmail string) (*Workspace, error) {
+	id := sanitizeID(name)
+
+	ws := Workspace{
+		ID:         id,
+		Name:       name,
+		OwnerEmail: ownerEmail,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+
+	wsData, _ := json.Marshal(ws)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wsPrefix + id,
+			Namespace: s.namespace,
+			Labels:    map[string]string{wsLabelKey: wsLabelValue},
+		},
+		Data: map[string]string{
+			"metadata": string(wsData),
+		},
+	}
+
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		if errors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("workspace %q already exists", name)
+		}
+		return nil, fmt.Errorf("creating workspace: %w", err)
+	}
+
+	// Create members ConfigMap with owner
+	owner := WorkspaceMember{
+		Email:    ownerEmail,
+		Name:     ownerEmail,
+		Role:     "admin",
+		JoinedAt: ws.CreatedAt,
+	}
+	membersData, _ := json.Marshal([]WorkspaceMember{owner})
+
+	membersCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wsPrefix + id + "-members",
+			Namespace: s.namespace,
+			Labels:    map[string]string{wsLabelKey: wsLabelValue},
+		},
+		Data: map[string]string{
+			"members": string(membersData),
+		},
+	}
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Create(ctx, membersCM, metav1.CreateOptions{}); err != nil {
+		return nil, fmt.Errorf("creating workspace members: %w", err)
+	}
+
+	return &ws, nil
+}
+
+// Delete removes a workspace and its member list.
+func (s *WorkspaceStore) Delete(ctx context.Context, wsID string) error {
+	_ = s.clientset.CoreV1().ConfigMaps(s.namespace).Delete(ctx, wsPrefix+wsID+"-members", metav1.DeleteOptions{})
+
+	if err := s.clientset.CoreV1().ConfigMaps(s.namespace).Delete(ctx, wsPrefix+wsID, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting workspace: %w", err)
+	}
+	return nil
+}
+
+// ListMembers returns all members of a workspace.
+func (s *WorkspaceStore) ListMembers(ctx context.Context, wsID string) ([]WorkspaceMember, error) {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, wsPrefix+wsID+"-members", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting workspace members: %w", err)
+	}
+
+	var members []WorkspaceMember
+	if err := json.Unmarshal([]byte(cm.Data["members"]), &members); err != nil {
+		return nil, err
+	}
+	return members, nil
+}
+
+// AddMember adds a user to a workspace.
+func (s *WorkspaceStore) AddMember(ctx context.Context, wsID, email, name, role string) error {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, wsPrefix+wsID+"-members", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting workspace members: %w", err)
+	}
+
+	var members []WorkspaceMember
+	if err := json.Unmarshal([]byte(cm.Data["members"]), &members); err != nil {
+		return err
+	}
+
+	for _, m := range members {
+		if m.Email == email {
+			return fmt.Errorf("user %q is already a workspace member", email)
+		}
+	}
+
+	members = append(members, WorkspaceMember{
+		Email:    email,
+		Name:     name,
+		Role:     role,
+		JoinedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+
+	data, _ := json.Marshal(members)
+	cm.Data["members"] = string(data)
+
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating workspace members: %w", err)
+	}
+	return nil
+}
+
+// RemoveMember removes a user from a workspace.
+func (s *WorkspaceStore) RemoveMember(ctx context.Context, wsID, email string) error {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, wsPrefix+wsID+"-members", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting workspace members: %w", err)
+	}
+
+	var members []WorkspaceMember
+	if err := json.Unmarshal([]byte(cm.Data["members"]), &members); err != nil {
+		return err
+	}
+
+	var updated []WorkspaceMember
+	for _, m := range members {
+		if m.Email != email {
+			updated = append(updated, m)
+		}
+	}
+
+	if len(updated) == len(members) {
+		return fmt.Errorf("user %q is not a workspace member", email)
+	}
+
+	data, _ := json.Marshal(updated)
+	cm.Data["members"] = string(data)
+
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating workspace members: %w", err)
+	}
+	return nil
+}
+
+// SetMemberRole changes a workspace member's role.
+func (s *WorkspaceStore) SetMemberRole(ctx context.Context, wsID, email, role string) error {
+	cm, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Get(ctx, wsPrefix+wsID+"-members", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting workspace members: %w", err)
+	}
+
+	var members []WorkspaceMember
+	if err := json.Unmarshal([]byte(cm.Data["members"]), &members); err != nil {
+		return err
+	}
+
+	found := false
+	for i, m := range members {
+		if m.Email == email {
+			members[i].Role = role
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("user %q is not a workspace member", email)
+	}
+
+	data, _ := json.Marshal(members)
+	cm.Data["members"] = string(data)
+
+	if _, err := s.clientset.CoreV1().ConfigMaps(s.namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating workspace members: %w", err)
+	}
+	return nil
+}
+
+// GetUserWorkspaces returns all workspaces a user belongs to.
+func (s *WorkspaceStore) GetUserWorkspaces(ctx context.Context, email string) ([]Workspace, error) {
+	allWS, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var userWS []Workspace
+	for _, ws := range allWS {
+		members, err := s.ListMembers(ctx, ws.ID)
+		if err != nil {
+			continue
+		}
+		for _, m := range members {
+			if m.Email == email {
+				userWS = append(userWS, ws)
+				break
+			}
+		}
+	}
+	return userWS, nil
+}
+
+// EnsureDefaultWorkspace creates a default workspace for a user if they have none.
+func (s *WorkspaceStore) EnsureDefaultWorkspace(ctx context.Context, email, name string) (*Workspace, error) {
+	workspaces, err := s.GetUserWorkspaces(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	if len(workspaces) > 0 {
+		return &workspaces[0], nil
+	}
+
+	wsName := "default"
+	if name != "" {
+		wsName = name
+	}
+
+	return s.Create(ctx, wsName, email)
+}

--- a/pkg/k8s/app.go
+++ b/pkg/k8s/app.go
@@ -214,6 +214,40 @@ func (c *Client) DeleteApp(ctx context.Context, name string) error {
 	return nil
 }
 
+// UpdateAppResources updates the memory and/or disk resource limits for an app.
+// Modifying the pod template spec triggers a rolling restart of all pods.
+func (c *Client) UpdateAppResources(ctx context.Context, name string, memoryMB, diskMB int) error {
+	depAPI := c.Clientset.AppsV1().Deployments(c.Namespace)
+	dep, err := depAPI.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting deployment %s: %w", name, err)
+	}
+
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("deployment %s has no containers", name)
+	}
+
+	container := &dep.Spec.Template.Spec.Containers[0]
+
+	if memoryMB > 0 {
+		container.Resources.Limits[corev1.ResourceMemory] = resource.MustParse(fmt.Sprintf("%dMi", memoryMB))
+		container.Resources.Requests[corev1.ResourceMemory] = resource.MustParse(fmt.Sprintf("%dMi", memoryMB/2))
+	}
+
+	if diskMB > 0 {
+		if dep.Annotations == nil {
+			dep.Annotations = map[string]string{}
+		}
+		dep.Annotations["microfoundry.io/disk-mb"] = strconv.Itoa(diskMB)
+	}
+
+	_, err = depAPI.Update(ctx, dep, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating resources for %s: %w", name, err)
+	}
+	return nil
+}
+
 // ScaleApp updates the replica count for an app.
 func (c *Client) ScaleApp(ctx context.Context, name string, instances int) error {
 	scale, err := c.Clientset.AppsV1().Deployments(c.Namespace).GetScale(ctx, name, metav1.GetOptions{})

--- a/pkg/k8s/keycloak.go
+++ b/pkg/k8s/keycloak.go
@@ -44,7 +44,7 @@ func (c *Client) DeployKeycloak(ctx context.Context, adminUser, adminPass string
 					Containers: []corev1.Container{{
 						Name:  keycloakName,
 						Image: keycloakImage,
-						Args:  []string{"start-dev", "--http-port=8180"},
+						Args:  []string{"start-dev", "--http-port=8180", "--health-enabled=true"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: int32(keycloakPort),
 							Protocol:      corev1.ProtocolTCP,
@@ -70,7 +70,7 @@ func (c *Client) DeployKeycloak(ctx context.Context, adminUser, adminPass string
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
 									Path: "/health/ready",
-									Port: intstr.FromInt32(int32(keycloakPort)),
+									Port: intstr.FromInt32(9000),
 								},
 							},
 							InitialDelaySeconds: 30,


### PR DESCRIPTION
## Summary

- **Workspace hierarchy**: Workspace > Organization > Application with full CRUD, member management, and K8s ConfigMap persistence
- **5-tier RBAC**: platform-admin > workspace-admin > org-admin > org-member > viewer with OPA Rego policies
- **CLI authentication**: `mf login/logout/whoami` with OIDC token flow and auto-refresh
- **Role-based navigation**: Conditional menu visibility based on user roles (Settings for platform-admin only, Workspaces for workspace-admin+, Users & Orgs for org-admin+)
- **CLI workspace commands**: `mf workspaces list/create/delete/members/add-member/remove-member/set-role/orgs`
- **Web UI**: Workspace management page, access denied page, IAM tab handlers

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `mf login --username myadmin --password Admin1234` obtains token
- [ ] `mf whoami` shows user, roles, active org/workspace
- [ ] `mf workspaces create --name "Acme" --owner admin@example.com` creates workspace
- [ ] `mf workspaces orgs acme` lists orgs in workspace
- [ ] Platform-admin sees all menus; workspace-admin sees Operations + Workspaces + Users & Orgs; org-member sees Operations only
- [ ] OPA denies org-member access to Settings resources

Resolves: Epic #62 | Foundation for: Epic #63 (IAM Policy Engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)