### PR TITLE
fix: enable docs heading anchor links

### DIFF
--- a/pkg/admin/handlers.go
+++ b/pkg/admin/handlers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
 	"github.com/younjinjeong/microfoundry/docs"
 	"github.com/younjinjeong/microfoundry/pkg/auth"
 	"github.com/younjinjeong/microfoundry/pkg/models"
@@ -559,8 +560,14 @@ func (s *Server) DocsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	mdParser := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+	)
+
 	var buf bytes.Buffer
-	if err := goldmark.Convert(md, &buf); err != nil {
+	if err := mdParser.Convert(md, &buf); err != nil {
 		http.Error(w, "markdown render error: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/admin/static/templates/docs.html
+++ b/pkg/admin/static/templates/docs.html
@@ -301,9 +301,11 @@
     if (headings.length === 0) return;
 
     headings.forEach(function(h, i) {
-        // Create anchor ID
-        const id = 'heading-' + i;
-        h.id = id;
+        // Use goldmark-generated ID, or create a fallback
+        if (!h.id) {
+            h.id = 'heading-' + i;
+        }
+        const id = h.id;
 
         const level = parseInt(h.tagName.charAt(1));
         const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- Enable `parser.WithAutoHeadingID()` in goldmark so markdown headings get proper IDs (e.g., `authentication--iam`)
- Update JS TOC builder to preserve goldmark-generated IDs instead of overwriting with `heading-N`
- Fixes: clicking TOC links and in-document anchors (`#section-name`) now scrolls to the correct heading

## Test plan
- [ ] Navigate to https://admin.cf-local.dev:8443/docs?tab=manual
- [ ] Click a TOC sidebar link — page should scroll to the heading
- [ ] Click an in-document anchor link (e.g., `#authentication--iam`) — should jump to section
- [ ] Verify all 6 doc tabs render correctly with heading anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)