### PR TITLE
feat: add Workspaces tab to IAM page

### DIFF
--- a/pkg/admin/iam_handlers.go
+++ b/pkg/admin/iam_handlers.go
@@ -14,10 +14,11 @@ func (s *Server) IAMTabHandler(w http.ResponseWriter, r *http.Request) {
 	tab := r.PathValue("tab")
 
 	validIAMTabs := map[string]string{
-		"orgs":     "tab_iam_orgs.html",
-		"users":    "tab_iam_users.html",
-		"policies": "tab_iam_policies.html",
-		"audit":    "tab_iam_audit.html",
+		"workspaces": "tab_iam_workspaces.html",
+		"orgs":       "tab_iam_orgs.html",
+		"users":      "tab_iam_users.html",
+		"policies":   "tab_iam_policies.html",
+		"audit":      "tab_iam_audit.html",
 	}
 
 	templateName, ok := validIAMTabs[tab]
@@ -27,6 +28,8 @@ func (s *Server) IAMTabHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch tab {
+	case "workspaces":
+		s.renderIAMWorkspacesTab(w, r)
 	case "orgs":
 		s.renderIAMOrgsTab(w, r)
 	case "users":
@@ -36,6 +39,245 @@ func (s *Server) IAMTabHandler(w http.ResponseWriter, r *http.Request) {
 	case "audit":
 		s.renderIAMAuditTab(w, r, templateName)
 	}
+}
+
+// renderIAMWorkspacesTab renders the workspaces tab content.
+func (s *Server) renderIAMWorkspacesTab(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	data := map[string]any{}
+
+	if user != nil {
+		store := s.wsStore
+		if store == nil {
+			data["Error"] = "Workspace store not available"
+			s.templates.RenderPartial(w, "tab_iam_workspaces.html", data)
+			return
+		}
+
+		ctx := r.Context()
+		workspaces, err := store.GetUserWorkspaces(ctx, user.Email)
+		if err != nil {
+			log.Printf("[IAM] failed to get user workspaces for %s: %v", user.Email, err)
+			data["Error"] = "Failed to load workspaces"
+		}
+
+		// Platform admins see all workspaces
+		for _, role := range user.Roles {
+			if role == "platform-admin" {
+				workspaces, err = store.List(ctx)
+				if err != nil {
+					log.Printf("[IAM] failed to list all workspaces: %v", err)
+				}
+				break
+			}
+		}
+
+		selectedWS := r.URL.Query().Get("ws")
+		if selectedWS == "" && len(workspaces) > 0 {
+			selectedWS = workspaces[0].ID
+		}
+
+		data["Workspaces"] = workspaces
+		data["SelectedWS"] = selectedWS
+		data["ActiveWS"] = user.ActiveWorkspaceID
+		data["User"] = user
+
+		if selectedWS != "" {
+			wsDetail, err := store.Get(ctx, selectedWS)
+			if err == nil {
+				data["WSDetail"] = wsDetail
+				members, err := store.ListMembers(ctx, selectedWS)
+				if err != nil {
+					log.Printf("[IAM] failed to list members for ws %s: %v", selectedWS, err)
+				}
+				data["Members"] = members
+
+				// List orgs in this workspace
+				if s.orgStore_ != nil {
+					orgs, err := s.orgStore_.ListByWorkspace(ctx, selectedWS)
+					if err != nil {
+						log.Printf("[IAM] failed to list orgs for ws %s: %v", selectedWS, err)
+					}
+					data["Orgs"] = orgs
+				}
+
+				userRole := "viewer"
+				for _, m := range members {
+					if m.Email == user.Email {
+						userRole = m.Role
+						break
+					}
+				}
+				data["UserRole"] = userRole
+			}
+		}
+	}
+
+	s.templates.RenderPartial(w, "tab_iam_workspaces.html", data)
+}
+
+// --- IAM Workspace CRUD handlers (redirect back to /users?tab=workspaces) ---
+
+// IAMCreateWorkspaceHandler creates a workspace and redirects to the workspaces tab.
+func (s *Server) IAMCreateWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.wsStore == nil {
+		http.Error(w, "Workspace store not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	name := r.FormValue("name")
+	if name == "" {
+		http.Error(w, "Workspace name is required", http.StatusBadRequest)
+		return
+	}
+
+	ws, err := s.wsStore.Create(r.Context(), name, user.Email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/users?tab=workspaces&ws="+ws.ID, http.StatusSeeOther)
+}
+
+// IAMDeleteWorkspaceHandler deletes a workspace and redirects to the workspaces tab.
+func (s *Server) IAMDeleteWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.wsStore == nil {
+		http.Error(w, "Workspace store not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if err := s.wsStore.Delete(r.Context(), wsID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("HX-Redirect", "/users?tab=workspaces")
+	w.WriteHeader(http.StatusOK)
+}
+
+// IAMInviteWorkspaceMemberHandler adds a member to a workspace.
+func (s *Server) IAMInviteWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.wsStore == nil {
+		http.Error(w, "Workspace store not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.FormValue("email")
+	name := r.FormValue("name")
+	role := r.FormValue("role")
+
+	if email == "" {
+		http.Error(w, "Email is required", http.StatusBadRequest)
+		return
+	}
+	if name == "" {
+		name = email
+	}
+	if role == "" {
+		role = "member"
+	}
+
+	if err := s.wsStore.AddMember(r.Context(), wsID, email, name, role); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/users?tab=workspaces&ws="+wsID, http.StatusSeeOther)
+}
+
+// IAMRemoveWorkspaceMemberHandler removes a member from a workspace.
+func (s *Server) IAMRemoveWorkspaceMemberHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.wsStore == nil {
+		http.Error(w, "Workspace store not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.PathValue("email")
+
+	if err := s.wsStore.RemoveMember(r.Context(), wsID, email); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// IAMSetWorkspaceMemberRoleHandler changes a workspace member's role.
+func (s *Server) IAMSetWorkspaceMemberRoleHandler(w http.ResponseWriter, r *http.Request) {
+	user := auth.UserFromContext(r.Context())
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if s.wsStore == nil {
+		http.Error(w, "Workspace store not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	email := r.PathValue("email")
+	role := r.FormValue("role")
+
+	validRoles := map[string]bool{"admin": true, "member": true, "viewer": true}
+	if !validRoles[role] {
+		http.Error(w, "Invalid role", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.wsStore.SetMemberRole(r.Context(), wsID, email, role); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	http.Redirect(w, r, "/users?tab=workspaces&ws="+wsID, http.StatusSeeOther)
+}
+
+// IAMSwitchWorkspaceHandler sets the active workspace.
+func (s *Server) IAMSwitchWorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	if s.sessions == nil {
+		http.Error(w, "Auth not enabled", http.StatusBadRequest)
+		return
+	}
+
+	wsID := r.PathValue("id")
+	if err := s.sessions.SetActiveWorkspace(w, r, wsID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Also set the first org in this workspace as active org
+	if s.orgStore_ != nil {
+		orgs, err := s.orgStore_.ListByWorkspace(r.Context(), wsID)
+		if err == nil && len(orgs) > 0 {
+			_ = s.sessions.SetActiveOrg(w, r, orgs[0].ID)
+		}
+	}
+
+	http.Redirect(w, r, "/users?tab=workspaces&ws="+wsID, http.StatusSeeOther)
 }
 
 // renderIAMOrgsTab renders the organizations tab content.

--- a/pkg/admin/org_handlers.go
+++ b/pkg/admin/org_handlers.go
@@ -34,6 +34,59 @@ func (s *Server) OrgsPageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch tab {
+	case "workspaces":
+		if s.wsStore != nil {
+			ctx := r.Context()
+			workspaces, err := s.wsStore.GetUserWorkspaces(ctx, user.Email)
+			if err != nil {
+				log.Printf("[IAM] failed to get user workspaces for %s: %v", user.Email, err)
+				content["Error"] = "Failed to load workspaces"
+			}
+			// Platform admins see all workspaces
+			for _, role := range user.Roles {
+				if role == "platform-admin" {
+					workspaces, err = s.wsStore.List(ctx)
+					if err != nil {
+						log.Printf("[IAM] failed to list all workspaces: %v", err)
+					}
+					break
+				}
+			}
+			selectedWS := r.URL.Query().Get("ws")
+			if selectedWS == "" && len(workspaces) > 0 {
+				selectedWS = workspaces[0].ID
+			}
+			content["Workspaces"] = workspaces
+			content["SelectedWS"] = selectedWS
+			content["ActiveWS"] = user.ActiveWorkspaceID
+			if selectedWS != "" {
+				wsDetail, err := s.wsStore.Get(ctx, selectedWS)
+				if err == nil {
+					content["WSDetail"] = wsDetail
+					members, err := s.wsStore.ListMembers(ctx, selectedWS)
+					if err != nil {
+						log.Printf("[IAM] failed to list members for ws %s: %v", selectedWS, err)
+					}
+					content["Members"] = members
+					if s.orgStore_ != nil {
+						orgs, err := s.orgStore_.ListByWorkspace(ctx, selectedWS)
+						if err != nil {
+							log.Printf("[IAM] failed to list orgs for ws %s: %v", selectedWS, err)
+						}
+						content["Orgs"] = orgs
+					}
+					userRole := "viewer"
+					for _, m := range members {
+						if m.Email == user.Email {
+							userRole = m.Role
+							break
+						}
+					}
+					content["UserRole"] = userRole
+				}
+			}
+		}
+
 	case "orgs":
 		ctx := r.Context()
 		store := s.orgStore()

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -267,6 +267,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("DELETE /users/keycloak/{id}", s.DeleteKeycloakUserHandler)
 	s.mux.HandleFunc("POST /users/keycloak/{id}/toggle", s.ToggleKeycloakUserHandler)
 	s.mux.HandleFunc("POST /users/keycloak/{id}/roles", s.AssignKeycloakRoleHandler)
+	// IAM — Workspace management (within /users tab)
+	s.mux.HandleFunc("POST /users/workspaces", s.IAMCreateWorkspaceHandler)
+	s.mux.HandleFunc("DELETE /users/workspaces/{id}", s.IAMDeleteWorkspaceHandler)
+	s.mux.HandleFunc("POST /users/workspaces/{id}/members", s.IAMInviteWorkspaceMemberHandler)
+	s.mux.HandleFunc("DELETE /users/workspaces/{id}/members/{email}", s.IAMRemoveWorkspaceMemberHandler)
+	s.mux.HandleFunc("POST /users/workspaces/{id}/members/{email}/role", s.IAMSetWorkspaceMemberRoleHandler)
+	s.mux.HandleFunc("POST /users/workspaces/{id}/activate", s.IAMSwitchWorkspaceHandler)
 	// IAM — OPA policies
 	s.mux.HandleFunc("POST /users/policies", s.SavePolicyHandler)
 

--- a/pkg/admin/static/templates/tabs/tab_iam_workspaces.html
+++ b/pkg/admin/static/templates/tabs/tab_iam_workspaces.html
@@ -1,0 +1,248 @@
+{{define "tab_iam_workspaces.html"}}
+{{$user := .User}}
+<div class="space-y-4">
+    {{if not $user}}
+    <div class="bg-gray-50 rounded-lg p-8 text-center">
+        <p class="text-gray-500">Sign in to manage workspaces.</p>
+    </div>
+    {{else}}
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <!-- Left Panel: Workspace List -->
+        <div class="lg:col-span-1 space-y-4">
+            <div class="bg-white rounded-lg border border-gray-200">
+                <div class="p-4 border-b border-gray-200 flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-gray-900">Workspaces</h3>
+                    <button onclick="document.getElementById('create-ws-form').classList.toggle('hidden')"
+                            data-tooltip="Create a new workspace"
+                            class="text-sm px-3 py-1.5 bg-gray-900 text-white rounded-md hover:bg-gray-800">
+                        + New
+                    </button>
+                </div>
+
+                <!-- Create Workspace Form -->
+                <div id="create-ws-form" class="hidden p-4 bg-gray-50 border-b border-gray-200">
+                    <form method="POST" action="/users/workspaces" class="space-y-3">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Workspace Name</label>
+                            <input type="text" name="name" required
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm p-2 border focus:ring-blue-500 focus:border-blue-500"
+                                   placeholder="my-company">
+                        </div>
+                        <div class="flex space-x-2">
+                            <button type="submit" data-tooltip="Create the workspace" data-tooltip-pos="top" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Create</button>
+                            <button type="button" onclick="document.getElementById('create-ws-form').classList.add('hidden')"
+                                    class="px-3 py-1.5 bg-white text-gray-700 text-sm rounded-md border hover:bg-gray-50">Cancel</button>
+                        </div>
+                    </form>
+                </div>
+
+                <!-- Workspace List -->
+                <div class="divide-y divide-gray-100">
+                    {{range .Workspaces}}
+                    <a href="/users?tab=workspaces&ws={{.ID}}"
+                       class="flex items-center justify-between p-4 hover:bg-gray-50 {{if eq .ID (index $ "SelectedWS")}}bg-blue-50 border-l-2 border-blue-600{{end}}">
+                        <div>
+                            <div class="text-sm font-medium text-gray-900">{{.Name}}</div>
+                            <div class="text-xs text-gray-500">{{.ID}}</div>
+                        </div>
+                        <div class="flex items-center space-x-2">
+                            {{if eq .OwnerEmail $user.Email}}
+                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">owner</span>
+                            {{end}}
+                            {{if eq .ID (index $ "ActiveWS")}}
+                            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">active</span>
+                            {{end}}
+                        </div>
+                    </a>
+                    {{else}}
+                    <div class="p-4 text-sm text-gray-500 text-center">No workspaces yet</div>
+                    {{end}}
+                </div>
+            </div>
+        </div>
+
+        <!-- Right Panel: Workspace Detail -->
+        <div class="lg:col-span-2">
+            {{if .WSDetail}}
+            {{$ws := .WSDetail}}
+            {{$members := .Members}}
+            {{$userRole := .UserRole}}
+            <div class="bg-white rounded-lg border border-gray-200">
+                <!-- Workspace Header -->
+                <div class="p-6 border-b border-gray-200">
+                    <div class="flex items-center justify-between">
+                        <div>
+                            <h3 class="text-xl font-bold text-gray-900">{{$ws.Name}}</h3>
+                            <p class="text-sm text-gray-500 mt-1">
+                                ID: <code class="bg-gray-100 px-1.5 py-0.5 rounded">{{$ws.ID}}</code>
+                                &middot; Owner: {{$ws.OwnerEmail}}
+                            </p>
+                        </div>
+                        <div class="flex items-center space-x-2">
+                            {{if ne (index $ "ActiveWS") $ws.ID}}
+                            <form method="POST" action="/users/workspaces/{{$ws.ID}}/activate">
+                                <button type="submit" data-tooltip="Set this as the active workspace" data-tooltip-pos="top" class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">
+                                    Set Active
+                                </button>
+                            </form>
+                            {{else}}
+                            <span class="inline-flex items-center px-3 py-1.5 rounded-md text-sm font-medium bg-green-100 text-green-800">
+                                Active Workspace
+                            </span>
+                            {{end}}
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Members Table -->
+                <div class="p-6">
+                    <h4 class="text-lg font-semibold text-gray-900 mb-4">Members</h4>
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">User</th>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Joined</th>
+                                {{if eq $userRole "admin"}}
+                                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                                {{end}}
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {{range $members}}
+                            <tr>
+                                <td class="px-4 py-3">
+                                    <div class="flex items-center">
+                                        <div class="h-8 w-8 rounded-full bg-gray-200 flex items-center justify-center text-sm font-medium text-gray-600">
+                                            {{slice .Email 0 1}}
+                                        </div>
+                                        <div class="ml-3">
+                                            <div class="text-sm font-medium text-gray-900">{{.Name}}</div>
+                                            <div class="text-xs text-gray-500">{{.Email}}</div>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="px-4 py-3">
+                                    {{if eq .Role "admin"}}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">admin</span>
+                                    {{else if eq .Role "member"}}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">member</span>
+                                    {{else}}
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">viewer</span>
+                                    {{end}}
+                                </td>
+                                <td class="px-4 py-3 text-sm text-gray-500">{{.JoinedAt}}</td>
+                                {{if eq $userRole "admin"}}
+                                <td class="px-4 py-3 text-right space-x-2">
+                                    {{if ne .Email $ws.OwnerEmail}}
+                                    <form method="POST" action="/users/workspaces/{{$ws.ID}}/members/{{.Email}}/role" class="inline">
+                                        <select name="role" onchange="this.form.submit()" class="text-xs border-gray-300 rounded py-1 px-2">
+                                            <option value="admin" {{if eq .Role "admin"}}selected{{end}}>Admin</option>
+                                            <option value="member" {{if eq .Role "member"}}selected{{end}}>Member</option>
+                                            <option value="viewer" {{if eq .Role "viewer"}}selected{{end}}>Viewer</option>
+                                        </select>
+                                    </form>
+                                    <button hx-delete="/users/workspaces/{{$ws.ID}}/members/{{.Email}}"
+                                            hx-confirm="Remove {{.Email}} from this workspace?"
+                                            hx-target="closest tr" hx-swap="outerHTML"
+                                            data-tooltip="Remove this user from the workspace" data-tooltip-pos="top"
+                                            class="text-red-600 hover:text-red-800 text-xs">Remove</button>
+                                    {{else}}
+                                    <span class="text-xs text-gray-400">Owner</span>
+                                    {{end}}
+                                </td>
+                                {{end}}
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                </div>
+
+                <!-- Invite Member -->
+                {{if eq $userRole "admin"}}
+                <div class="p-6 border-t border-gray-200 bg-gray-50">
+                    <h4 class="text-sm font-semibold text-gray-900 mb-3">Invite Member</h4>
+                    <form method="POST" action="/users/workspaces/{{$ws.ID}}/members" class="flex items-end space-x-3">
+                        <div class="flex-1">
+                            <label class="block text-xs font-medium text-gray-700">Email</label>
+                            <input type="email" name="email" required
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm p-2 border focus:ring-blue-500 focus:border-blue-500"
+                                   placeholder="user@example.com">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-gray-700">Name</label>
+                            <input type="text" name="name"
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm p-2 border focus:ring-blue-500 focus:border-blue-500"
+                                   placeholder="Display name">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-gray-700">Role</label>
+                            <select name="role" class="mt-1 block rounded-md border-gray-300 shadow-sm text-sm p-2 border">
+                                <option value="member">Member</option>
+                                <option value="admin">Admin</option>
+                                <option value="viewer">Viewer</option>
+                            </select>
+                        </div>
+                        <button type="submit" data-tooltip="Add a user to this workspace" data-tooltip-pos="top" class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">Invite</button>
+                    </form>
+                </div>
+                {{end}}
+
+                <!-- Organizations in this Workspace -->
+                <div class="p-6 border-t border-gray-200">
+                    <h4 class="text-lg font-semibold text-gray-900 mb-4">Organizations</h4>
+                    {{if .Orgs}}
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Namespace</th>
+                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Owner</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {{range .Orgs}}
+                            <tr>
+                                <td class="px-4 py-3">
+                                    <a href="/users?tab=orgs&org={{.ID}}" class="text-sm font-medium text-blue-600 hover:text-blue-800">{{.Name}}</a>
+                                </td>
+                                <td class="px-4 py-3 text-sm text-gray-500">
+                                    <code class="bg-gray-100 px-1.5 py-0.5 rounded">{{.Namespace}}</code>
+                                </td>
+                                <td class="px-4 py-3 text-sm text-gray-500">{{.OwnerEmail}}</td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                    {{else}}
+                    <p class="text-sm text-gray-500">No organizations in this workspace yet. Create one from the Organizations tab.</p>
+                    {{end}}
+                </div>
+
+                <!-- Danger Zone -->
+                {{if eq $userRole "admin"}}
+                <div class="p-6 border-t border-red-200 bg-red-50 rounded-b-lg">
+                    <h4 class="text-sm font-semibold text-red-900 mb-2">Danger Zone</h4>
+                    <p class="text-xs text-red-700 mb-3">Deleting a workspace removes its member list. Organizations within it are not deleted.</p>
+                    <button hx-delete="/users/workspaces/{{$ws.ID}}"
+                            hx-confirm="Delete workspace '{{$ws.Name}}'? This cannot be undone."
+                            data-tooltip="Delete this workspace" data-tooltip-pos="top"
+                            class="px-3 py-1.5 bg-red-600 text-white text-sm rounded-md hover:bg-red-700">
+                        Delete Workspace
+                    </button>
+                </div>
+                {{end}}
+            </div>
+            {{else}}
+            <div class="bg-white rounded-lg border border-gray-200 p-12 text-center">
+                <svg class="w-12 h-12 mx-auto mb-3 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                </svg>
+                <p class="text-gray-500">Select a workspace to view details</p>
+            </div>
+            {{end}}
+        </div>
+    </div>
+    {{end}}
+</div>
+{{end}}

--- a/pkg/admin/static/templates/users.html
+++ b/pkg/admin/static/templates/users.html
@@ -29,6 +29,14 @@
     <div class="bg-white rounded-lg shadow">
         <div class="border-b border-gray-200">
             <nav class="flex -mb-px overflow-x-auto" aria-label="Tabs">
+                <a href="/users?tab=workspaces"
+                   hx-get="/users/tab/workspaces"
+                   hx-target="#tab-content"
+                   hx-push-url="/users?tab=workspaces"
+                   class="whitespace-nowrap py-4 px-6 font-medium text-sm border-b-2 {{if eq $tab "workspaces"}}border-blue-600 text-blue-600{{else}}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{{end}}"
+                   data-tooltip="Manage workspaces (company-level groupings)">
+                    Workspaces
+                </a>
                 <a href="/users?tab=orgs"
                    hx-get="/users/tab/orgs"
                    hx-target="#tab-content"
@@ -82,7 +90,9 @@
             })();
         </script>
         <div id="tab-content" class="p-6">
-            {{if eq $tab "orgs"}}
+            {{if eq $tab "workspaces"}}
+                {{template "tab_iam_workspaces.html" $c}}
+            {{else if eq $tab "orgs"}}
                 {{template "tab_iam_orgs.html" $c}}
             {{else if eq $tab "users"}}
                 {{template "tab_iam_users.html" $c}}

--- a/pkg/admin/templates.go
+++ b/pkg/admin/templates.go
@@ -216,10 +216,11 @@ func NewTemplateRenderer() *TemplateRenderer {
 		"tab_performance.html":  base,
 		"alerts_list.html":      base,
 		"log_history.html":      base,
-		"tab_iam_orgs.html":     base,
-		"tab_iam_users.html":    base,
-		"tab_iam_policies.html": base,
-		"tab_iam_audit.html":    base,
+		"tab_iam_workspaces.html": base,
+		"tab_iam_orgs.html":      base,
+		"tab_iam_users.html":     base,
+		"tab_iam_policies.html":  base,
+		"tab_iam_audit.html":     base,
 	}
 
 	return &TemplateRenderer{base: base, pages: pages, partials: partials}


### PR DESCRIPTION
## Summary
- Adds a **Workspaces** tab as the first tab in the `/users` (Users & Orgs) IAM page
- Workspace management is now accessible directly within the IAM interface, following the same layout pattern as the Organizations tab
- Includes full CRUD: create/delete workspaces, invite/remove members, set roles, activate workspace, and view organizations within each workspace

## Changes
| File | Description |
|------|-------------|
| `users.html` | Add Workspaces tab link before Organizations |
| `tab_iam_workspaces.html` | **New** — Tab partial with 3-column workspace management UI |
| `iam_handlers.go` | Add `renderIAMWorkspacesTab` + 6 IAM CRUD handlers |
| `org_handlers.go` | Add `workspaces` case to `OrgsPageHandler` for full-page loads |
| `server.go` | Register 6 `/users/workspaces/*` routes |
| `templates.go` | Register new tab partial |

## Test plan
- [ ] Navigate to `/users` — Workspaces should be the first tab
- [ ] Click Workspaces tab — should show workspace list and detail panel
- [ ] Create a workspace — should appear in the list
- [ ] Invite/remove members — member table updates correctly
- [ ] Set active workspace — badge shows "active"
- [ ] Delete workspace — workspace removed from list
- [ ] Organizations within workspace link to the Orgs tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)