### PR TITLE
fix: replace broken shields.io badges with static versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![CI](https://github.com/younjinjeong/microfoundry/actions/workflows/ci.yml/badge.svg?branch=rc)](https://github.com/younjinjeong/microfoundry/actions/workflows/ci.yml)
 [![Release](https://github.com/younjinjeong/microfoundry/actions/workflows/release.yml/badge.svg)](https://github.com/younjinjeong/microfoundry/releases)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev)
-[![License](https://img.shields.io/github/license/younjinjeong/microfoundry)](LICENSE)
-[![Latest Release](https://img.shields.io/github/v/release/younjinjeong/microfoundry)](https://github.com/younjinjeong/microfoundry/releases/latest)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/badge/Release-v0.1.0-blue.svg)](https://github.com/younjinjeong/microfoundry/releases/tag/v0.1.0)
 
 **A micro CloudFoundry for Kubernetes** — lightweight PaaS that preserves the CloudFoundry developer experience while running on cloud-native infrastructure.
 


### PR DESCRIPTION
## Summary
- Replaced dynamic `shields.io/github/license` and `shields.io/github/v/release` badges with static equivalents
- Dynamic badges fail on private repos (shields.io queries public GitHub API → 404)
- Static badges show correct info: `License: MIT` and `Release: v0.1.0`

## Root cause
The repo is private. Shields.io `github/*` endpoints hit the unauthenticated GitHub API which returns 404 for private repos. GitHub Actions badges work fine because they're served by GitHub itself.

## Test plan
- [ ] Verify all 5 badges render correctly on the PR diff view
- [ ] Confirm badges still work after merging to `rc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)